### PR TITLE
Expand the navbar by default for mobile devices

### DIFF
--- a/tpl/bootstrap.php
+++ b/tpl/bootstrap.php
@@ -134,7 +134,7 @@ if ($isCpct):
 endif;
 ?>
 			<div class="navbar-header">
-				<button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar" aria-expanded="false" aria-controls="navbar">
+				<button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#navbar" aria-expanded="true" aria-controls="navbar">
 					<span class="sr-only"><?php echo I18n::_('Toggle navigation'); ?></span>
 					<span class="icon-bar"></span>
 					<span class="icon-bar"></span>
@@ -144,7 +144,7 @@ endif;
 					<img alt="<?php echo I18n::_($NAME); ?>" src="img/icon.svg" width="38" />
 				</a>
 			</div>
-			<div id="navbar" class="navbar-collapse collapse">
+			<div id="navbar" class="navbar-collapse collapse in">
 				<ul class="nav navbar-nav">
 					<li id="loadingindicator" class="navbar-text hidden">
 						<span class="glyphicon glyphicon-time" aria-hidden="true"></span>


### PR DESCRIPTION
When the navbar is collapsed by default on mobile the Send button is
hidden. It was very confusing to have to expand the menu to find the
Send button. Having the navbar expanded by default makes it easier
to find the Send button since it's is readily visible.

## Changes
* Expand the navbar by default for mobile devices

