### PR TITLE
fix sending anonymous comments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,7 @@ vendor/**/tests
 vendor/**/build_phar.php
 !vendor/**/*.php
 
-# Ignore local node modules, unit testing logs, api docs and eclipse project files
+# Ignore local node modules, unit testing logs, api docs and IDE project files
 js/node_modules/
 js/test.log
 tst/log/
@@ -39,3 +39,4 @@ tst/ConfigurationCombinationsTest.php
 .buildpath
 .project
 .externalToolBuilders
+.c9

--- a/js/privatebin.js
+++ b/js/privatebin.js
@@ -4099,7 +4099,7 @@ jQuery.PrivateBin = (function($, sjcl, Base64, RawDeflate) {
                 DiscussionViewer.addComment(
                     comment,
                     CryptTool.decipher(key, password, comment.data),
-                    CryptTool.decipher(key, password, comment.meta.nickname)
+                    comment.meta.nickname ? CryptTool.decipher(key, password, comment.meta.nickname) : ''
                 );
             }
 

--- a/tpl/bootstrap.php
+++ b/tpl/bootstrap.php
@@ -75,7 +75,7 @@ if ($MARKDOWN):
 <?php
 endif;
 ?>
-		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-19QipeKjOhdFEn7KpfTd9p1YJqXIxSDm+KrTTIQKRhKErCq82AtFkOUVf2+qXDi/xJoYXW5QVIksKK6w2hgFXQ==" crossorigin="anonymous"></script>
+		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-58qLFLcas6iQt7PWb4HcjAQlhKEi+XyZfYALB9VFkoeXR2vhpbQh1DuHc9jardc/HcDkr1hMkQfTlCjyWuTB8g==" crossorigin="anonymous"></script>
 		<!--[if lt IE 10]>
 		<style type="text/css">body {padding-left:60px;padding-right:60px;} #ienotice {display:block;} #oldienotice {display:block;}</style>
 		<![endif]-->

--- a/tpl/page.php
+++ b/tpl/page.php
@@ -54,7 +54,7 @@ if ($QRCODE):
 <?php
 endif;
 ?>
-		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-19QipeKjOhdFEn7KpfTd9p1YJqXIxSDm+KrTTIQKRhKErCq82AtFkOUVf2+qXDi/xJoYXW5QVIksKK6w2hgFXQ==" crossorigin="anonymous"></script>
+		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-58qLFLcas6iQt7PWb4HcjAQlhKEi+XyZfYALB9VFkoeXR2vhpbQh1DuHc9jardc/HcDkr1hMkQfTlCjyWuTB8g==" crossorigin="anonymous"></script>
 		<!--[if lt IE 10]>
 		<style type="text/css">body {padding-left:60px;padding-right:60px;} #ienotice {display:block;} #oldienotice {display:block;}</style>
 		<![endif]-->


### PR DESCRIPTION
During testing of the jQuery upgrade I discovered this issue with the decryption of anonymous comments (= comments with no nickname property). That part of the code was last changed in the JS refactoring, so it could also be a regression from then.