### PR TITLE
Fix ARIA for Editor/preview tabs.

### DIFF
--- a/js/privatebin.js
+++ b/js/privatebin.js
@@ -2205,6 +2205,9 @@ jQuery.PrivateBin = (function($, RawDeflate) {
             $messageEdit.addClass('active');
             $messagePreview.removeClass('active');
 
+            $('#messageedit').attr("aria-selected",true);
+            $('#messagepreview').attr("aria-selected",false);
+
             PasteViewer.hide();
 
             // reshow input
@@ -2233,6 +2236,9 @@ jQuery.PrivateBin = (function($, RawDeflate) {
             // toggle buttons
             $messageEdit.removeClass('active');
             $messagePreview.addClass('active');
+
+            $('#messageedit').attr("aria-selected","false");
+            $('#messagepreview').attr("aria-selected","true");
 
             // hide input as now preview is shown
             $message.addClass('hidden');

--- a/js/privatebin.js
+++ b/js/privatebin.js
@@ -2205,8 +2205,8 @@ jQuery.PrivateBin = (function($, RawDeflate) {
             $messageEdit.addClass('active');
             $messagePreview.removeClass('active');
 
-            $('#messageedit').attr("aria-selected",true);
-            $('#messagepreview').attr("aria-selected",false);
+            $('#messageedit').attr('aria-selected','true');
+            $('#messagepreview').attr('aria-selected','false');
 
             PasteViewer.hide();
 
@@ -2237,8 +2237,8 @@ jQuery.PrivateBin = (function($, RawDeflate) {
             $messageEdit.removeClass('active');
             $messagePreview.addClass('active');
 
-            $('#messageedit').attr("aria-selected","false");
-            $('#messagepreview').attr("aria-selected","true");
+            $('#messageedit').attr('aria-selected','false');
+            $('#messagepreview').attr('aria-selected','true');
 
             // hide input as now preview is shown
             $message.addClass('hidden');

--- a/tpl/bootstrap.php
+++ b/tpl/bootstrap.php
@@ -72,7 +72,7 @@ endif;
 ?>
 		<script type="text/javascript" data-cfasync="false" src="js/purify-2.0.7.js" integrity="sha512-XjNEK1xwh7SJ/7FouwV4VZcGW9cMySL3SwNpXgrURLBcXXQYtZdqhGoNdEwx9vwLvFjUGDQVNgpOrTsXlSTiQg==" crossorigin="anonymous"></script>
 		<script type="text/javascript" data-cfasync="false" src="js/legacy.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-LYos+qXHIRqFf5ZPNphvtTB0cgzHUizu2wwcOwcwz/VIpRv9lpcBgPYz4uq6jx0INwCAj6Fbnl5HoKiLufS2jg==" crossorigin="anonymous"></script>
-		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-wizOnILU1zHsTf7zI5sUykY0+hYrw0b43LaJv16fudk4K7t+nx2u3jRuGdjwhMZVSLQKb0dgiJ/IpXTaOCZslQ==" crossorigin="anonymous"></script>
+		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-hUQ004Y9aJ0sCtoNjuMbNBSD/W5vebyLoIesVxejHaY6lD62Xupq48QmP6qo/IOOmBI3a8uLJFGOT7YSQ1+IBw==" crossorigin="anonymous"></script>
 		<link rel="apple-touch-icon" href="img/apple-touch-icon.png?<?php echo rawurlencode($VERSION); ?>" sizes="180x180" />
 		<link rel="icon" type="image/png" href="img/favicon-32x32.png?<?php echo rawurlencode($VERSION); ?>" sizes="32x32" />
 		<link rel="icon" type="image/png" href="img/favicon-16x16.png?<?php echo rawurlencode($VERSION); ?>" sizes="16x16" />
@@ -517,8 +517,8 @@ endif;
 ?>
 				</div>
 				<ul id="editorTabs" class="nav nav-tabs hidden">
-					<li role="presentation" class="active"><a id="messageedit" href="#"><?php echo I18n::_('Editor'); ?></a></li>
-					<li role="presentation"><a id="messagepreview" href="#"><?php echo I18n::_('Preview'); ?></a></li>
+					<li role="presentation" class="active"><a role="tab" aria-selected="true" aria-controls="editorTabs" id="messageedit" href="#"><?php echo I18n::_('Editor'); ?></a></li>
+					<li role="presentation"><a role="tab" aria-selected="false" aria-controls="editorTabs" id="messagepreview" href="#"><?php echo I18n::_('Preview'); ?></a></li>
 					<li role="presentation" class="pull-right">
 <?php
 if ($isPage):

--- a/tpl/bootstrap.php
+++ b/tpl/bootstrap.php
@@ -72,7 +72,7 @@ endif;
 ?>
 		<script type="text/javascript" data-cfasync="false" src="js/purify-2.0.7.js" integrity="sha512-XjNEK1xwh7SJ/7FouwV4VZcGW9cMySL3SwNpXgrURLBcXXQYtZdqhGoNdEwx9vwLvFjUGDQVNgpOrTsXlSTiQg==" crossorigin="anonymous"></script>
 		<script type="text/javascript" data-cfasync="false" src="js/legacy.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-LYos+qXHIRqFf5ZPNphvtTB0cgzHUizu2wwcOwcwz/VIpRv9lpcBgPYz4uq6jx0INwCAj6Fbnl5HoKiLufS2jg==" crossorigin="anonymous"></script>
-		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-hUQ004Y9aJ0sCtoNjuMbNBSD/W5vebyLoIesVxejHaY6lD62Xupq48QmP6qo/IOOmBI3a8uLJFGOT7YSQ1+IBw==" crossorigin="anonymous"></script>
+		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-RJwTFnQikma3rIso3dda8anhgsoFT7dZdARUw9m5/9Gl9A+U3B3H7LEjuLRFmC0rV86SfuXNnKwILAbF96Hr/w==" crossorigin="anonymous"></script>
 		<link rel="apple-touch-icon" href="img/apple-touch-icon.png?<?php echo rawurlencode($VERSION); ?>" sizes="180x180" />
 		<link rel="icon" type="image/png" href="img/favicon-32x32.png?<?php echo rawurlencode($VERSION); ?>" sizes="32x32" />
 		<link rel="icon" type="image/png" href="img/favicon-16x16.png?<?php echo rawurlencode($VERSION); ?>" sizes="16x16" />

--- a/tpl/page.php
+++ b/tpl/page.php
@@ -50,7 +50,7 @@ endif;
 ?>
 		<script type="text/javascript" data-cfasync="false" src="js/purify-2.0.7.js" integrity="sha512-XjNEK1xwh7SJ/7FouwV4VZcGW9cMySL3SwNpXgrURLBcXXQYtZdqhGoNdEwx9vwLvFjUGDQVNgpOrTsXlSTiQg==" crossorigin="anonymous"></script>
 		<script type="text/javascript" data-cfasync="false" src="js/legacy.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-LYos+qXHIRqFf5ZPNphvtTB0cgzHUizu2wwcOwcwz/VIpRv9lpcBgPYz4uq6jx0INwCAj6Fbnl5HoKiLufS2jg==" crossorigin="anonymous"></script>
-		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-hUQ004Y9aJ0sCtoNjuMbNBSD/W5vebyLoIesVxejHaY6lD62Xupq48QmP6qo/IOOmBI3a8uLJFGOT7YSQ1+IBw==" crossorigin="anonymous"></script>
+		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-RJwTFnQikma3rIso3dda8anhgsoFT7dZdARUw9m5/9Gl9A+U3B3H7LEjuLRFmC0rV86SfuXNnKwILAbF96Hr/w==" crossorigin="anonymous"></script>
 		<link rel="apple-touch-icon" href="img/apple-touch-icon.png?<?php echo rawurlencode($VERSION); ?>" sizes="180x180" />
 		<link rel="icon" type="image/png" href="img/favicon-32x32.png?<?php echo rawurlencode($VERSION); ?>" sizes="32x32" />
 		<link rel="icon" type="image/png" href="img/favicon-16x16.png?<?php echo rawurlencode($VERSION); ?>" sizes="16x16" />

--- a/tpl/page.php
+++ b/tpl/page.php
@@ -50,7 +50,7 @@ endif;
 ?>
 		<script type="text/javascript" data-cfasync="false" src="js/purify-2.0.7.js" integrity="sha512-XjNEK1xwh7SJ/7FouwV4VZcGW9cMySL3SwNpXgrURLBcXXQYtZdqhGoNdEwx9vwLvFjUGDQVNgpOrTsXlSTiQg==" crossorigin="anonymous"></script>
 		<script type="text/javascript" data-cfasync="false" src="js/legacy.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-LYos+qXHIRqFf5ZPNphvtTB0cgzHUizu2wwcOwcwz/VIpRv9lpcBgPYz4uq6jx0INwCAj6Fbnl5HoKiLufS2jg==" crossorigin="anonymous"></script>
-		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-wizOnILU1zHsTf7zI5sUykY0+hYrw0b43LaJv16fudk4K7t+nx2u3jRuGdjwhMZVSLQKb0dgiJ/IpXTaOCZslQ==" crossorigin="anonymous"></script>
+		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-hUQ004Y9aJ0sCtoNjuMbNBSD/W5vebyLoIesVxejHaY6lD62Xupq48QmP6qo/IOOmBI3a8uLJFGOT7YSQ1+IBw==" crossorigin="anonymous"></script>
 		<link rel="apple-touch-icon" href="img/apple-touch-icon.png?<?php echo rawurlencode($VERSION); ?>" sizes="180x180" />
 		<link rel="icon" type="image/png" href="img/favicon-32x32.png?<?php echo rawurlencode($VERSION); ?>" sizes="32x32" />
 		<link rel="icon" type="image/png" href="img/favicon-16x16.png?<?php echo rawurlencode($VERSION); ?>" sizes="16x16" />


### PR DESCRIPTION
Fixes https://github.com/PrivateBin/PrivateBin/issues/534

**Please note**: This fix is only for the default, Bootstrap template. The template in tpl/page.php has the editor and preview buttons in a DIV with an ARIA-Hidden role, thus it needs more work to expose those controls to a screen reader as well.