### PR TITLE
Italian Translation update

### DIFF
--- a/i18n/it.json
+++ b/i18n/it.json
@@ -18,7 +18,7 @@
     "Invalid data.":
         "Dati non validi.",
     "You are unlucky. Try again.":
-        "Riprova, sarai più fortunato.",
+        "Ritenta, sarai più fortunato.",
     "Error saving comment. Sorry.":
         "Errore durante il salvataggio del commento.",
     "Error saving paste. Sorry.":
@@ -93,7 +93,7 @@
     "Anonymous":
         "Anonimo",
     "Avatar generated from IP address":
-        "Avatar Anonimo (Vizhash dell'indirizzo IP)",
+        "Avatar generato dall'indirizzo IP)",
     "Add comment":
         "Aggiungi un commento",
     "Optional nickname…":
@@ -107,7 +107,7 @@
     "Could not refresh display: %s":
         "Non riesco ad aggiornare il display: %s",
     "unknown status":
-        "errore sconosciuto",
+        "stato sconosciuto",
     "server error or not responding":
         "errore o mancata risposta dal server",
     "Could not post comment: %s":
@@ -117,11 +117,11 @@
     "Sending paste…":
         "Messaggio in fase di invio…",
     "Your paste is <a id=\"pasteurl\" href=\"%s\">%s</a> <span id=\"copyhint\">(Hit [Ctrl]+[c] to copy)</span>":
-        "Il tuo messaggio è qui: <a id=\"pasteurl\" href=\"%s\">%s</a> <span id=\"copyhint\">([CTRL | CMD]+[C] per copiare il link)</span>",
+        "Il tuo messaggio è qui: <a id=\"pasteurl\" href=\"%s\">%s</a> <span id=\"copyhint\">(Premi [Ctrl]+[c] (Windows) o [Cmd]+[c] (Mac) per copiare il link)</span>",
     "Delete data":
         "Cancella i dati",
     "Could not create paste: %s":
-        "Non rieco a creare il messaggio: %s",
+        "Non riesco a creare il messaggio: %s",
     "Cannot decrypt paste: Decryption key missing in URL (Did you use a redirector or an URL shortener which strips part of the URL?)":
         "Non riesco a decifrare il messaggio: manca la chiave di decifrazione nell'URL (La chiave è parte integrante dell'URL. Per caso hai usato un Redirector o un altro servizio che ha rimosso una parte dell'URL?)",
     "Format": "Formato",
@@ -129,8 +129,8 @@
     "Source Code": "Codice Sorgente",
     "Markdown": "Markdown",
     "Download attachment": "Scarica Allegato",
-    "Cloned: '%s'": "Copia: '%s'",
-    "The cloned file '%s' was attached to this paste.": "The cloned file '%s' was attached to this paste.",
+    "Cloned: '%s'": "Clonato: '%s'",
+    "The cloned file '%s' was attached to this paste.": "Il file clonato '%s' era allegato a questo messaggio.",
     "Attach a file": "Allega un file",
     "Remove attachment": "Rimuovi allegato",
     "Your browser does not support uploading encrypted files. Please use a newer browser.":
@@ -143,13 +143,13 @@
     "%s requires the PATH to end in a \"%s\". Please update the PATH in your index.php.":
         "%s necessita che PATH termini con \"%s\". Aggiorna la variabile PATH nel tuo index.php.",
     "Decrypt":
-        "Decrypt",
+        "Decifra",
     "Enter password":
         "Inserisci la password",
-    "Loading…": "Loading…",
-    "Decrypting paste…": "Decrypting paste…",
-    "Preparing new paste…": "Preparing new paste…",
+    "Loading…": "Carico…",
+    "Decrypting paste…": "Decifro il messaggio…",
+    "Preparing new paste…": "Preparo il nuovo messaggio…",
     "In case this message never disappears please have a look at <a href=\"https://github.com/PrivateBin/PrivateBin/wiki/FAQ#why-does-not-the-loading-message-go-away\">this FAQ for information to troubleshoot</a>.":
-        "Nel caso questo messaggio non scompaia, controlla questa <a href=\"https://github.com/PrivateBin/PrivateBin/wiki/FAQ#why-does-not-the-loading-message-go-away\"> FAQ</a> per trovare informazioni su come risolvere il problema (in Inglese).",
-    "+++ no paste text +++": "+++ no paste text +++"
+        "Nel caso questo messaggio non scompaia, controlla questa <a href=\"https://github.com/PrivateBin/PrivateBin/wiki/FAQ#why-does-not-the-loading-message-go-away\">FAQ</a> per trovare informazioni su come risolvere il problema.",
+    "+++ no paste text +++": "+++ nessun testo nel messaggio +++"
 }

--- a/i18n/it.json
+++ b/i18n/it.json
@@ -150,6 +150,6 @@
     "Decrypting paste…": "Decifro il messaggio…",
     "Preparing new paste…": "Preparo il nuovo messaggio…",
     "In case this message never disappears please have a look at <a href=\"https://github.com/PrivateBin/PrivateBin/wiki/FAQ#why-does-not-the-loading-message-go-away\">this FAQ for information to troubleshoot</a>.":
-        "Nel caso questo messaggio non scompaia, controlla questa <a href=\"https://github.com/PrivateBin/PrivateBin/wiki/FAQ#why-does-not-the-loading-message-go-away\">FAQ</a> per trovare informazioni su come risolvere il problema.",
+        "Nel caso questo messaggio non scompaia, controlla questa <a href=\"https://github.com/PrivateBin/PrivateBin/wiki/FAQ#why-does-not-the-loading-message-go-away\">FAQ</a> per trovare informazioni su come risolvere il problema (in Inglese).",
     "+++ no paste text +++": "+++ nessun testo nel messaggio +++"
 }


### PR DESCRIPTION
- new strings translated
- couple of minor errors fixed

Some strings (i.e. line 133) are literal translations.

I could probably give a better translation by reading the messages in
their context, when I get the next update.