### PR TITLE
#552 Add support for a CONFIG_PATH env variable

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -18,7 +18,7 @@ options](#configuration) to adjust as you see fit.
   - open_basedir access to `/dev/urandom`
   - mcrypt extension
   - com_dotnet extension
-  
+
   Mcrypt needs to be able to access `/dev/urandom`. This means if `open_basedir` is set, it must include this file.
 - GD extension
 - some disk space or (optionally) a database supported by [PDO](https://secure.php.net/manual/book.pdo.php)
@@ -43,12 +43,33 @@ process (see also
 >
 > The full path of PrivateBin on your webserver is:
 > /home/example.com/htdocs/paste
-> 
+>
 > When setting the path like this:
 > define('PATH', '../../secret/privatebin/');
 >
 > PrivateBin will look for your includes / data here:
 > /home/example.com/secret/privatebin
+
+### Changing the config path only
+
+In situations where you want to keep the PrivateBin static files separate from the
+rest of your data, or you want to reuse the installation files on multiple vhosts,
+you may only want to change the `conf.php`. In this instance, you can set the
+`CONFIG_PATH` environment variable to the absolute path to the `conf.php` file.
+This can be done in your web server's virtual host config, the PHP config, or in
+the index.php if you choose to customize it.
+
+Note that your PHP process will need read access to the config wherever it may be.
+
+> #### CONFIG_PATH example
+> Setting the value in an Apache Vhost:
+> SetEnv CONFIG_PATH /var/lib/privatebin/conf.php
+>
+> In a php-fpm pool config:
+> env[CONFIG_PATH] = /var/lib/privatebin/conf.php
+>
+> In the index.php, near the top:
+> putenv('CONFIG_PATH=/var/lib/privatebin/conf.php');
 
 ### Transport security
 
@@ -66,8 +87,9 @@ See [this FAQ item](https://github.com/PrivateBin/PrivateBin/wiki/FAQ#what-are-t
 
 In the file `cfg/conf.php` you can configure PrivateBin. A `cfg/conf.sample.php`
 is provided containing all options and default values. You can copy it to
-`cfg/conf.php` and adapt it as needed. The config file is divided into multiple
-sections, which are enclosed in square brackets.
+`cfg/conf.php` and adapt it as needed. Alternatively you can copy it anywhere and
+set the `CONFIG_PATH` environment variable (see above notes). The config file is
+divided into multiple sections, which are enclosed in square brackets.
 
 In the `[main]` section you can enable or disable the discussion feature, set
 the limit of stored pastes and comments in bytes. The `[traffic]` section lets

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -107,7 +107,8 @@ class Configuration
         $configFile = $basePath . 'conf.php';
 
         if (getenv('CONFIG_PATH') !== false) {
-            $configFile = getenv('CONFIG_PATH');
+            $configFile    = getenv('CONFIG_PATH');
+            $configFilePhp = substr($configFile, 0, -3) . 'php';
 
             // Rename INI files to avoid configuration leakage
             if (
@@ -115,9 +116,12 @@ class Configuration
                 is_readable($configFile) &&
                 is_writable(dirname($configFile))
             ) {
-                $oldConfigFile = $configFile;
-                $configFile    = substr($configFile, 0, -3) . 'php';
-                DataStore::prependRename($oldConfigFile, $configFile, ';');
+                DataStore::prependRename($configFile, $configFilePhp, ';');
+            }
+
+            // Rename successful? Already renamed? use that file
+            if (is_readable($configFilePhp)) {
+                $configFile = $configFilePhp;
             }
         }
 

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -104,11 +104,21 @@ class Configuration
         $config     = array();
         $basePath   = PATH . 'cfg' . DIRECTORY_SEPARATOR;
         $configIni  = $basePath . 'conf.ini';
+        $configFile = $basePath . 'conf.php';
 
         if (getenv('CONFIG_PATH') !== false) {
             $configFile = getenv('CONFIG_PATH');
-        } else {
-            $configFile = $basePath . 'conf.php';
+
+            // Rename INI files to avoid configuration leakage
+            if (
+                strtolower(substr($configFile, -3, 3)) == 'ini' &&
+                is_readable($configFile) &&
+                is_writable(dirname($configFile))
+            ) {
+                $oldConfigFile = $configFile;
+                $configFile    = substr($configFile, 0, -3) . 'php';
+                DataStore::prependRename($oldConfigFile, $configFile, ';');
+            }
         }
 
         // rename INI files to avoid configuration leakage

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -102,8 +102,14 @@ class Configuration
     public function __construct()
     {
         $config     = array();
-        $configFile = PATH . 'cfg' . DIRECTORY_SEPARATOR . 'conf.php';
-        $configIni  = PATH . 'cfg' . DIRECTORY_SEPARATOR . 'conf.ini';
+        $basePath   = PATH. 'cfg' . DIRECTORY_SEPARATOR;
+        $configIni  = $basePath . 'conf.ini';
+
+        if (getenv('CONFIG_PATH') !== false) {
+            $configFile = getenv('CONFIG_PATH');
+        } else {
+            $configFile = $basePath . 'conf.php';
+        }
 
         // rename INI files to avoid configuration leakage
         if (is_readable($configIni)) {
@@ -112,7 +118,7 @@ class Configuration
             // cleanup sample, too
             $configIniSample = $configIni . '.sample';
             if (is_readable($configIniSample)) {
-                DataStore::prependRename($configIniSample, PATH . 'cfg' . DIRECTORY_SEPARATOR . 'conf.sample.php', ';');
+                DataStore::prependRename($configIniSample, $basePath . 'conf.sample.php', ';');
             }
         }
 

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -102,7 +102,7 @@ class Configuration
     public function __construct()
     {
         $config     = array();
-        $basePath   = PATH. 'cfg' . DIRECTORY_SEPARATOR;
+        $basePath   = PATH . 'cfg' . DIRECTORY_SEPARATOR;
         $configIni  = $basePath . 'conf.ini';
 
         if (getenv('CONFIG_PATH') !== false) {


### PR DESCRIPTION
Closes #552 

I have put a very detailed description into the issue as to why I want to add this. I considered using a constant and adding a DEFINE to the index.php but for the use case this is more elegant.

## Changes
* Query a `CONFIG_PATH` env var for the path to the config.php before using the default path.

## ToDo
* Nothing