### PR TITLE
Updated bootstrap.php to fix a display issue

### DIFF
--- a/tpl/bootstrap.php
+++ b/tpl/bootstrap.php
@@ -269,7 +269,7 @@ if ($PASSWORD):
 ?>
 					<li>
 						<div id="password" class="navbar-form hidden">
-							<input type="password" id="passwordinput" placeholder="<?php echo I18n::_('Password (recommended)'); ?>" class="form-control" size="19" />
+							<input type="password" id="passwordinput" placeholder="<?php echo I18n::_('Password (recommended)'); ?>" class="form-control" size="23" />
 						</div>
 					</li>
 <?php


### PR DESCRIPTION
The text "password (recommended)" on the password field was being truncated to "password (recommen" because of a size issue.

This PR fixes https://github.com/PrivateBin/PrivateBin/issues/231

## Changes
* Expanded the password field to 23 in size to prevent the help text from being truncated. (affected all major browsers - excluding mobile). 


