### PR TITLE
Preview encoding fix

### DIFF
--- a/js/privatebin.js
+++ b/js/privatebin.js
@@ -297,25 +297,10 @@ jQuery.PrivateBin = (function($, RawDeflate) {
          */
         me.urls2links = function(html)
         {
-            let reverseEntityMap = {};
-            for (let entity of ['&', '"', '/', '=']) {
-                reverseEntityMap[entityMap[entity]] = entity;
-            }
-            const entityRegex = new RegExp(Object.keys(reverseEntityMap).join('|'), 'g');
-
-            // encode HTML entities, find and insert links, partially decoding only the href property of it
-            return me.htmlEntities(html)
-                     .replace(
-                        /(((https?|ftp):&#x2F;&#x2F;[\w?!&.-;#@~%+*-]+(?![\w\s?!&.;#~%-]*>))|((magnet):[\w?&.-;#@~%+*-]+))/ig,
-                        function(encodedUrl) {
-                            let decodedUrl = encodedUrl.replace(
-                                entityRegex, function(entity) {
-                                    return reverseEntityMap[entity];
-                                }
-                            );
-                            return '<a href="' + decodedUrl + '" rel="nofollow">' + encodedUrl + '</a>';
-                        }
-                     )
+            return html.replace(
+                /(((https?|ftp):\/\/[\w?!=&.\/-;#@~%+*-]+(?![\w\s?!&.\/;#~%"=-]*>))|((magnet):[\w?=&.\/-;#@~%+*-]+))/ig,
+                '<a href="$1" rel="nofollow">$1</a>'
+            );
         };
 
         /**

--- a/js/privatebin.js
+++ b/js/privatebin.js
@@ -392,7 +392,7 @@ jQuery.PrivateBin = (function($, RawDeflate) {
         {
             element.html(
                 element.html().replace(
-                    /(((https?|ftp):\/\/[\w?!=&.\/-;#@~%+*-]+(?![\w\s?!&.\/;#~%"=-]*>))|((magnet):[\w?=&.\/-;#@~%+*-]+))/ig,
+                    /(((https?|ftp):\/\/[\w?!=&.\/-;#@~%+*-]+(?![\w\s?!&.\/;#~%"=-]>))|((magnet):[\w?=&.\/-;#@~%+*-]+))/ig,
                     '<a href="$1" rel="nofollow">$1</a>'
                 )
             );

--- a/js/privatebin.js
+++ b/js/privatebin.js
@@ -297,10 +297,25 @@ jQuery.PrivateBin = (function($, RawDeflate) {
          */
         me.urls2links = function(html)
         {
-            return html.replace(
-                /(((https?|ftp):\/\/[\w?!=&.\/-;#@~%+*-]+(?![\w\s?!&.\/;#~%"=-]*>))|((magnet):[\w?=&.\/-;#@~%+*-]+))/ig,
-                '<a href="$1" rel="nofollow">$1</a>'
-            );
+            let reverseEntityMap = {};
+            for (let entity of ['&', '"', '/', '=']) {
+                reverseEntityMap[entityMap[entity]] = entity;
+            }
+            const entityRegex = new RegExp(Object.keys(reverseEntityMap).join('|'), 'g');
+
+            // encode HTML entities, find and insert links, partially decoding only the href property of it
+            return me.htmlEntities(html)
+                     .replace(
+                        /(((https?|ftp):&#x2F;&#x2F;[\w?!&.-;#@~%+*-]+(?![\w\s?!&.;#~%-]*>))|((magnet):[\w?&.-;#@~%+*-]+))/ig,
+                        function(encodedUrl) {
+                            let decodedUrl = encodedUrl.replace(
+                                entityRegex, function(entity) {
+                                    return reverseEntityMap[entity];
+                                }
+                            );
+                            return '<a href="' + decodedUrl + '" rel="nofollow">' + encodedUrl + '</a>';
+                        }
+                     )
         };
 
         /**

--- a/js/privatebin.js
+++ b/js/privatebin.js
@@ -281,7 +281,7 @@ jQuery.PrivateBin = (function($, RawDeflate) {
         };
 
         /**
-         * convert URLs to clickable links.
+         * convert URLs to clickable links in the provided element.
          *
          * URLs to handle:
          * <pre>
@@ -292,14 +292,15 @@ jQuery.PrivateBin = (function($, RawDeflate) {
          *
          * @name   Helper.urls2links
          * @function
-         * @param  {string} html
-         * @return {string}
+         * @param  {HTMLElement} element
          */
-        me.urls2links = function(html)
+        me.urls2links = function(element)
         {
-            return html.replace(
-                /(((https?|ftp):\/\/[\w?!=&.\/-;#@~%+*-]+(?![\w\s?!&.\/;#~%"=-]*>))|((magnet):[\w?=&.\/-;#@~%+*-]+))/ig,
-                '<a href="$1" rel="nofollow">$1</a>'
+            element.html(
+                element.html().replace(
+                    /(((https?|ftp):\/\/[\w?!=&.\/-;#@~%+*-]+(?![\w\s?!&.\/;#~%"=-]*>))|((magnet):[\w?=&.\/-;#@~%+*-]+))/ig,
+                    '<a href="$1" rel="nofollow">$1</a>'
+                )
             );
         };
 
@@ -2439,11 +2440,6 @@ jQuery.PrivateBin = (function($, RawDeflate) {
                 // add table classes from bootstrap css
                 $plainText.find('table').addClass('table-condensed table-bordered');
             } else {
-                // escape HTML entities, link URLs, sanitize
-                const escapedLinkedText = Helper.urls2links(text);
-                let sanitizeLinkedText = '',
-                    sanitizerConfiguration = {};
-
                 if (format === 'syntaxhighlighting') {
                     // yes, this is really needed to initialize the environment
                     if (typeof prettyPrint === 'function')
@@ -2451,22 +2447,16 @@ jQuery.PrivateBin = (function($, RawDeflate) {
                         prettyPrint();
                     }
 
-                    sanitizeLinkedText = prettyPrintOne(
-                        escapedLinkedText, null, true
+                    $prettyPrint.html(
+                        prettyPrintOne(
+                            Helper.htmlEntities(text), null, true
+                        )
                     );
                 } else {
                     // = 'plaintext'
-                    sanitizeLinkedText = escapedLinkedText;
-                    sanitizerConfiguration = {
-                        ALLOWED_TAGS: ['a'],
-                        ALLOWED_ATTR: ['href', 'rel']
-                    };
+                    $prettyPrint.text(text);
                 }
-                $prettyPrint.html(
-                    DOMPurify.sanitize(
-                        sanitizeLinkedText, sanitizerConfiguration
-                    )
-                );
+                Helper.urls2links($prettyPrint);
                 $prettyPrint.css('white-space', 'pre-wrap');
                 $prettyPrint.css('word-break', 'normal');
                 $prettyPrint.removeClass('prettyprint');
@@ -3243,14 +3233,8 @@ jQuery.PrivateBin = (function($, RawDeflate) {
             const $commentEntryData = $commentEntry.find('div.commentdata');
 
             // set & parse text
-            $commentEntryData.html(
-                DOMPurify.sanitize(
-                    Helper.urls2links(commentText), {
-                        ALLOWED_TAGS: ['a'],
-                        ALLOWED_ATTR: ['href', 'rel']
-                    }
-                )
-            );
+            $commentEntryData.text(commentText);
+            Helper.urls2links($commentEntryData);
 
             // set nickname
             if (nickname.length > 0) {

--- a/js/test/Helper.js
+++ b/js/test/Helper.js
@@ -81,7 +81,15 @@ describe('Helper', function () {
             'ignores non-URL content',
             'string',
             function (content) {
-                return content === $.PrivateBin.Helper.urls2links(content);
+                content = content.replace("\r", "\n").replace("\u0000", '');
+                let clean = jsdom();
+                $('body').html('<div id="foo"></div>');
+                let e = $('#foo');
+                e.text(content);
+                $.PrivateBin.Helper.urls2links(e);
+                let result = e.text();
+                clean();
+                return content === result;
             }
         );
         jsc.property(
@@ -95,9 +103,12 @@ describe('Helper', function () {
             function (prefix, schema, address, query, fragment, postfix) {
                 query    = query.join('');
                 fragment = fragment.join('');
-                prefix   = $.PrivateBin.Helper.htmlEntities(prefix);
-                postfix  = ' ' + $.PrivateBin.Helper.htmlEntities(postfix);
-                let url  = schema + '://' + address.join('') + '/?' + query + '#' + fragment;
+                prefix = prefix.replace("\r", "\n").replace("\u0000", '');
+                postfix  = ' ' + postfix.replace("\r", "\n").replace("\u0000", '');
+                let url  = schema + '://' + address.join('') + '/?' + query + '#' + fragment,
+                    clean = jsdom();
+                $('body').html('<div id="foo"></div>');
+                let e = $('#foo');
 
                 // special cases: When the query string and fragment imply the beginning of an HTML entity, eg. &#0 or &#x
                 if (
@@ -108,8 +119,12 @@ describe('Helper', function () {
                     url = schema + '://' + address.join('') + '/?' + query.substring(0, query.length - 1);
                     postfix = '';
                 }
-
-                return prefix + '<a href="' + url + '" rel="nofollow">' + url + '</a>' + postfix === $.PrivateBin.Helper.urls2links(prefix + url + postfix);
+                e.text(prefix + url + postfix);
+                $.PrivateBin.Helper.urls2links(e);
+                let result = e.html();
+                clean();
+                url = $('<div />').text(url).html();
+                return $('<div />').text(prefix).html() + '<a href="' + url + '" rel="nofollow">' + url + '</a>' + $('<div />').text(postfix).html() === result;
             }
         );
         jsc.property(
@@ -118,10 +133,18 @@ describe('Helper', function () {
             jsc.array(common.jscQueryString()),
             'string',
             function (prefix, query, postfix) {
-                prefix   = $.PrivateBin.Helper.htmlEntities(prefix);
-                postfix  = $.PrivateBin.Helper.htmlEntities(postfix);
-                let url  = 'magnet:?' + query.join('').replace(/^&+|&+$/gm,'');
-                return prefix + '<a href="' + url + '" rel="nofollow">' + url + '</a> ' + postfix === $.PrivateBin.Helper.urls2links(prefix + url + ' ' + postfix);
+                prefix = prefix.replace("\r", "\n").replace("\u0000", '');
+                postfix = ' ' + postfix.replace("\r", "\n").replace("\u0000", '');
+                let url  = 'magnet:?' + query.join('').replace(/^&+|&+$/gm,''),
+                    clean = jsdom();
+                $('body').html('<div id="foo"></div>');
+                let e = $('#foo');
+                e.text(prefix + url + postfix);
+                $.PrivateBin.Helper.urls2links(e);
+                let result = e.html();
+                clean();
+                url = $('<div />').text(url).html();
+                return $('<div />').text(prefix).html() + '<a href="' + url + '" rel="nofollow">' + url + '</a>' + $('<div />').text(postfix).html() === result;
             }
         );
     });

--- a/js/test/Helper.js
+++ b/js/test/Helper.js
@@ -81,7 +81,7 @@ describe('Helper', function () {
             'ignores non-URL content',
             'string',
             function (content) {
-                content = content.replace("\r", "\n").replace("\u0000", '');
+                content = content.replace(/\r/g, '\n').replace(/\u0000/g, '');
                 let clean = jsdom();
                 $('body').html('<div id="foo"></div>');
                 let e = $('#foo');
@@ -103,8 +103,8 @@ describe('Helper', function () {
             function (prefix, schema, address, query, fragment, postfix) {
                 query    = query.join('');
                 fragment = fragment.join('');
-                prefix = prefix.replace("\r", "\n").replace("\u0000", '');
-                postfix  = ' ' + postfix.replace("\r", "\n").replace("\u0000", '');
+                prefix = prefix.replace(/\r/g, '\n').replace(/\u0000/g, '');
+                postfix  = ' ' + postfix.replace(/\r/g, '\n').replace(/\u0000/g, '');
                 let url  = schema + '://' + address.join('') + '/?' + query + '#' + fragment,
                     clean = jsdom();
                 $('body').html('<div id="foo"></div>');
@@ -133,8 +133,8 @@ describe('Helper', function () {
             jsc.array(common.jscQueryString()),
             'string',
             function (prefix, query, postfix) {
-                prefix = prefix.replace("\r", "\n").replace("\u0000", '');
-                postfix = ' ' + postfix.replace("\r", "\n").replace("\u0000", '');
+                prefix = prefix.replace(/\r/g, '\n').replace(/\u0000/g, '');
+                postfix = ' ' + postfix.replace(/\r/g, '\n').replace(/\u0000/g, '');
                 let url  = 'magnet:?' + query.join('').replace(/^&+|&+$/gm,''),
                     clean = jsdom();
                 $('body').html('<div id="foo"></div>');

--- a/js/test/Helper.js
+++ b/js/test/Helper.js
@@ -81,7 +81,7 @@ describe('Helper', function () {
             'ignores non-URL content',
             'string',
             function (content) {
-                return content === $.PrivateBin.Helper.urls2links(content);
+                return $.PrivateBin.Helper.htmlEntities(content) === $.PrivateBin.Helper.urls2links(content);
             }
         );
         jsc.property(
@@ -95,8 +95,7 @@ describe('Helper', function () {
             function (prefix, schema, address, query, fragment, postfix) {
                 query    = query.join('');
                 fragment = fragment.join('');
-                prefix   = $.PrivateBin.Helper.htmlEntities(prefix);
-                postfix  = ' ' + $.PrivateBin.Helper.htmlEntities(postfix);
+                postfix  = ' ' + postfix;
                 let url  = schema + '://' + address.join('') + '/?' + query + '#' + fragment;
 
                 // special cases: When the query string and fragment imply the beginning of an HTML entity, eg. &#0 or &#x
@@ -109,7 +108,7 @@ describe('Helper', function () {
                     postfix = '';
                 }
 
-                return prefix + '<a href="' + url + '" rel="nofollow">' + url + '</a>' + postfix === $.PrivateBin.Helper.urls2links(prefix + url + postfix);
+                return $.PrivateBin.Helper.htmlEntities(prefix) + '<a href="' + url + '" rel="nofollow">' + $.PrivateBin.Helper.htmlEntities(url) + '</a>' + $.PrivateBin.Helper.htmlEntities(postfix) === $.PrivateBin.Helper.urls2links(prefix + url + postfix);
             }
         );
         jsc.property(
@@ -118,10 +117,8 @@ describe('Helper', function () {
             jsc.array(common.jscQueryString()),
             'string',
             function (prefix, query, postfix) {
-                prefix   = $.PrivateBin.Helper.htmlEntities(prefix);
-                postfix  = $.PrivateBin.Helper.htmlEntities(postfix);
                 let url  = 'magnet:?' + query.join('').replace(/^&+|&+$/gm,'');
-                return prefix + '<a href="' + url + '" rel="nofollow">' + url + '</a> ' + postfix === $.PrivateBin.Helper.urls2links(prefix + url + ' ' + postfix);
+                return $.PrivateBin.Helper.htmlEntities(prefix) + '<a href="' + url + '" rel="nofollow">' + $.PrivateBin.Helper.htmlEntities(url) + '</a> ' + $.PrivateBin.Helper.htmlEntities(postfix) === $.PrivateBin.Helper.urls2links(prefix + url + ' ' + postfix);
             }
         );
     });

--- a/js/test/Helper.js
+++ b/js/test/Helper.js
@@ -81,7 +81,7 @@ describe('Helper', function () {
             'ignores non-URL content',
             'string',
             function (content) {
-                return $.PrivateBin.Helper.htmlEntities(content) === $.PrivateBin.Helper.urls2links(content);
+                return content === $.PrivateBin.Helper.urls2links(content);
             }
         );
         jsc.property(
@@ -95,7 +95,8 @@ describe('Helper', function () {
             function (prefix, schema, address, query, fragment, postfix) {
                 query    = query.join('');
                 fragment = fragment.join('');
-                postfix  = ' ' + postfix;
+                prefix   = $.PrivateBin.Helper.htmlEntities(prefix);
+                postfix  = ' ' + $.PrivateBin.Helper.htmlEntities(postfix);
                 let url  = schema + '://' + address.join('') + '/?' + query + '#' + fragment;
 
                 // special cases: When the query string and fragment imply the beginning of an HTML entity, eg. &#0 or &#x
@@ -108,7 +109,7 @@ describe('Helper', function () {
                     postfix = '';
                 }
 
-                return $.PrivateBin.Helper.htmlEntities(prefix) + '<a href="' + url + '" rel="nofollow">' + $.PrivateBin.Helper.htmlEntities(url) + '</a>' + $.PrivateBin.Helper.htmlEntities(postfix) === $.PrivateBin.Helper.urls2links(prefix + url + postfix);
+                return prefix + '<a href="' + url + '" rel="nofollow">' + url + '</a>' + postfix === $.PrivateBin.Helper.urls2links(prefix + url + postfix);
             }
         );
         jsc.property(
@@ -117,8 +118,10 @@ describe('Helper', function () {
             jsc.array(common.jscQueryString()),
             'string',
             function (prefix, query, postfix) {
+                prefix   = $.PrivateBin.Helper.htmlEntities(prefix);
+                postfix  = $.PrivateBin.Helper.htmlEntities(postfix);
                 let url  = 'magnet:?' + query.join('').replace(/^&+|&+$/gm,'');
-                return $.PrivateBin.Helper.htmlEntities(prefix) + '<a href="' + url + '" rel="nofollow">' + $.PrivateBin.Helper.htmlEntities(url) + '</a> ' + $.PrivateBin.Helper.htmlEntities(postfix) === $.PrivateBin.Helper.urls2links(prefix + url + ' ' + postfix);
+                return prefix + '<a href="' + url + '" rel="nofollow">' + url + '</a> ' + postfix === $.PrivateBin.Helper.urls2links(prefix + url + ' ' + postfix);
             }
         );
     });

--- a/tpl/bootstrap.php
+++ b/tpl/bootstrap.php
@@ -72,7 +72,7 @@ endif;
 ?>
 		<script type="text/javascript" data-cfasync="false" src="js/purify-2.0.8.js" integrity="sha512-QwcEKGuEmKtMguCO9pqNtUtZqq9b/tJ8gNr5qhY8hykq3zKTlDOvpZAmf6Rs8yH35Bz1ZdctUjj2qEWxT5aXCg==" crossorigin="anonymous"></script>
 		<script type="text/javascript" data-cfasync="false" src="js/legacy.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-LYos+qXHIRqFf5ZPNphvtTB0cgzHUizu2wwcOwcwz/VIpRv9lpcBgPYz4uq6jx0INwCAj6Fbnl5HoKiLufS2jg==" crossorigin="anonymous"></script>
-		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-enOoc3FEmX00nbC+28Qrhjc2shbso/DWmeHVbLDy+a0jvXXweYXCr/B1PRqnXJzTBdPqVBYLVM1u6peVlTwNxg==" crossorigin="anonymous"></script>
+		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-YrCefSac8MOPuEvP3IJTSt6svl0P34qwnFy6czhtOJ6yN6ykmmrFdXKWMmD/gyp+hBnFdQnkC7o3GtrjuZkZgA==" crossorigin="anonymous"></script>
 		<link rel="apple-touch-icon" href="img/apple-touch-icon.png?<?php echo rawurlencode($VERSION); ?>" sizes="180x180" />
 		<link rel="icon" type="image/png" href="img/favicon-32x32.png?<?php echo rawurlencode($VERSION); ?>" sizes="32x32" />
 		<link rel="icon" type="image/png" href="img/favicon-16x16.png?<?php echo rawurlencode($VERSION); ?>" sizes="16x16" />

--- a/tpl/bootstrap.php
+++ b/tpl/bootstrap.php
@@ -72,7 +72,7 @@ endif;
 ?>
 		<script type="text/javascript" data-cfasync="false" src="js/purify-2.0.8.js" integrity="sha512-QwcEKGuEmKtMguCO9pqNtUtZqq9b/tJ8gNr5qhY8hykq3zKTlDOvpZAmf6Rs8yH35Bz1ZdctUjj2qEWxT5aXCg==" crossorigin="anonymous"></script>
 		<script type="text/javascript" data-cfasync="false" src="js/legacy.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-LYos+qXHIRqFf5ZPNphvtTB0cgzHUizu2wwcOwcwz/VIpRv9lpcBgPYz4uq6jx0INwCAj6Fbnl5HoKiLufS2jg==" crossorigin="anonymous"></script>
-		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-YrCefSac8MOPuEvP3IJTSt6svl0P34qwnFy6czhtOJ6yN6ykmmrFdXKWMmD/gyp+hBnFdQnkC7o3GtrjuZkZgA==" crossorigin="anonymous"></script>
+		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-JDQ0DFju78H5r/ZGC1n54tXnkhfijFRXxOvyWPZUTKlWKF2b1GVoPaS3eckgNcpb3MGvcYiMlhcg3xZNeyWtLQ==" crossorigin="anonymous"></script>
 		<link rel="apple-touch-icon" href="img/apple-touch-icon.png?<?php echo rawurlencode($VERSION); ?>" sizes="180x180" />
 		<link rel="icon" type="image/png" href="img/favicon-32x32.png?<?php echo rawurlencode($VERSION); ?>" sizes="32x32" />
 		<link rel="icon" type="image/png" href="img/favicon-16x16.png?<?php echo rawurlencode($VERSION); ?>" sizes="16x16" />

--- a/tpl/bootstrap.php
+++ b/tpl/bootstrap.php
@@ -72,7 +72,7 @@ endif;
 ?>
 		<script type="text/javascript" data-cfasync="false" src="js/purify-2.0.8.js" integrity="sha512-QwcEKGuEmKtMguCO9pqNtUtZqq9b/tJ8gNr5qhY8hykq3zKTlDOvpZAmf6Rs8yH35Bz1ZdctUjj2qEWxT5aXCg==" crossorigin="anonymous"></script>
 		<script type="text/javascript" data-cfasync="false" src="js/legacy.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-LYos+qXHIRqFf5ZPNphvtTB0cgzHUizu2wwcOwcwz/VIpRv9lpcBgPYz4uq6jx0INwCAj6Fbnl5HoKiLufS2jg==" crossorigin="anonymous"></script>
-		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-YrCefSac8MOPuEvP3IJTSt6svl0P34qwnFy6czhtOJ6yN6ykmmrFdXKWMmD/gyp+hBnFdQnkC7o3GtrjuZkZgA==" crossorigin="anonymous"></script>
+		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-TJnv+hN/muDppfHqKPn8WDN9DTIlzrizLc283g/1wfJ/gS8Lk9x5fBebAPApPoVPasryUgkh3xPJ0ptImT6jbQ==" crossorigin="anonymous"></script>
 		<link rel="apple-touch-icon" href="img/apple-touch-icon.png?<?php echo rawurlencode($VERSION); ?>" sizes="180x180" />
 		<link rel="icon" type="image/png" href="img/favicon-32x32.png?<?php echo rawurlencode($VERSION); ?>" sizes="32x32" />
 		<link rel="icon" type="image/png" href="img/favicon-16x16.png?<?php echo rawurlencode($VERSION); ?>" sizes="16x16" />

--- a/tpl/bootstrap.php
+++ b/tpl/bootstrap.php
@@ -72,7 +72,7 @@ endif;
 ?>
 		<script type="text/javascript" data-cfasync="false" src="js/purify-2.0.8.js" integrity="sha512-QwcEKGuEmKtMguCO9pqNtUtZqq9b/tJ8gNr5qhY8hykq3zKTlDOvpZAmf6Rs8yH35Bz1ZdctUjj2qEWxT5aXCg==" crossorigin="anonymous"></script>
 		<script type="text/javascript" data-cfasync="false" src="js/legacy.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-LYos+qXHIRqFf5ZPNphvtTB0cgzHUizu2wwcOwcwz/VIpRv9lpcBgPYz4uq6jx0INwCAj6Fbnl5HoKiLufS2jg==" crossorigin="anonymous"></script>
-		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-a6n/k3GMzkTTKsM1hyQ4+j8nIYuWB28ASR9vHvqOtEPzor4kp5ImcTRhOyNyolbeVDkuxnhducRAWnVCJwvjHg==" crossorigin="anonymous"></script>
+		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-QxNK2redCFTgf0W/sniAeqIiX4LOSrqONVTEgt1pQOMgbItohHiV/gx0EV/36Wz+pTtDsqiP2GIvQp+C4ki8Pg==" crossorigin="anonymous"></script>
 		<link rel="apple-touch-icon" href="img/apple-touch-icon.png?<?php echo rawurlencode($VERSION); ?>" sizes="180x180" />
 		<link rel="icon" type="image/png" href="img/favicon-32x32.png?<?php echo rawurlencode($VERSION); ?>" sizes="32x32" />
 		<link rel="icon" type="image/png" href="img/favicon-16x16.png?<?php echo rawurlencode($VERSION); ?>" sizes="16x16" />

--- a/tpl/bootstrap.php
+++ b/tpl/bootstrap.php
@@ -72,7 +72,7 @@ endif;
 ?>
 		<script type="text/javascript" data-cfasync="false" src="js/purify-2.0.8.js" integrity="sha512-QwcEKGuEmKtMguCO9pqNtUtZqq9b/tJ8gNr5qhY8hykq3zKTlDOvpZAmf6Rs8yH35Bz1ZdctUjj2qEWxT5aXCg==" crossorigin="anonymous"></script>
 		<script type="text/javascript" data-cfasync="false" src="js/legacy.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-LYos+qXHIRqFf5ZPNphvtTB0cgzHUizu2wwcOwcwz/VIpRv9lpcBgPYz4uq6jx0INwCAj6Fbnl5HoKiLufS2jg==" crossorigin="anonymous"></script>
-		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-TJnv+hN/muDppfHqKPn8WDN9DTIlzrizLc283g/1wfJ/gS8Lk9x5fBebAPApPoVPasryUgkh3xPJ0ptImT6jbQ==" crossorigin="anonymous"></script>
+		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-YrCefSac8MOPuEvP3IJTSt6svl0P34qwnFy6czhtOJ6yN6ykmmrFdXKWMmD/gyp+hBnFdQnkC7o3GtrjuZkZgA==" crossorigin="anonymous"></script>
 		<link rel="apple-touch-icon" href="img/apple-touch-icon.png?<?php echo rawurlencode($VERSION); ?>" sizes="180x180" />
 		<link rel="icon" type="image/png" href="img/favicon-32x32.png?<?php echo rawurlencode($VERSION); ?>" sizes="32x32" />
 		<link rel="icon" type="image/png" href="img/favicon-16x16.png?<?php echo rawurlencode($VERSION); ?>" sizes="16x16" />

--- a/tpl/page.php
+++ b/tpl/page.php
@@ -50,7 +50,7 @@ endif;
 ?>
 		<script type="text/javascript" data-cfasync="false" src="js/purify-2.0.8.js" integrity="sha512-QwcEKGuEmKtMguCO9pqNtUtZqq9b/tJ8gNr5qhY8hykq3zKTlDOvpZAmf6Rs8yH35Bz1ZdctUjj2qEWxT5aXCg==" crossorigin="anonymous"></script>
 		<script type="text/javascript" data-cfasync="false" src="js/legacy.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-LYos+qXHIRqFf5ZPNphvtTB0cgzHUizu2wwcOwcwz/VIpRv9lpcBgPYz4uq6jx0INwCAj6Fbnl5HoKiLufS2jg==" crossorigin="anonymous"></script>
-		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-TJnv+hN/muDppfHqKPn8WDN9DTIlzrizLc283g/1wfJ/gS8Lk9x5fBebAPApPoVPasryUgkh3xPJ0ptImT6jbQ==" crossorigin="anonymous"></script>
+		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-YrCefSac8MOPuEvP3IJTSt6svl0P34qwnFy6czhtOJ6yN6ykmmrFdXKWMmD/gyp+hBnFdQnkC7o3GtrjuZkZgA==" crossorigin="anonymous"></script>
 		<link rel="apple-touch-icon" href="img/apple-touch-icon.png?<?php echo rawurlencode($VERSION); ?>" sizes="180x180" />
 		<link rel="icon" type="image/png" href="img/favicon-32x32.png?<?php echo rawurlencode($VERSION); ?>" sizes="32x32" />
 		<link rel="icon" type="image/png" href="img/favicon-16x16.png?<?php echo rawurlencode($VERSION); ?>" sizes="16x16" />

--- a/tpl/page.php
+++ b/tpl/page.php
@@ -50,7 +50,7 @@ endif;
 ?>
 		<script type="text/javascript" data-cfasync="false" src="js/purify-2.0.8.js" integrity="sha512-QwcEKGuEmKtMguCO9pqNtUtZqq9b/tJ8gNr5qhY8hykq3zKTlDOvpZAmf6Rs8yH35Bz1ZdctUjj2qEWxT5aXCg==" crossorigin="anonymous"></script>
 		<script type="text/javascript" data-cfasync="false" src="js/legacy.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-LYos+qXHIRqFf5ZPNphvtTB0cgzHUizu2wwcOwcwz/VIpRv9lpcBgPYz4uq6jx0INwCAj6Fbnl5HoKiLufS2jg==" crossorigin="anonymous"></script>
-		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-YrCefSac8MOPuEvP3IJTSt6svl0P34qwnFy6czhtOJ6yN6ykmmrFdXKWMmD/gyp+hBnFdQnkC7o3GtrjuZkZgA==" crossorigin="anonymous"></script>
+		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-TJnv+hN/muDppfHqKPn8WDN9DTIlzrizLc283g/1wfJ/gS8Lk9x5fBebAPApPoVPasryUgkh3xPJ0ptImT6jbQ==" crossorigin="anonymous"></script>
 		<link rel="apple-touch-icon" href="img/apple-touch-icon.png?<?php echo rawurlencode($VERSION); ?>" sizes="180x180" />
 		<link rel="icon" type="image/png" href="img/favicon-32x32.png?<?php echo rawurlencode($VERSION); ?>" sizes="32x32" />
 		<link rel="icon" type="image/png" href="img/favicon-16x16.png?<?php echo rawurlencode($VERSION); ?>" sizes="16x16" />

--- a/tpl/page.php
+++ b/tpl/page.php
@@ -50,7 +50,7 @@ endif;
 ?>
 		<script type="text/javascript" data-cfasync="false" src="js/purify-2.0.8.js" integrity="sha512-QwcEKGuEmKtMguCO9pqNtUtZqq9b/tJ8gNr5qhY8hykq3zKTlDOvpZAmf6Rs8yH35Bz1ZdctUjj2qEWxT5aXCg==" crossorigin="anonymous"></script>
 		<script type="text/javascript" data-cfasync="false" src="js/legacy.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-LYos+qXHIRqFf5ZPNphvtTB0cgzHUizu2wwcOwcwz/VIpRv9lpcBgPYz4uq6jx0INwCAj6Fbnl5HoKiLufS2jg==" crossorigin="anonymous"></script>
-		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-a6n/k3GMzkTTKsM1hyQ4+j8nIYuWB28ASR9vHvqOtEPzor4kp5ImcTRhOyNyolbeVDkuxnhducRAWnVCJwvjHg==" crossorigin="anonymous"></script>
+		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-QxNK2redCFTgf0W/sniAeqIiX4LOSrqONVTEgt1pQOMgbItohHiV/gx0EV/36Wz+pTtDsqiP2GIvQp+C4ki8Pg==" crossorigin="anonymous"></script>
 		<link rel="apple-touch-icon" href="img/apple-touch-icon.png?<?php echo rawurlencode($VERSION); ?>" sizes="180x180" />
 		<link rel="icon" type="image/png" href="img/favicon-32x32.png?<?php echo rawurlencode($VERSION); ?>" sizes="32x32" />
 		<link rel="icon" type="image/png" href="img/favicon-16x16.png?<?php echo rawurlencode($VERSION); ?>" sizes="16x16" />

--- a/tpl/page.php
+++ b/tpl/page.php
@@ -50,7 +50,7 @@ endif;
 ?>
 		<script type="text/javascript" data-cfasync="false" src="js/purify-2.0.8.js" integrity="sha512-QwcEKGuEmKtMguCO9pqNtUtZqq9b/tJ8gNr5qhY8hykq3zKTlDOvpZAmf6Rs8yH35Bz1ZdctUjj2qEWxT5aXCg==" crossorigin="anonymous"></script>
 		<script type="text/javascript" data-cfasync="false" src="js/legacy.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-LYos+qXHIRqFf5ZPNphvtTB0cgzHUizu2wwcOwcwz/VIpRv9lpcBgPYz4uq6jx0INwCAj6Fbnl5HoKiLufS2jg==" crossorigin="anonymous"></script>
-		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-YrCefSac8MOPuEvP3IJTSt6svl0P34qwnFy6czhtOJ6yN6ykmmrFdXKWMmD/gyp+hBnFdQnkC7o3GtrjuZkZgA==" crossorigin="anonymous"></script>
+		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-JDQ0DFju78H5r/ZGC1n54tXnkhfijFRXxOvyWPZUTKlWKF2b1GVoPaS3eckgNcpb3MGvcYiMlhcg3xZNeyWtLQ==" crossorigin="anonymous"></script>
 		<link rel="apple-touch-icon" href="img/apple-touch-icon.png?<?php echo rawurlencode($VERSION); ?>" sizes="180x180" />
 		<link rel="icon" type="image/png" href="img/favicon-32x32.png?<?php echo rawurlencode($VERSION); ?>" sizes="32x32" />
 		<link rel="icon" type="image/png" href="img/favicon-16x16.png?<?php echo rawurlencode($VERSION); ?>" sizes="16x16" />

--- a/tpl/page.php
+++ b/tpl/page.php
@@ -50,7 +50,7 @@ endif;
 ?>
 		<script type="text/javascript" data-cfasync="false" src="js/purify-2.0.8.js" integrity="sha512-QwcEKGuEmKtMguCO9pqNtUtZqq9b/tJ8gNr5qhY8hykq3zKTlDOvpZAmf6Rs8yH35Bz1ZdctUjj2qEWxT5aXCg==" crossorigin="anonymous"></script>
 		<script type="text/javascript" data-cfasync="false" src="js/legacy.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-LYos+qXHIRqFf5ZPNphvtTB0cgzHUizu2wwcOwcwz/VIpRv9lpcBgPYz4uq6jx0INwCAj6Fbnl5HoKiLufS2jg==" crossorigin="anonymous"></script>
-		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-enOoc3FEmX00nbC+28Qrhjc2shbso/DWmeHVbLDy+a0jvXXweYXCr/B1PRqnXJzTBdPqVBYLVM1u6peVlTwNxg==" crossorigin="anonymous"></script>
+		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-YrCefSac8MOPuEvP3IJTSt6svl0P34qwnFy6czhtOJ6yN6ykmmrFdXKWMmD/gyp+hBnFdQnkC7o3GtrjuZkZgA==" crossorigin="anonymous"></script>
 		<link rel="apple-touch-icon" href="img/apple-touch-icon.png?<?php echo rawurlencode($VERSION); ?>" sizes="180x180" />
 		<link rel="icon" type="image/png" href="img/favicon-32x32.png?<?php echo rawurlencode($VERSION); ?>" sizes="32x32" />
 		<link rel="icon" type="image/png" href="img/favicon-16x16.png?<?php echo rawurlencode($VERSION); ?>" sizes="16x16" />


### PR DESCRIPTION
This PR fixes #588 - source code / plain text broken when containing HTML tags.

## Changes
* refactor switch into nested if/else, to improve readability - no functional change, but helped me understand the intent of the logic
* revert Helper.urls2links() to be applied on top of HTML elements
* this allows the insertion of strings via text nodes, which makes the browser handle the HTML entity encoding for us

Plain text and source code now render correctly.

Markdown remains unchanged and unknown and risky HTML tags will still get stripped from it - this is intended, as far as I know. In [my tests](https://snip.dssr.ch/?8560054f84df4d13#26GKC5tiNspz58dzWCh1ev7AJEDLXhpKuzorLvAcQqep) I could still insert some HTML code inside of markdown-code blocks (3 backticks) and get a seemingly correct display. Adding the same code without a code block in markdown it got stripped entirely (in the above example link, click "clone", then remove the 3 backticks and switch the "Preview" to see the effect).