### PR TITLE
suppress autocompletion of password input field

### DIFF
--- a/tpl/bootstrap.php
+++ b/tpl/bootstrap.php
@@ -159,7 +159,16 @@ if ($PASSWORD):
 ?>
 					<li>
 						<div id="password" class="navbar-form hidden">
-							<input type="password" id="passwordinput" placeholder="<?php echo I18n::_('Password (recommended)'); ?>" class="form-control" size="19" />
+
+							<!-- The following form element glues pseudo-login data together, so that password managers can try to look up stored value pairs.
+							     The username field is made hidden, because I found that otherwise password managers will fill in data into the password field.
+							     See https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion#The_autocomplete_attribute_and_login_fields
+							-->
+
+							<form>
+								<input type="text" name="username" class="hidden" />
+								<input type="password" id="passwordinput" placeholder="<?php echo I18n::_('Password (recommended)'); ?>" class="form-control" size="20" />
+							</form>
 						</div>
 					</li>
 <?php


### PR DESCRIPTION
<!-- This is a template for your Pull Request. This are just some suggestions for you. You do not have to use all of them. -->

<!-- **Attention:** Please tick this box to agree to release your code under the projects license. Otherwise your PR cannot be accepted. -->
* [x] I agree to release the changes in this PR under the Zlib/libpng license as shown in the  [LICENSE file](https://github.com/PrivateBin/PrivateBin/blob/master/LICENSE.md#zliblibpng-license-for-privatebin).

<!-- Alternatively uncomment and tick this box to release your code under public domain:
* [ ] To the extent possible under law, I have waived all copyright and related or neighboring rights to this PR and publish it as public domain.
-->

<!-- If your PR fixes an issue, mention it here. You can also just copy the URL - GitHub will convert it for you.
If this PR fixes several issues, please prepend each issue url/number with the word "fix"/"fixes" or "close"/"closes" as this automatically closes the issues you mentioned when the PR is merged.
-->
This PR fixes #118

* add a form element, and a hidden dummy and empty-value username field, so that a password manager cannot find a matching "user".
* tested with Firefox ESR 45.4.0 (debian 8)
* input field increased to hold the help text
* fix #118
