### PR TITLE
Safari isn't available on Windows anymore

### DIFF
--- a/tpl/page.php
+++ b/tpl/page.php
@@ -79,8 +79,7 @@ endif;
 			<div id="ienotice"><?php echo I18n::_('Still using Internet Explorer? Do yourself a favor, switch to a modern browser:'), PHP_EOL; ?>
 				<a href="https://www.mozilla.org/firefox/">Firefox</a>,
 				<a href="https://www.opera.com/">Opera</a>,
-				<a href="https://www.google.com/chrome">Chrome</a>,
-				<a href="https://www.apple.com/safari">Safari</a>...
+				<a href="https://www.google.com/chrome">Chrome</a>...
 			</div>
 		</header>
 		<section>


### PR DESCRIPTION
We don't need to mention Safari, as apple has dropped support for Windows anymore, and since Internet Explorer isn't on Macs, there should be little to worry about :p


## Changes
<!-- List all the changes you have done -->
* Removed the mentioning of Safari when using internet explorer.
