### PR TITLE
Fix download-link color in dark boostrap themes

### DIFF
--- a/css/bootstrap/privatebin.css
+++ b/css/bootstrap/privatebin.css
@@ -144,3 +144,7 @@ footer h4 {
 li.L0, li.L1, li.L2, li.L3, li.L5, li.L6, li.L7, li.L8 {
 	list-style-type: decimal !important;
 }
+
+.dark-theme .alert-info .alert-link {
+	color: #fff;
+}

--- a/tpl/bootstrap.php
+++ b/tpl/bootstrap.php
@@ -92,6 +92,9 @@ endif;
 if ($isCpct):
 ?> class="navbar-spacing"<?php
 endif;
+if ($isDark):
+?> class="dark-theme"<?php
+endif;
 ?>>
 		<div id="passwordmodal" tabindex="-1" class="modal fade" role="dialog" aria-hidden="true">
 			<div class="modal-dialog" role="document">


### PR DESCRIPTION
This makes the "Download attachment" link white in `bootstrap-dark` and `boostrap-dark-page`. This is an upstream bug of darkstrap, but it's not maintained anymore, so I think fixing it directly here is OK. It could also be fixed here:

https://github.com/PrivateBin/PrivateBin/blob/7f3339def0d0c241f6976904542d6a2a90095c6f/css/bootstrap/darkstrap-0.9.3.css#L5575-L5577

But I don't know if you want to edit that file, because it's an upstream file. But since it's not maintained anymore, it maybe would be a possibility? But for now I did it without it, but let me know if I should change it.

## Changes
* Add new `dark-theme` class to body, which could also be used for other similar fixes of the dark theme (I don't know any at the moment, but I still thought it would be better to add it at the body and not only at the download link).
* Fix the link-color in `privatebin.css` to not edit `darkstrap-0.9.3.css`

Before:
![screenshot before](https://user-images.githubusercontent.com/458548/46322637-57bfb200-c5ea-11e8-8d7f-96fc6f94d5f2.png)
After:
![screenshot after](https://user-images.githubusercontent.com/458548/46322640-5bebcf80-c5ea-11e8-9fd6-25a63335797e.png)