### PR TITLE
Fix URL shortener button not being shown

### DIFF
--- a/tpl/bootstrap.php
+++ b/tpl/bootstrap.php
@@ -468,17 +468,16 @@ endif;
 				<div id="pastesuccess" role="alert" class="hidden alert alert-success">
 					<span class="glyphicon glyphicon-ok" aria-hidden="true"></span>
 					<div id="deletelink"></div>
-					<div id="pastelink">
-<?php
-if (strlen($URLSHORTENER)):
-?>
-						<button id="shortenbutton" data-shortener="<?php echo htmlspecialchars($URLSHORTENER); ?>" type="button" class="btn btn-<?php echo $isDark ? 'warning' : 'primary'; ?>">
-							<span class="glyphicon glyphicon-send" aria-hidden="true"></span> <?php echo I18n::_('Shorten URL'), PHP_EOL; ?>
-						</button>
-<?php
-endif;
-?>
-					</div>
+					<div id="pastelink"></div>
+					<?php
+					if (strlen($URLSHORTENER)):
+					?>
+											<button id="shortenbutton" data-shortener="<?php echo htmlspecialchars($URLSHORTENER); ?>" type="button" class="btn btn-<?php echo $isDark ? 'warning' : 'primary'; ?>">
+												<span class="glyphicon glyphicon-send" aria-hidden="true"></span> <?php echo I18n::_('Shorten URL'), PHP_EOL; ?>
+											</button>
+					<?php
+					endif;
+					?>
 				</div>
 				<ul id="editorTabs" class="nav nav-tabs hidden">
 					<li role="presentation" class="active"><a id="messageedit" href="#"><?php echo I18n::_('Editor'); ?></a></li>

--- a/tpl/bootstrap.php
+++ b/tpl/bootstrap.php
@@ -472,9 +472,9 @@ endif;
 					<?php
 					if (strlen($URLSHORTENER)):
 					?>
-											<button id="shortenbutton" data-shortener="<?php echo htmlspecialchars($URLSHORTENER); ?>" type="button" class="btn btn-<?php echo $isDark ? 'warning' : 'primary'; ?>">
-												<span class="glyphicon glyphicon-send" aria-hidden="true"></span> <?php echo I18n::_('Shorten URL'), PHP_EOL; ?>
-											</button>
+						<button id="shortenbutton" data-shortener="<?php echo htmlspecialchars($URLSHORTENER); ?>" type="button" class="btn btn-<?php echo $isDark ? 'warning' : 'primary'; ?>">
+							<span class="glyphicon glyphicon-send" aria-hidden="true"></span> <?php echo I18n::_('Shorten URL'), PHP_EOL; ?>
+						</button>
 					<?php
 					endif;
 					?>


### PR DESCRIPTION
Move URL shortener out of `#pastelink` as that is overwritten by the JS. (IMHO it makes no sense anyway to have it inside `#pastelink`. 

Fixes https://github.com/PrivateBin/PrivateBin/issues/280

I'll mark this as a braking change, as maybe someone's CSS depends on it, but I consider this very unlikely.