### PR TITLE
suppress autocompletion of password input field

### DIFF
--- a/tpl/bootstrap-compact.php
+++ b/tpl/bootstrap-compact.php
@@ -193,7 +193,18 @@ if ($PASSWORD):
 ?>
 						<li>
 							<div id="password" class="navbar-form hidden">
-								<input type="password" id="passwordinput" placeholder="<?php echo I18n::_('Password (recommended)'); ?>" class="form-control" size="19"/>
+								<form>
+									<!--	The form element glues pseudo-login data together, so that password managers can try to look up stored value pairs.
+									     	The username field is intentionally set up with a pseudo username, and is hidden,
+										in order to prevent password managers from filling in data into the password field.
+										See 
+https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion#The_autocomplete_attribute_and_login_fields
+									-->
+
+									<input type="text" value="privatebin-1FuCKEPWUQ6WAmpjMdfqaBuYhVzUcTuJC" name="username" class="hidden" aria-hidden="true" />
+									<input type="password" id="passwordinput" placeholder="<?php echo I18n::_('Password (recommended)'); ?>" class="form-control" 
+size="20" />
+								</form>
 							</div>
 						</li>
 <?php

--- a/tpl/bootstrap-dark-page.php
+++ b/tpl/bootstrap-dark-page.php
@@ -159,7 +159,17 @@ if ($PASSWORD):
 ?>
 					<li>
 						<div id="password" class="navbar-form hidden">
-							<input type="password" id="passwordinput" placeholder="<?php echo I18n::_('Password (recommended)'); ?>" class="form-control" size="19" />
+							<form>
+								<!--	The form element glues pseudo-login data together, so that password managers can try to look up stored value pairs.
+								     	The username field is intentionally set up with a pseudo username, and is hidden,
+									in order to prevent password managers from filling in data into the password field.
+									See 
+https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion#The_autocomplete_attribute_and_login_fields
+								-->
+
+								<input type="text" value="privatebin-1FuCKEPWUQ6WAmpjMdfqaBuYhVzUcTuJC" name="username" class="hidden" aria-hidden="true" />
+								<input type="password" id="passwordinput" placeholder="<?php echo I18n::_('Password (recommended)'); ?>" class="form-control" size="20" />
+							</form>
 						</div>
 					</li>
 <?php

--- a/tpl/bootstrap-dark.php
+++ b/tpl/bootstrap-dark.php
@@ -159,7 +159,17 @@ if ($PASSWORD):
 ?>
 					<li>
 						<div id="password" class="navbar-form hidden">
-							<input type="password" id="passwordinput" placeholder="<?php echo I18n::_('Password (recommended)'); ?>" class="form-control" size="19" />
+							<form>
+								<!--	The form element glues pseudo-login data together, so that password managers can try to look up stored value pairs.
+								     	The username field is intentionally set up with a pseudo username, and is hidden,
+									in order to prevent password managers from filling in data into the password field.
+									See 
+https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion#The_autocomplete_attribute_and_login_fields
+								-->
+
+								<input type="text" value="privatebin-1FuCKEPWUQ6WAmpjMdfqaBuYhVzUcTuJC" name="username" class="hidden" aria-hidden="true" />
+								<input type="password" id="passwordinput" placeholder="<?php echo I18n::_('Password (recommended)'); ?>" class="form-control" size="20" />
+							</form>
 						</div>
 					</li>
 <?php

--- a/tpl/bootstrap-page.php
+++ b/tpl/bootstrap-page.php
@@ -159,7 +159,17 @@ if ($PASSWORD):
 ?>
 					<li>
 						<div id="password" class="navbar-form hidden">
-							<input type="password" id="passwordinput" placeholder="<?php echo I18n::_('Password (recommended)'); ?>" class="form-control" size="19" />
+							<form>
+								<!--	The form element glues pseudo-login data together, so that password managers can try to look up stored value pairs.
+								     	The username field is intentionally set up with a pseudo username, and is hidden,
+									in order to prevent password managers from filling in data into the password field.
+									See 
+https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion#The_autocomplete_attribute_and_login_fields
+								-->
+
+								<input type="text" value="privatebin-1FuCKEPWUQ6WAmpjMdfqaBuYhVzUcTuJC" name="username" class="hidden" aria-hidden="true" />
+								<input type="password" id="passwordinput" placeholder="<?php echo I18n::_('Password (recommended)'); ?>" class="form-control" size="20" />
+							</form>
 						</div>
 					</li>
 <?php

--- a/tpl/bootstrap.php
+++ b/tpl/bootstrap.php
@@ -159,7 +159,17 @@ if ($PASSWORD):
 ?>
 					<li>
 						<div id="password" class="navbar-form hidden">
-							<input type="password" id="passwordinput" placeholder="<?php echo I18n::_('Password (recommended)'); ?>" class="form-control" size="19" />
+							<form>
+								<!--	The form element glues pseudo-login data together, so that password managers can try to look up stored value pairs.
+								     	The username field is intentionally set up with a pseudo username, and is hidden,
+									in order to prevent password managers from filling in data into the password field.
+									See 
+https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion#The_autocomplete_attribute_and_login_fields
+								-->
+
+								<input type="text" value="privatebin-1FuCKEPWUQ6WAmpjMdfqaBuYhVzUcTuJC" name="username" class="hidden" aria-hidden="true" />
+								<input type="password" id="passwordinput" placeholder="<?php echo I18n::_('Password (recommended)'); ?>" class="form-control" size="20" />
+							</form>
 						</div>
 					</li>
 <?php


### PR DESCRIPTION
<!-- This is a template for your Pull Request. This are just some suggestions for you. You do not have to use all of them. -->

<!-- **Attention:** Please tick this box to agree to release your code under the projects license. Otherwise your PR cannot be accepted. -->
* [x] I agree to release the changes in this PR under the Zlib/libpng license as shown in the  [LICENSE file](https://github.com/PrivateBin/PrivateBin/blob/master/LICENSE.md#zliblibpng-license-for-privatebin).

<!-- Alternatively uncomment and tick this box to release your code under public domain:
* [ ] To the extent possible under law, I have waived all copyright and related or neighboring rights to this PR and publish it as public domain.
-->


* fix #118
* increased the password input field to fit the "Password (recommended)" text
* prefill dummy username field with 80 character random value
* substitutes PR #125 (which is closed)