### PR TITLE
Feature FAQ link in Readme & remove legacy things

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,9 +95,9 @@ file](https://github.com/PrivateBin/PrivateBin/wiki/Configuration):
 
 ## Further resources
 
-* [Installation guide](https://github.com/PrivateBin/PrivateBin/blob/master/INSTALL.md#installation)
+* [FAQ](https://github.com/PrivateBin/PrivateBin/wiki/FAQ)
 
-* [Upgrading from ZeroBin 0.19 Alpha](https://github.com/PrivateBin/PrivateBin/wiki/Upgrading-from-ZeroBin-0.19-Alpha)
+* [Installation guide](https://github.com/PrivateBin/PrivateBin/blob/master/INSTALL.md#installation)
 
 * [Configuration guide](https://github.com/PrivateBin/PrivateBin/wiki/Configuration)
 


### PR DESCRIPTION
* remove old ZeroBin 0.19 guide, this is so old already, few people will benefit from a direct link in the Readme. It stays in the wiki for those, who need it.
* add direct link to the FAQ - it's one of our best documentation/sources, so it's a shame it is not featured more prominently 😉

