### PR TITLE
[DONOTMERGE] Challenge response api

### DIFF
--- a/js/pastemeta.jsonld
+++ b/js/pastemeta.jsonld
@@ -26,6 +26,9 @@
 		},
 		"time_to_live": {
 			"@type": "pb:RemainingSeconds"
+		},
+		"challenge": {
+			"@type": "pb:Challenge"
 		}
 	}
 }

--- a/js/privatebin.js
+++ b/js/privatebin.js
@@ -665,23 +665,6 @@ jQuery.PrivateBin = (function($, RawDeflate) {
         let base58 = new baseX('123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz');
 
         /**
-         * convert hexadecimal string to binary representation
-         *
-         * @name   CryptTool.hex2bin
-         * @function
-         * @private
-         * @param  {string} message hex string
-         * @return {string} binary representation as a DOMString
-         */
-        function hex2bin(message) {
-            let result = [];
-            for (let i = 0, l = message.length; i < l; i += 2) {
-                result.push(parseInt(message.substr(i, 2), 16));
-            }
-            return String.fromCharCode.apply(String, result);
-        }
-
-        /**
          * convert UTF-8 string stored in a DOMString to a standard UTF-16 DOMString
          *
          * Iterates over the bytes of the message, converting them all hexadecimal
@@ -1014,9 +997,7 @@ jQuery.PrivateBin = (function($, RawDeflate) {
                             false, // may not export this
                             ['sign']
                         ),
-                        stringToArraybuffer(
-                            hex2bin(id)
-                        )
+                        stringToArraybuffer(id)
                     )
                 )
             );

--- a/js/privatebin.js
+++ b/js/privatebin.js
@@ -4229,7 +4229,9 @@ jQuery.PrivateBin = (function($, RawDeflate) {
 
             // prepare server interaction
             ServerInteraction.prepare();
-            ServerInteraction.setCryptParameters(TopNav.getPassword());
+            const key = CryptTool.getSymmetricKey(),
+                  password = TopNav.getPassword();
+            ServerInteraction.setCryptParameters(password, key);
 
             // set success/fail functions
             ServerInteraction.setSuccess(showCreatedPaste);
@@ -4250,7 +4252,10 @@ jQuery.PrivateBin = (function($, RawDeflate) {
                 TopNav.getOpenDiscussion() ? 1 : 0,
                 TopNav.getBurnAfterReading() ? 1 : 0
             ]);
-            ServerInteraction.setUnencryptedData('meta', {'expire': TopNav.getExpiration()});
+            ServerInteraction.setUnencryptedData('meta', {
+                'expire':    TopNav.getExpiration(),
+                'challenge': CryptTool.getCredentials(key, password)
+            });
 
             // prepare PasteViewer for later preview
             PasteViewer.setText(plainText);

--- a/js/test/AttachmentViewer.js
+++ b/js/test/AttachmentViewer.js
@@ -4,9 +4,6 @@ var common = require('../common');
 describe('AttachmentViewer', function () {
     describe('setAttachment, showAttachment, removeAttachment, hideAttachment, hideAttachmentPreview, hasAttachment, getAttachment & moveAttachmentTo', function () {
         this.timeout(30000);
-        before(function () {
-            cleanup();
-        });
 
         jsc.property(
             'displays & hides data as requested',

--- a/js/test/CryptTool.js
+++ b/js/test/CryptTool.js
@@ -237,19 +237,48 @@ conseq_or_bottom inv (interp (nth_iterate sBody n) (MemElem mem))
         });
     });
 
+    describe('getCredentials', function () {
+        it('generates credentials with password', async function () {
+            const clean = jsdom();
+            window.crypto = new WebCrypto();
+            // choosen by fair dice roll
+            const key = atob('EqueAutxlrekNNEvJWB1uaaiwbk/GGpn4++cdk+uDMc='),
+                  // -- "That's amazing. I've got the same combination on my luggage."
+                  password = Array.apply(0, Array(6)).map((_,b) => b + 1).join('');
+            const credentials = await $.PrivateBin.CryptTool.getCredentials(
+                key, password
+            );
+            clean();
+            assert.strictEqual(credentials, 'JS8bJWFx1bAPI2LMxfWrw4AQ7cedNVl8UmjUd/pW7Yg=');
+        });
+
+        it('generates credentials without password', async function () {
+            const clean = jsdom();
+            window.crypto = new WebCrypto();
+            // choosen by fair dice roll
+            const key = atob('U844LK1y2uUPthTgMvPECwGyQzwScCwkaEI/+qLfQSE='),
+                  password = '';
+            const credentials = await $.PrivateBin.CryptTool.getCredentials(
+                key, password
+            );
+            clean();
+            assert.strictEqual(credentials, 'VfAvY7T9rm3K3JKtiOeb+B+rXnE6yZ4bYQTaD9jwjEk=');
+        });
+    });
+
     describe('getSymmetricKey', function () {
         this.timeout(30000);
-        var keys = [];
+        let keys = [];
 
         // the parameter is used to ensure the test is run more then one time
         jsc.property(
             'returns random, non-empty keys',
             'integer',
             function(counter) {
-                var clean = jsdom();
+                const clean = jsdom();
                 window.crypto = new WebCrypto();
-                var key = $.PrivateBin.CryptTool.getSymmetricKey(),
-                    result = (key !== '' && keys.indexOf(key) === -1);
+                const key = $.PrivateBin.CryptTool.getSymmetricKey(),
+                      result = (key !== '' && keys.indexOf(key) === -1);
                 keys.push(key);
                 clean();
                 return result;

--- a/js/test/InitialCheck.js
+++ b/js/test/InitialCheck.js
@@ -22,7 +22,7 @@ describe('InitialCheck', function () {
                         '</body></html>'
                     );
                     $.PrivateBin.Alert.init();
-                    window.crypto = null;
+                    window.crypto = new WebCrypto();
                     const result1 = !$.PrivateBin.InitialCheck.init(),
                           result2 = !$('#errormessage').hasClass('hidden');
                     clean();
@@ -76,7 +76,7 @@ describe('InitialCheck', function () {
                     '</body></html>'
                 );
                 $.PrivateBin.Alert.init();
-                window.crypto = null;
+                window.crypto = new WebCrypto();
                 const result1 = $.PrivateBin.InitialCheck.init(),
                       result2 = isSecureContext === $('#httpnotice').hasClass('hidden');
                 clean();

--- a/js/types.jsonld
+++ b/js/types.jsonld
@@ -92,6 +92,9 @@
 		"@type": "dp:Second",
 		"@minimum": 1
 	},
+	"Challenge": {
+		"@type": "pb:Base64"
+	},
 	"CipherParameters": {
 		"@container": "@list",
 		"@value": [

--- a/lib/Filter.php
+++ b/lib/Filter.php
@@ -72,6 +72,7 @@ class Filter
     /**
      * fixed time string comparison operation to prevent timing attacks
      * https://crackstation.net/hashing-security.htm?=rd#slowequals
+     * can be replaced with hash_equals() after we drop PHP 5.5 support
      *
      * @access public
      * @static

--- a/lib/FormatV2.php
+++ b/lib/FormatV2.php
@@ -123,8 +123,7 @@ class FormatV2
         // require only the key 'expire' in the metadata of pastes
         if (!$isComment && (
             count($message['meta']) === 0 ||
-            !array_key_exists('expire', $message['meta']) ||
-            count($message['meta']) > 1
+            !array_key_exists('expire', $message['meta'])
         )) {
             return false;
         }

--- a/lib/FormatV2.php
+++ b/lib/FormatV2.php
@@ -67,6 +67,13 @@ class FormatV2
         if (!($ct = base64_decode($message['ct'], true))) {
             return false;
         }
+        // - (optional) challenge
+        if (
+            !$isComment && array_key_exists('challenge', $message['meta']) &&
+            !base64_decode($message['meta']['challenge'], true)
+        ) {
+            return false;
+        }
 
         // Make sure some fields have a reasonable size:
         // - initialization vector

--- a/lib/Model/Paste.php
+++ b/lib/Model/Paste.php
@@ -116,9 +116,9 @@ class Paste extends AbstractModel
         $this->_data['meta']['salt']    = serversalt::generate();
         // if a challenge was sent, we store the HMAC of paste ID & challenge
         if (array_key_exists('challenge', $this->_data['meta'])) {
-            $this->_data['meta']['challenge'] = hash_hmac(
-                'sha256', $this->getId(), base64_decode($this->_data['meta']['challenge'])
-            );
+            $this->_data['meta']['challenge'] = base64_encode(hash_hmac(
+                'sha256', hex2bin($this->getId()), base64_decode($this->_data['meta']['challenge']), true
+            ));
         }
 
         // store paste

--- a/lib/Model/Paste.php
+++ b/lib/Model/Paste.php
@@ -117,7 +117,7 @@ class Paste extends AbstractModel
         // if a challenge was sent, we store the HMAC of paste ID & challenge
         if (array_key_exists('challenge', $this->_data['meta'])) {
             $this->_data['meta']['challenge'] = base64_encode(hash_hmac(
-                'sha256', hex2bin($this->getId()), base64_decode($this->_data['meta']['challenge']), true
+                'sha256', $this->getId(), base64_decode($this->_data['meta']['challenge']), true
             ));
         }
 

--- a/tpl/bootstrap.php
+++ b/tpl/bootstrap.php
@@ -71,7 +71,7 @@ if ($MARKDOWN):
 endif;
 ?>
 		<script type="text/javascript" data-cfasync="false" src="js/purify-1.0.11.js" integrity="sha512-p7UyJuyBkhMcMgE4mDsgK0Lz70OvetLefua1oXs1OujWv9gOxh4xy8InFux7bZ4/DAZsTmO4rgVwZW9BHKaTaw==" crossorigin="anonymous"></script>
-		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-tQGC7Jwx3TVRu69OGEmWl0K6lwDmgh5of3xU1Xbo4U0EY1Sv9qyUMQaOgGnMET3WMu9kbuZHsPnf7d9tTXhbsQ==" crossorigin="anonymous"></script>
+		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-o8Q/t6/gpmx6bQaHw3gru3cjOD5BLE/KdBKja73SllZo0/FuLvAjJ+40KhZ8ig/EpioP04etJtfTnNzF/isXow==" crossorigin="anonymous"></script>
 		<!--[if IE]>
 		<style type="text/css">body {padding-left:60px;padding-right:60px;} #ienotice {display:block;}</style>
 		<![endif]-->

--- a/tpl/bootstrap.php
+++ b/tpl/bootstrap.php
@@ -71,7 +71,7 @@ if ($MARKDOWN):
 endif;
 ?>
 		<script type="text/javascript" data-cfasync="false" src="js/purify-1.0.11.js" integrity="sha512-p7UyJuyBkhMcMgE4mDsgK0Lz70OvetLefua1oXs1OujWv9gOxh4xy8InFux7bZ4/DAZsTmO4rgVwZW9BHKaTaw==" crossorigin="anonymous"></script>
-		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-o8Q/t6/gpmx6bQaHw3gru3cjOD5BLE/KdBKja73SllZo0/FuLvAjJ+40KhZ8ig/EpioP04etJtfTnNzF/isXow==" crossorigin="anonymous"></script>
+		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-r9MutKcgP/igbs8aUbENyJEie7LMyJ22f2On0RwGL0Hq0seJnmnPo4avDfhR0E/TZWDoux2arzxYHneH2/Ltmw==" crossorigin="anonymous"></script>
 		<!--[if IE]>
 		<style type="text/css">body {padding-left:60px;padding-right:60px;} #ienotice {display:block;}</style>
 		<![endif]-->

--- a/tpl/bootstrap.php
+++ b/tpl/bootstrap.php
@@ -71,7 +71,7 @@ if ($MARKDOWN):
 endif;
 ?>
 		<script type="text/javascript" data-cfasync="false" src="js/purify-1.0.11.js" integrity="sha512-p7UyJuyBkhMcMgE4mDsgK0Lz70OvetLefua1oXs1OujWv9gOxh4xy8InFux7bZ4/DAZsTmO4rgVwZW9BHKaTaw==" crossorigin="anonymous"></script>
-		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-GNjHU6N7D0xG0WHf1DSrJrGavV+ES+w2t0vgICKD2UJ6g40Y1W+3le0iX7GgC8G6ADBsepMSaEyh47a2adA2HA==" crossorigin="anonymous"></script>
+		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-JTOr7OLbpnUePy6e/3tj28v3L4Cf1Xvoo1WQVRmJbBAcBK2skOsz4vBkC0RbeRkaObPIYXuv5egrFYseABbuZA==" crossorigin="anonymous"></script>
 		<!--[if IE]>
 		<style type="text/css">body {padding-left:60px;padding-right:60px;} #ienotice {display:block;}</style>
 		<![endif]-->

--- a/tpl/bootstrap.php
+++ b/tpl/bootstrap.php
@@ -71,7 +71,7 @@ if ($MARKDOWN):
 endif;
 ?>
 		<script type="text/javascript" data-cfasync="false" src="js/purify-1.0.11.js" integrity="sha512-p7UyJuyBkhMcMgE4mDsgK0Lz70OvetLefua1oXs1OujWv9gOxh4xy8InFux7bZ4/DAZsTmO4rgVwZW9BHKaTaw==" crossorigin="anonymous"></script>
-		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-Yq2HyT+H1PmQxCaDeh6E/ChOrTBSYsu8BuS4yb8UPHlyMVaxqSOtyfy6hx6vAsVT0G3bKeLRAuejhvPTOoz7fQ==" crossorigin="anonymous"></script>
+		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-GNjHU6N7D0xG0WHf1DSrJrGavV+ES+w2t0vgICKD2UJ6g40Y1W+3le0iX7GgC8G6ADBsepMSaEyh47a2adA2HA==" crossorigin="anonymous"></script>
 		<!--[if IE]>
 		<style type="text/css">body {padding-left:60px;padding-right:60px;} #ienotice {display:block;}</style>
 		<![endif]-->

--- a/tpl/bootstrap.php
+++ b/tpl/bootstrap.php
@@ -71,7 +71,7 @@ if ($MARKDOWN):
 endif;
 ?>
 		<script type="text/javascript" data-cfasync="false" src="js/purify-1.0.11.js" integrity="sha512-p7UyJuyBkhMcMgE4mDsgK0Lz70OvetLefua1oXs1OujWv9gOxh4xy8InFux7bZ4/DAZsTmO4rgVwZW9BHKaTaw==" crossorigin="anonymous"></script>
-		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-JTOr7OLbpnUePy6e/3tj28v3L4Cf1Xvoo1WQVRmJbBAcBK2skOsz4vBkC0RbeRkaObPIYXuv5egrFYseABbuZA==" crossorigin="anonymous"></script>
+		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-tQGC7Jwx3TVRu69OGEmWl0K6lwDmgh5of3xU1Xbo4U0EY1Sv9qyUMQaOgGnMET3WMu9kbuZHsPnf7d9tTXhbsQ==" crossorigin="anonymous"></script>
 		<!--[if IE]>
 		<style type="text/css">body {padding-left:60px;padding-right:60px;} #ienotice {display:block;}</style>
 		<![endif]-->

--- a/tpl/page.php
+++ b/tpl/page.php
@@ -49,7 +49,7 @@ if ($MARKDOWN):
 endif;
 ?>
 		<script type="text/javascript" data-cfasync="false" src="js/purify-1.0.11.js" integrity="sha512-p7UyJuyBkhMcMgE4mDsgK0Lz70OvetLefua1oXs1OujWv9gOxh4xy8InFux7bZ4/DAZsTmO4rgVwZW9BHKaTaw==" crossorigin="anonymous"></script>
-		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-Yq2HyT+H1PmQxCaDeh6E/ChOrTBSYsu8BuS4yb8UPHlyMVaxqSOtyfy6hx6vAsVT0G3bKeLRAuejhvPTOoz7fQ==" crossorigin="anonymous"></script>
+		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-GNjHU6N7D0xG0WHf1DSrJrGavV+ES+w2t0vgICKD2UJ6g40Y1W+3le0iX7GgC8G6ADBsepMSaEyh47a2adA2HA==" crossorigin="anonymous"></script>
 		<!--[if IE]>
 		<style type="text/css">body {padding-left:60px;padding-right:60px;} #ienotice {display:block;}</style>
 		<![endif]-->

--- a/tpl/page.php
+++ b/tpl/page.php
@@ -49,7 +49,7 @@ if ($MARKDOWN):
 endif;
 ?>
 		<script type="text/javascript" data-cfasync="false" src="js/purify-1.0.11.js" integrity="sha512-p7UyJuyBkhMcMgE4mDsgK0Lz70OvetLefua1oXs1OujWv9gOxh4xy8InFux7bZ4/DAZsTmO4rgVwZW9BHKaTaw==" crossorigin="anonymous"></script>
-		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-GNjHU6N7D0xG0WHf1DSrJrGavV+ES+w2t0vgICKD2UJ6g40Y1W+3le0iX7GgC8G6ADBsepMSaEyh47a2adA2HA==" crossorigin="anonymous"></script>
+		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-JTOr7OLbpnUePy6e/3tj28v3L4Cf1Xvoo1WQVRmJbBAcBK2skOsz4vBkC0RbeRkaObPIYXuv5egrFYseABbuZA==" crossorigin="anonymous"></script>
 		<!--[if IE]>
 		<style type="text/css">body {padding-left:60px;padding-right:60px;} #ienotice {display:block;}</style>
 		<![endif]-->

--- a/tpl/page.php
+++ b/tpl/page.php
@@ -49,7 +49,7 @@ if ($MARKDOWN):
 endif;
 ?>
 		<script type="text/javascript" data-cfasync="false" src="js/purify-1.0.11.js" integrity="sha512-p7UyJuyBkhMcMgE4mDsgK0Lz70OvetLefua1oXs1OujWv9gOxh4xy8InFux7bZ4/DAZsTmO4rgVwZW9BHKaTaw==" crossorigin="anonymous"></script>
-		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-tQGC7Jwx3TVRu69OGEmWl0K6lwDmgh5of3xU1Xbo4U0EY1Sv9qyUMQaOgGnMET3WMu9kbuZHsPnf7d9tTXhbsQ==" crossorigin="anonymous"></script>
+		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-o8Q/t6/gpmx6bQaHw3gru3cjOD5BLE/KdBKja73SllZo0/FuLvAjJ+40KhZ8ig/EpioP04etJtfTnNzF/isXow==" crossorigin="anonymous"></script>
 		<!--[if IE]>
 		<style type="text/css">body {padding-left:60px;padding-right:60px;} #ienotice {display:block;}</style>
 		<![endif]-->

--- a/tpl/page.php
+++ b/tpl/page.php
@@ -49,7 +49,7 @@ if ($MARKDOWN):
 endif;
 ?>
 		<script type="text/javascript" data-cfasync="false" src="js/purify-1.0.11.js" integrity="sha512-p7UyJuyBkhMcMgE4mDsgK0Lz70OvetLefua1oXs1OujWv9gOxh4xy8InFux7bZ4/DAZsTmO4rgVwZW9BHKaTaw==" crossorigin="anonymous"></script>
-		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-o8Q/t6/gpmx6bQaHw3gru3cjOD5BLE/KdBKja73SllZo0/FuLvAjJ+40KhZ8ig/EpioP04etJtfTnNzF/isXow==" crossorigin="anonymous"></script>
+		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-r9MutKcgP/igbs8aUbENyJEie7LMyJ22f2On0RwGL0Hq0seJnmnPo4avDfhR0E/TZWDoux2arzxYHneH2/Ltmw==" crossorigin="anonymous"></script>
 		<!--[if IE]>
 		<style type="text/css">body {padding-left:60px;padding-right:60px;} #ienotice {display:block;}</style>
 		<![endif]-->

--- a/tpl/page.php
+++ b/tpl/page.php
@@ -49,7 +49,7 @@ if ($MARKDOWN):
 endif;
 ?>
 		<script type="text/javascript" data-cfasync="false" src="js/purify-1.0.11.js" integrity="sha512-p7UyJuyBkhMcMgE4mDsgK0Lz70OvetLefua1oXs1OujWv9gOxh4xy8InFux7bZ4/DAZsTmO4rgVwZW9BHKaTaw==" crossorigin="anonymous"></script>
-		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-JTOr7OLbpnUePy6e/3tj28v3L4Cf1Xvoo1WQVRmJbBAcBK2skOsz4vBkC0RbeRkaObPIYXuv5egrFYseABbuZA==" crossorigin="anonymous"></script>
+		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-tQGC7Jwx3TVRu69OGEmWl0K6lwDmgh5of3xU1Xbo4U0EY1Sv9qyUMQaOgGnMET3WMu9kbuZHsPnf7d9tTXhbsQ==" crossorigin="anonymous"></script>
 		<!--[if IE]>
 		<style type="text/css">body {padding-left:60px;padding-right:60px;} #ienotice {display:block;}</style>
 		<![endif]-->

--- a/tst/Bootstrap.php
+++ b/tst/Bootstrap.php
@@ -155,7 +155,7 @@ class Helper
     public static function getPastePost($version = 2, array $meta = array())
     {
         $example         = self::getPaste($version, $meta);
-        $example['meta'] = array('expire' => $example['meta']['expire']);
+        $example['meta'] = array_merge(array('expire' => $example['meta']['expire']), $meta);
         return $example;
     }
 

--- a/tst/ControllerTest.php
+++ b/tst/ControllerTest.php
@@ -814,7 +814,7 @@ class ControllerTest extends PHPUnit_Framework_TestCase
     public function testReadBurnAfterReadingWithToken()
     {
         $token = base64_encode(hash_hmac(
-            'sha256', hex2bin(Helper::getPasteId()), random_bytes(32), true
+            'sha256', Helper::getPasteId(), random_bytes(32), true
         ));
         $burnPaste = Helper::getPaste(2, array('challenge' => $token));
         $burnPaste['adata'][3] = 1;
@@ -839,7 +839,7 @@ class ControllerTest extends PHPUnit_Framework_TestCase
     public function testReadBurnAfterReadingWithIncorrectToken()
     {
         $token = base64_encode(hash_hmac(
-            'sha256', hex2bin(Helper::getPasteId()), random_bytes(32), true
+            'sha256', Helper::getPasteId(), random_bytes(32), true
         ));
         $burnPaste = Helper::getPaste(2, array('challenge' => base64_encode(random_bytes(32))));
         $burnPaste['adata'][3] = 1;

--- a/tst/ControllerTest.php
+++ b/tst/ControllerTest.php
@@ -814,7 +814,7 @@ class ControllerTest extends PHPUnit_Framework_TestCase
     public function testReadBurnAfterReadingWithToken()
     {
         $token = base64_encode(hash_hmac(
-            'sha256', Helper::getPasteId(), random_bytes(32)
+            'sha256', hex2bin(Helper::getPasteId()), random_bytes(32), true
         ));
         $burnPaste = Helper::getPaste(2, array('challenge' => $token));
         $burnPaste['adata'][3] = 1;
@@ -839,7 +839,7 @@ class ControllerTest extends PHPUnit_Framework_TestCase
     public function testReadBurnAfterReadingWithIncorrectToken()
     {
         $token = base64_encode(hash_hmac(
-            'sha256', Helper::getPasteId(), random_bytes(32)
+            'sha256', hex2bin(Helper::getPasteId()), random_bytes(32), true
         ));
         $burnPaste = Helper::getPaste(2, array('challenge' => base64_encode(random_bytes(32))));
         $burnPaste['adata'][3] = 1;

--- a/tst/ControllerTest.php
+++ b/tst/ControllerTest.php
@@ -816,7 +816,7 @@ class ControllerTest extends PHPUnit_Framework_TestCase
         $token = base64_encode(hash_hmac(
             'sha256', Helper::getPasteId(), random_bytes(32), true
         ));
-        $burnPaste = Helper::getPaste(2, array('challenge' => $token));
+        $burnPaste             = Helper::getPaste(2, array('challenge' => $token));
         $burnPaste['adata'][3] = 1;
         $this->_data->create(Helper::getPasteId(), $burnPaste);
         $this->assertTrue($this->_data->exists(Helper::getPasteId()), 'paste exists before deleting data');
@@ -841,7 +841,7 @@ class ControllerTest extends PHPUnit_Framework_TestCase
         $token = base64_encode(hash_hmac(
             'sha256', Helper::getPasteId(), random_bytes(32), true
         ));
-        $burnPaste = Helper::getPaste(2, array('challenge' => base64_encode(random_bytes(32))));
+        $burnPaste             = Helper::getPaste(2, array('challenge' => base64_encode(random_bytes(32))));
         $burnPaste['adata'][3] = 1;
         $this->_data->create(Helper::getPasteId(), $burnPaste);
         $this->assertTrue($this->_data->exists(Helper::getPasteId()), 'paste exists before deleting data');

--- a/tst/FormatV2Test.php
+++ b/tst/FormatV2Test.php
@@ -21,6 +21,10 @@ class FormatV2Test extends PHPUnit_Framework_TestCase
         $paste['ct'] = '$';
         $this->assertFalse(FormatV2::isValid($paste), 'invalid base64 encoding of ct');
 
+        $paste                      = Helper::getPastePost();
+        $paste['meta']['challenge'] = '$';
+        $this->assertFalse(FormatV2::isValid($paste), 'invalid base64 encoding of ct');
+
         $paste       = Helper::getPastePost();
         $paste['ct'] = 'bm9kYXRhbm9kYXRhbm9kYXRhbm9kYXRhbm9kYXRhCg==';
         $this->assertFalse(FormatV2::isValid($paste), 'low ct entropy');

--- a/tst/FormatV2Test.php
+++ b/tst/FormatV2Test.php
@@ -71,6 +71,8 @@ class FormatV2Test extends PHPUnit_Framework_TestCase
         $paste['adata'][0][7] = '!#@';
         $this->assertFalse(FormatV2::isValid($paste), 'invalid compression');
 
-        $this->assertFalse(FormatV2::isValid(Helper::getPaste()), 'invalid meta key');
+        $paste = Helper::getPastePost();
+        unset($paste['meta']['expire']);
+        $this->assertFalse(FormatV2::isValid($paste), 'invalid missing meta key');
     }
 }

--- a/tst/ModelTest.php
+++ b/tst/ModelTest.php
@@ -276,9 +276,9 @@ class ModelTest extends PHPUnit_Framework_TestCase
     {
         $pasteData = Helper::getPastePost();
         $pasteData['meta']['challenge'] = base64_encode(random_bytes(32));
-        $token = hash_hmac(
-            'sha256', Helper::getPasteId(), base64_decode($pasteData['meta']['challenge'])
-        );
+        $token = base64_encode(hash_hmac(
+            'sha256', hex2bin(Helper::getPasteId()), base64_decode($pasteData['meta']['challenge']), true
+        ));
         $this->_model->getPaste(Helper::getPasteId())->delete();
         $paste = $this->_model->getPaste(Helper::getPasteId());
         $this->assertFalse($paste->exists(), 'paste does not yet exist');

--- a/tst/ModelTest.php
+++ b/tst/ModelTest.php
@@ -274,9 +274,9 @@ class ModelTest extends PHPUnit_Framework_TestCase
 
     public function testToken()
     {
-        $pasteData = Helper::getPastePost();
+        $pasteData                      = Helper::getPastePost();
         $pasteData['meta']['challenge'] = base64_encode(random_bytes(32));
-        $token = base64_encode(hash_hmac(
+        $token                          = base64_encode(hash_hmac(
             'sha256', Helper::getPasteId(), base64_decode($pasteData['meta']['challenge']), true
         ));
         $this->_model->getPaste(Helper::getPasteId())->delete();
@@ -331,7 +331,7 @@ class ModelTest extends PHPUnit_Framework_TestCase
      */
     public function testInvalidFormat()
     {
-        $pasteData = Helper::getPastePost();
+        $pasteData             = Helper::getPastePost();
         $pasteData['adata'][1] = 'foo';
         $this->_model->getPaste(Helper::getPasteId())->delete();
 

--- a/tst/ModelTest.php
+++ b/tst/ModelTest.php
@@ -277,7 +277,7 @@ class ModelTest extends PHPUnit_Framework_TestCase
         $pasteData = Helper::getPastePost();
         $pasteData['meta']['challenge'] = base64_encode(random_bytes(32));
         $token = base64_encode(hash_hmac(
-            'sha256', hex2bin(Helper::getPasteId()), base64_decode($pasteData['meta']['challenge']), true
+            'sha256', Helper::getPasteId(), base64_decode($pasteData['meta']['challenge']), true
         ));
         $this->_model->getPaste(Helper::getPasteId())->delete();
         $paste = $this->_model->getPaste(Helper::getPasteId());

--- a/tst/RequestTest.php
+++ b/tst/RequestTest.php
@@ -130,6 +130,22 @@ class RequestTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('read', $request->getOperation());
     }
 
+    public function testApiReadWithToken()
+    {
+        $this->reset();
+        $id                        = $this->getRandomId();
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+        $_SERVER['HTTP_ACCEPT']    = 'application/json, text/javascript, */*; q=0.01';
+        $_SERVER['QUERY_STRING']   = $id . '&token=foo';
+        $_GET[$id]                 = '';
+        $_GET['token']             = 'foo';
+        $request                   = new Request;
+        $this->assertTrue($request->isJsonApiCall(), 'is JSON Api call');
+        $this->assertEquals($id, $request->getParam('pasteid'));
+        $this->assertEquals('foo', $request->getParam('token'));
+        $this->assertEquals('read', $request->getOperation());
+    }
+
     public function testApiDelete()
     {
         $this->reset();


### PR DESCRIPTION
This PR fixes #245 

## Changes
* adds one (optional) parameter sent when creating a paste called `challenge` in the `meta` section of the JSON payload. It is the base64 encoded result of a PBKDF2 key derivation (SHA-256, 100000 iterations, AES-GCM 256 bit) using half of the paste key as the HMAC's salt, second half of the paste key + (optional) password as the string to protect (results in 256 bits of data).
* If such a `challenge` is sent in the paste creation, the server stores a base64 encoded SHA-256 HMAC of the paste ID it generates with the base64 decoded `challenge` as the secret.
* adds one (optional) GET parameter sent when requesting a paste from the server called `token`. It is calculated in the same way as the server does with the challenge. The `token` sent by the client to the server should therefore be identical with the `challenge` as calculated and stored by the server.
  * if the `token` parameter is omitted, the server returns the paste immediately, triggering a deletion for burn-after-reading pastes - this is to support third-party clients that haven't implemented this challenge response API
  * if the paste in question doesn't have a `challenge`, but a `token` is sent, the server returns the paste immediately, triggering a deletion for burn-after-reading pastes - this is to support the old paste format and those created using third-party clients that haven't implemented this challenge response API
  * if the paste has a `challenge` and it matches the `token`, the server returns the paste, burn-after-reading pastes get deleted at this point
  * if the paste has a `challenge`, but it doesn't match the `token`, the server returns a generic error message (as if the paste wouldn't exist) and burn-after-reading pastes are NOT deleted at this point - this allows clients to display a password enter dialog, in case the paste is password protected
* The password dialog now only shows up once - if the wrong password is entered the generic error message is displayed ("paste doesn't exist or was deleted"). The user can retry by refreshing the browser window.

## ToDo
* [ ] have logic and API changes reviewed by @rugk 
* [ ] discuss and decide if we leave this optional in the creation API or make it mandatory
* [ ] discuss if the UI change reg. passwords is acceptable or we need to display a different message client-side if we get the generic error

I'm not that happy about the password dialog behaviour with this change - Because we don't want to introduce a mechanism to test if a burn-after-reading paste has been read (by just trying to read it with a invalid token), we have to give the same answer when the token is incorrect as when such a paste has been read. Hence the client can't distinguish between having sent an incorrect password or it already being deleted. This is why I currently don't recurse the password dialog if it fails, as I want to display the paste does'nt exist message at some point.

Suggestions on how to improve this, UI-wise, are appreciated. Maybe we only need to answer this way for burn-after-reading pastes but do return a better status / message for mismatching tokens for regular pastes?

I'm not considering this a blocker or must have for the 1.3 release. We can continue working on this until we are all happy with it.