### PR TITLE
Dropzone should be fixed to viewport, instead of fixed to sibling element

### DIFF
--- a/css/bootstrap/privatebin.css
+++ b/css/bootstrap/privatebin.css
@@ -82,7 +82,7 @@ body.loading {
 
 #dropzone {
 	text-align: center;
-	position: absolute;
+	position: fixed;
 	top: 0;
 	left: 0;
 	width: 100%;

--- a/css/privatebin.css
+++ b/css/privatebin.css
@@ -117,7 +117,7 @@ h3.title {
 
 #dropzone {
 	text-align: center;
-	position: absolute;
+	position: fixed;
 	top: 0;
 	left: 0;
 	width: 100%;


### PR DESCRIPTION


<!-- This is a template for your Pull Request. This are just some suggestions for you. You do not have to use all of them. -->

<!-- If your PR fixes an issue, mention it here. You can also just copy the URL - GitHub will convert it for you.
If this PR fixes several issues, please prepend each issue url/number with the word "fix"/"fixes" or "close"/"closes" as this automatically closes the issues you mentioned when the PR is merged.
-->
This PR fixes 
The problem when:
1. The page is taller than viewport (scroll horizontally)
2. Drag and drop a file when the page is not scrolled to the top
3. The dropzone(blue overlay) will offset from window, partically visible

Example:
<img width="1079" alt="dropzone offset" src="https://user-images.githubusercontent.com/10842569/63407832-9190d700-c3bb-11e9-86d6-24e1bf128e81.png">

After the fix dropzone will always fit viewport.

## Changes
<!-- List all the changes you have done -->
* 
* 

## ToDo
<!-- Add things, you still want to do. It is recommend to put "[DNM]", "[DONOTMERGE]", "[WIP]" or "[WORKINPROGRESS]" **into the title** of your PR if you still want to work on this PR, but just do not want to have it merged yet. -->
* [ ] 
* [ ] 
* [ ] 
