### PR TITLE
Ask Google not to translate the page

### DIFF
--- a/tpl/bootstrap.php
+++ b/tpl/bootstrap.php
@@ -11,6 +11,7 @@ $isPage = substr($template, -5) === '-page';
 		<meta name="viewport" content="width=device-width, initial-scale=1">
 		<meta name="robots" content="noindex" />
 		<meta name="referrer" content="no-referrer">
+		<meta name="google" content="notranslate">
 		<title><?php echo I18n::_($NAME); ?></title>
 <?php
 if (!$isDark):

--- a/tpl/page.php
+++ b/tpl/page.php
@@ -6,6 +6,7 @@ use PrivateBin\I18n;
 		<meta charset="utf-8" />
 		<meta name="robots" content="noindex" />
 		<meta name="referrer" content="no-referrer">
+		<meta name="google" content="notranslate">
 		<title><?php echo I18n::_($NAME); ?></title>
 		<link type="text/css" rel="stylesheet" href="css/privatebin.css?<?php echo rawurlencode($VERSION); ?>" />
 <?php


### PR DESCRIPTION
Ask Google to not analyse the contents of the page for translation purposes

We already have i18n. Furthermore, Google may analyse sensitive content for
the purpose of recognising whether the page needs to be translated, see
https://support.google.com/webmasters/answer/79812?hl=en

(as it has reportedly been happened with Protonmail)

----

Hello dear user. Consider switching to Firefox. We can only ask Google's browser to not do it. We cannot prevent it...

---

adopted/credits from/to https://github.com/threema-ch/threema-web/pull/681 by @lgrahl (I hope the plain copy is okay :smile:)