### PR TITLE
Fix #413. Exclude Let's Encrypt bot from blacklisted bots

### DIFF
--- a/.htaccess.disabled
+++ b/.htaccess.disabled
@@ -1,3 +1,4 @@
 RewriteEngine on
+RewriteCond !%{HTTP_USER_AGENT} "Let's Encrypt validation server" [NC]
 RewriteCond %{HTTP_USER_AGENT} ^.*(bot|spider|crawl|https?://|WhatsApp|SkypeUriPreview|facebookexternalhit) [NC]
 RewriteRule .* - [R=403,L]


### PR DESCRIPTION
This PR fixes #413.

I added a RewriteCond exception for Let's Encrypt bot so that it won't be denied by the next RewriteCond rule.