### PR TITLE
Add a Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,18 @@
+# Documentation, might leak version number
+CHANGELOG.md
+LICENSE.md
+CREDITS.md
+INSTALL.md
+README.md
+doc/
+
+# Dotfiles, pointless
+.codeclimate.yml
+.csslintrc
+.editorconfig
+.eslint*
+.git*
+.php_cs
+.styleci.yml
+.travis.yml
+.github

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM php:apache
+
+RUN apt-get update && apt-get install -y \
+        libfreetype6-dev \
+        libjpeg62-turbo-dev \
+        libpng12-dev \
+        wget \
+        zip \
+        unzip; \
+    # We install and enable php-gd
+    docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/; \
+    docker-php-ext-install -j$(nproc) gd; \
+
+    # We enable Apache's mod_rewrite
+    a2enmod rewrite
+
+COPY . .


### PR DESCRIPTION
This is not a perfect Dockerfile, but is a perfect base for anyone willing to run PrivateBin
inside a container. There are a lot of ways to improve it, first being "having configuration
in environment variables".
Anyway, this Dockerfile is great as a basis, and it is possible to "fork" the image and add
our own config file into it.
Another improvement might be "adding a docker-compose.yml full stack, with mysql+bin".

Feel free to do it \o/

* [x] I agree to release the changes in this PR under the Zlib/libpng license as shown in the  [LICENSE file](https://github.com/PrivateBin/PrivateBin/blob/master/LICENSE.md#zliblibpng-license-for-privatebin).

* [x] To the extent possible under law, I have waived all copyright and related or neighboring rights to this PR and publish it as public domain.

## Changes
* Add a Dockerfile and a dockerignore (to prevent information leak)

## To do - Won't do
* [ ] Docker Compose
* [ ] Add environment variables for configuration
* [ ] Enable (or not) the .htaccess
* [x] Composer install? Depends on #150 

