### PR TITLE
Default to en if browser does not provide a language

### DIFF
--- a/js/privatebin.js
+++ b/js/privatebin.js
@@ -441,7 +441,7 @@ jQuery.PrivateBin = (function($, sjcl, Base64, RawDeflate) {
 
             // auto-select language based on browser settings
             if (newLanguage.length === 0) {
-                newLanguage = (navigator.language || navigator.userLanguage).substring(0, 2);
+                newLanguage = (navigator.language || navigator.userLanguage || 'en').substring(0, 2);
             }
 
             // if language is already used skip update

--- a/js/test/I18n.js
+++ b/js/test/I18n.js
@@ -99,6 +99,28 @@ describe('I18n', function () {
                 return language === result && language === alias;
             }
         );
+
+        jsc.property(
+            'should default to en',
+            function() {
+                var clean = jsdom('', {url: 'https://privatebin.net/'});
+
+                [ 'language', 'userLanguage' ].forEach(function (key) {
+                    Object.defineProperty(navigator, key, {
+                        value: undefined,
+                        writeable: false
+                    });
+                });
+
+                $.PrivateBin.I18n.reset('en');
+                $.PrivateBin.I18n.loadTranslations();
+                var result = $.PrivateBin.I18n.translate('en'),
+                    alias  = $.PrivateBin.I18n._('en');
+
+                clean();
+                return 'en' === result && 'en' === alias;
+            }
+        );
     });
 });
 


### PR DESCRIPTION
This PR fixes #296

If the language from the browser can not be detected, I've set the default language to "en".