### PR TITLE
Download Attachment changes.  Support for Edge and change to Blob

### DIFF
--- a/js/privatebin.js
+++ b/js/privatebin.js
@@ -1928,30 +1928,29 @@ jQuery.PrivateBin = (function($, sjcl, Base64, RawDeflate) {
             // IE does not support setting a data URI on an a element
             // Convert dataURI to a Blob and use msSaveBlob to download
             if (window.Blob && navigator.msSaveBlob) {
-                // data URI format: data:[<contentType>][;base64],<data>
-
-                // position in data URI string of where data begins
-                var base64Start = attachmentData.indexOf(',') + 1;
-                // position in data URI string of where contentType ends
-                var contentTypeEnd = attachmentData.indexOf(';');
-
-                // extract contentType
-                var contentType = attachmentData.substring(5, contentTypeEnd);
-                // extract data and convert to binary
-                var buf = Base64.atob(attachmentData.substring(base64Start));
-
-                // Transform into a Blob
-                var bufLength = buf.length;
-                var array = new Uint8Array(bufLength);
-
-                for (var i = 0; i < bufLength; i++) {
-                    array[i] = buf.charCodeAt(i);
-                }
-
-                var file = new window.Blob([ array ], { type: contentType });
-
                 $attachmentLink.bind('click', function () {
-                    navigator.msSaveBlob(file, fileName);
+                    // data URI format: data:[<mediaType>][;base64],<data>
+
+                    // position in data URI string of where data begins
+                    var base64Start = attachmentData.indexOf(',') + 1;
+                    // position in data URI string of where mediaType ends
+                    var mediaTypeEnd = attachmentData.indexOf(';');
+
+                    // extract mediaType
+                    var mediaType = attachmentData.substring(5, mediaTypeEnd);
+                    // extract data and convert to binary
+                    var decodedData = Base64.atob(attachmentData.substring(base64Start));
+
+                    // Transform into a Blob
+                    var decodedDataLength = decodedData.length;
+                    var buf = new Uint8Array(decodedDataLength);
+
+                    for (var i = 0; i < decodedDataLength; i++) {
+                        buf[i] = decodedData.charCodeAt(i);
+                    }
+
+                    var blob = new window.Blob([ buf ], { type: mediaType });
+                    navigator.msSaveBlob(blob, fileName);
                 });
             } else {
                 $attachmentLink.attr('href', attachmentData);

--- a/js/privatebin.js
+++ b/js/privatebin.js
@@ -1928,7 +1928,7 @@ jQuery.PrivateBin = (function($, sjcl, Base64, RawDeflate) {
             // IE does not support setting a data URI on an a element
             // Convert dataURI to a Blob and use msSaveBlob to download
             if (window.Blob && navigator.msSaveBlob) {
-                $attachmentLink.bind('click', function () {
+                $attachmentLink.off('click').on('click', function () {
                     // data URI format: data:[<mediaType>][;base64],<data>
 
                     // position in data URI string of where data begins
@@ -2001,7 +2001,7 @@ jQuery.PrivateBin = (function($, sjcl, Base64, RawDeflate) {
             me.hideAttachmentPreview();
             $attachmentLink.prop('href', '');
             $attachmentLink.prop('download', '');
-            $attachmentLink.unbind('click');
+            $attachmentLink.off('click');
             $attachmentPreview.html('');
         };
 

--- a/js/privatebin.js
+++ b/js/privatebin.js
@@ -1925,12 +1925,22 @@ jQuery.PrivateBin = (function($, sjcl, Base64, RawDeflate) {
         {
             var imagePrefix = 'data:image/';
 
-            if (window.Blob) {
+            // IE does not support setting a data URI on an a element
+            // Convert dataURI to a Blob and use msSaveBlob to download
+            if (window.Blob && navigator.msSaveBlob) {
+                // data URI format: data:[<contentType>][;base64],<data>
+
+                // position in data URI string of where data begins
                 var base64Start = attachmentData.indexOf(',') + 1;
+                // position in data URI string of where contentType ends
                 var contentTypeEnd = attachmentData.indexOf(';');
 
+                // extract contentType
                 var contentType = attachmentData.substring(5, contentTypeEnd);
+                // extract data and convert to binary
                 var buf = Base64.atob(attachmentData.substring(base64Start));
+
+                // Transform into a Blob
                 var bufLength = buf.length;
                 var array = new Uint8Array(bufLength);
 
@@ -1940,15 +1950,9 @@ jQuery.PrivateBin = (function($, sjcl, Base64, RawDeflate) {
 
                 var file = new window.Blob([ array ], { type: contentType });
 
-                if (navigator.msSaveBlob) {
-                    $attachmentLink.bind('click', function () {
-                        navigator.msSaveBlob(file, fileName);
-                    });
-                } else if (window.URL && window.URL.createObjectURL) {
-                    $attachmentLink.attr('href', window.URL.createObjectURL(file));
-                } else {
-                    $attachmentLink.attr('href', attachmentData);
-                }
+                $attachmentLink.bind('click', function () {
+                    navigator.msSaveBlob(file, fileName);
+                });
             } else {
                 $attachmentLink.attr('href', attachmentData);
             }

--- a/tpl/bootstrap.php
+++ b/tpl/bootstrap.php
@@ -75,7 +75,7 @@ if ($MARKDOWN):
 <?php
 endif;
 ?>
-		<script type="text/javascript" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-RP/Q7x1nwpIRC2bOYlYNjOe85laGtKgKioX+h+Th0QKl01Gc2FPNrWNVtr3zJvNEpm4Oq3Ksi+av71GX3S/RBQ==" crossorigin="anonymous"></script>
+		<script type="text/javascript" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-fvvGIUd9iLItXzuFtg02nKMi0CxkkxenXQgJ5OdbGFRLzE5Ox25PrlctVdm3f3ZAPOQxtSyi9jBf56/zr8nBqw==" crossorigin="anonymous"></script>
 		<!--[if lt IE 10]>
 		<style type="text/css">body {padding-left:60px;padding-right:60px;} #ienotice {display:block;} #oldienotice {display:block;}</style>
 		<![endif]-->

--- a/tpl/page.php
+++ b/tpl/page.php
@@ -54,7 +54,7 @@ if ($QRCODE):
 <?php
 endif;
 ?>
-		<script type="text/javascript" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-RP/Q7x1nwpIRC2bOYlYNjOe85laGtKgKioX+h+Th0QKl01Gc2FPNrWNVtr3zJvNEpm4Oq3Ksi+av71GX3S/RBQ==" crossorigin="anonymous"></script>
+		<script type="text/javascript" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-fvvGIUd9iLItXzuFtg02nKMi0CxkkxenXQgJ5OdbGFRLzE5Ox25PrlctVdm3f3ZAPOQxtSyi9jBf56/zr8nBqw==" crossorigin="anonymous"></script>
 		<!--[if lt IE 10]>
 		<style type="text/css">body {padding-left:60px;padding-right:60px;} #ienotice {display:block;} #oldienotice {display:block;}</style>
 		<![endif]-->


### PR DESCRIPTION
This PR fixes #295 

Internet Explorer uses msSaveBlob.  I've had to bind a click event however.  I also swapped to using the Blob for the download link on other browsers instead of using the dataURI.