### PR TITLE
Fix source code being not rendered

### DIFF
--- a/js/privatebin.js
+++ b/js/privatebin.js
@@ -18,14 +18,14 @@ jQuery.fn.draghover = function() {
     return this.each(function() {
         let collection = $(),
             self = $(this);
-  
+
         self.on('dragenter', function(e) {
             if (collection.length === 0) {
                 self.trigger('draghoverstart');
             }
             collection = collection.add(e.target);
         });
-  
+
         self.on('dragleave drop', function(e) {
             collection = collection.not(e.target);
             if (collection.length === 0) {
@@ -375,7 +375,7 @@ jQuery.PrivateBin = (function($, RawDeflate) {
         };
 
         /**
-         * formats the text that needs to be formatted, so DomPurify can properly escape it. 
+         * formats the text that needs to be formatted, so DomPurify can properly escape it.
          *
          * @name   Helper.preformatTextForDomPurify
          * @function
@@ -543,7 +543,7 @@ jQuery.PrivateBin = (function($, RawDeflate) {
 
         /**
          * calculate expiration date given initial date and expiration period
-         * 
+         *
          * @name   Helper.calculateExpirationDate
          * @function
          * @param  {Date} initialDate - may not be empty
@@ -556,7 +556,7 @@ jQuery.PrivateBin = (function($, RawDeflate) {
             if (typeof expirationDisplayStringOrSecondsToExpire === 'string') {
                 secondsToExpiration = me.durationToSeconds(expirationDisplayStringOrSecondsToExpire);
             }
-            
+
             if (typeof secondsToExpiration !== 'number') {
                 throw new Error('Cannot calculate expiration date.');
             }
@@ -2529,10 +2529,10 @@ jQuery.PrivateBin = (function($, RawDeflate) {
                 return;
             }
 
-            text = Helper.preformatTextForDomPurify(text, format);
-            
+            const processedText = Helper.preformatTextForDomPurify(text, format);
+
             // escape HTML entities, link URLs, sanitize
-            const escapedLinkedText = Helper.urls2links(text),
+            const escapedLinkedText = Helper.urls2links(processedText),
                   sanitizedLinkedText = DOMPurify.sanitize(
                     escapedLinkedText, {
                         ALLOWED_TAGS: ['a'],
@@ -3763,11 +3763,11 @@ jQuery.PrivateBin = (function($, RawDeflate) {
 
         /**
          * Template Email body.
-         * 
+         *
          * @name   TopNav.templateEmailBody
-         * @private 
-         * @param {string} expirationDateString 
-         * @param {bool} isBurnafterreading 
+         * @private
+         * @param {string} expirationDateString
+         * @param {bool} isBurnafterreading
          */
         function templateEmailBody(expirationDateString, isBurnafterreading)
         {
@@ -3805,10 +3805,10 @@ jQuery.PrivateBin = (function($, RawDeflate) {
 
         /**
          * Trigger Email send.
-         * 
+         *
          * @name   TopNav.triggerEmailSend
-         * @private 
-         * @param {string} emailBody 
+         * @private
+         * @param {string} emailBody
          */
         function triggerEmailSend(emailBody)
         {
@@ -4021,7 +4021,7 @@ jQuery.PrivateBin = (function($, RawDeflate) {
 
         /**
          * show the "email" button
-         * 
+         *
          * @name   TopNav.showEmailbutton
          * @function
          * @param {int|undefined} optionalRemainingTimeInSeconds
@@ -4049,7 +4049,7 @@ jQuery.PrivateBin = (function($, RawDeflate) {
 
         /**
          * hide the "email" button
-         * 
+         *
          * @name   TopNav.hideEmailButton
          * @function
          */
@@ -4083,7 +4083,7 @@ jQuery.PrivateBin = (function($, RawDeflate) {
 
         /**
          * only hides the qr code button
-         * 
+         *
          * @name   TopNav.hideQrCodeButton
          * @function
          */
@@ -4094,7 +4094,7 @@ jQuery.PrivateBin = (function($, RawDeflate) {
 
         /**
          * hide all irrelevant buttons when viewing burn after reading paste
-         * 
+         *
          * @name   TopNav.hideBurnAfterReadingButtons
          * @function
          */
@@ -4130,7 +4130,7 @@ jQuery.PrivateBin = (function($, RawDeflate) {
 
         /**
          * hides the custom attachment
-         * 
+         *
          * @name  TopNav.hideCustomAttachment
          * @function
          */
@@ -4254,7 +4254,7 @@ jQuery.PrivateBin = (function($, RawDeflate) {
 
         /**
          * Highlight file upload
-         * 
+         *
          * @name  TopNav.highlightFileupload
          * @function
          */
@@ -4273,7 +4273,7 @@ jQuery.PrivateBin = (function($, RawDeflate) {
 
         /**
          * set the format on bootstrap templates in dropdown programmatically
-         * 
+         *
          * @name    TopNav.setFormat
          * @function
          */
@@ -4284,7 +4284,7 @@ jQuery.PrivateBin = (function($, RawDeflate) {
 
         /**
          * returns if attachment dropdown is readonly, not editable
-         * 
+         *
          * @name   TopNav.isAttachmentReadonly
          * @function
          * @return {bool}

--- a/js/privatebin.js
+++ b/js/privatebin.js
@@ -392,7 +392,7 @@ jQuery.PrivateBin = (function($, RawDeflate) {
         me.urls2links = function(html)
         {
             return html.replace(
-                /(((https?|ftp):\/\/[\w?!=&.\/-;#@~%+*-]+(?![\w\s?!&.\/;#~%"=-]*>))|((magnet):[\w?=&.\/-;#@~%+*-]+))/ig,
+                /(((https?|ftp):\/\/[\w?!=&.\/-;#@~%+*-]+(?![\w\s?!&.\/;#~%"=-]>))|((magnet):[\w?=&.\/-;#@~%+*-]+))/ig,
                 '<a href="$1" rel="nofollow">$1</a>'
             );
         };
@@ -2504,6 +2504,14 @@ jQuery.PrivateBin = (function($, RawDeflate) {
                 return;
             }
 
+            // encode < to make sure DomPurify does not interpret e.g. HTML or XML markup as code
+            // cf. https://developer.mozilla.org/en-US/docs/Web/HTML/Element/xmp#Summary
+            // As Markdown, by definition, is/allows HTML code, we do not do anything there.
+            if (format !== 'markdown') {
+                // one character is enough, as this is not security-relevant (all output will go through DOMPurify later)
+                text = text.replace(/</g, '&lt;');
+            }
+            
             // escape HTML entities, link URLs, sanitize
             const escapedLinkedText = Helper.urls2links(text),
                   sanitizedLinkedText = DOMPurify.sanitize(

--- a/js/privatebin.js
+++ b/js/privatebin.js
@@ -2547,6 +2547,7 @@ jQuery.PrivateBin = (function($, RawDeflate) {
                             prettyPrintOne(processedText, null, true)
                         )
                     );
+                    break;
                 case 'markdown':
                     const converter = new showdown.Converter({
                         strikethrough: true,

--- a/tpl/bootstrap.php
+++ b/tpl/bootstrap.php
@@ -72,7 +72,7 @@ endif;
 ?>
 		<script type="text/javascript" data-cfasync="false" src="js/purify-2.0.8.js" integrity="sha512-x2Kev3A7fqc/QKCzRHoJ7qCiglgxXtY8WDUMPOUBI6jVueqRkRMGjP1IqD9iUWVuND81ckCCS27Br5M11tw0IA==" crossorigin="anonymous"></script>
 		<script type="text/javascript" data-cfasync="false" src="js/legacy.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-3L/E22cdC3wDFXKM1i32bw4HdrfX14du2xswUKanOY6CLrD+e0hykmLvES+zfBKF1GFQFKr3OmdCVH2y+zHlsA==" crossorigin="anonymous"></script>
-		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-5l2RuILQ59Go14jKwavtCpGEnUhzIkYyLF1ctlOaYxD5HVuBg4IAj5svkFQ4rirruhw88REZ6swax3CuLHeftg==" crossorigin="anonymous"></script>
+		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-oFz+/zZ/kgeaA2BnbXgGhb74k9E13EiyA/TXGeWRoGo/7ZK+eScOHZfw8+GRNGqDq/d5EVMXwh9OcftfjHnNmA==" crossorigin="anonymous"></script>
 		<link rel="apple-touch-icon" href="img/apple-touch-icon.png?<?php echo rawurlencode($VERSION); ?>" sizes="180x180" />
 		<link rel="icon" type="image/png" href="img/favicon-32x32.png?<?php echo rawurlencode($VERSION); ?>" sizes="32x32" />
 		<link rel="icon" type="image/png" href="img/favicon-16x16.png?<?php echo rawurlencode($VERSION); ?>" sizes="16x16" />

--- a/tpl/bootstrap.php
+++ b/tpl/bootstrap.php
@@ -41,38 +41,38 @@ if ($SYNTAXHIGHLIGHTING):
 endif;
 ?>
 		<noscript><link type="text/css" rel="stylesheet" href="css/noscript.css" /></noscript>
-		<script type="text/javascript" data-cfasync="false" src="js/jquery-3.4.1.js" integrity="sha512-bnIvzh6FU75ZKxp0GXLH9bewza/OIw6dLVh9ICg0gogclmYGguQJWl8U30WpbsGTqbIiAwxTsbe76DErLq5EDQ==" crossorigin="anonymous"></script>
+		<script type="text/javascript" data-cfasync="false" src="js/jquery-3.4.1.js" integrity="sha512-9anGruNHwVXk3XlsUXFrdEe8Iq5EdB/Otrz+4C+VWtQGPThhPyQRCKPh8+H1QPyu2NmEi5oPuCPACVXPmhnvrQ==" crossorigin="anonymous"></script>
 <?php
 if ($QRCODE):
 ?>
-		<script async type="text/javascript" data-cfasync="false" src="js/kjua-0.6.0.js" integrity="sha512-GEEIHvphDt1NmaxzX8X1ZkBiGKXCv+Ofzwi8SMEH5wQVWqdGIvBO/fnxxKZ90RU1bVp6srS68nHIpZo6iVcG9g==" crossorigin="anonymous"></script>
+		<script async type="text/javascript" data-cfasync="false" src="js/kjua-0.6.0.js" integrity="sha512-mS5pSr1OST+Q29k4J4epdY+UFR9EmQ/mm96tV4QN22NHQPaWAXuDOAEAA9RAPpmY5jY2SDz8lMHN9CPysV/Dsg==" crossorigin="anonymous"></script>
 <?php
 endif;
 if ($ZEROBINCOMPATIBILITY):
 ?>
-		<script type="text/javascript" data-cfasync="false" src="js/base64-1.7.js" integrity="sha512-JdwsSP3GyHR+jaCkns9CL9NTt4JUJqm/BsODGmYhBcj5EAPKcHYh+OiMfyHbcDLECe17TL0hjXADFkusAqiYgA==" crossorigin="anonymous"></script>
+		<script type="text/javascript" data-cfasync="false" src="js/base64-1.7.js" integrity="sha512-V6V3jxySWm/c62rSuY64hIU1/xYwaeQ+RJQyOzUMiZEMMlZXlnbif6/v/4v3Nck/cch7LylQU8lMplZUnIhSoA==" crossorigin="anonymous"></script>
 <?php
 endif;
 ?>
-		<script type="text/javascript" data-cfasync="false" src="js/zlib-1.2.11.js" integrity="sha512-Yey/0yoaVmSbqMEyyff3DIu8kCPwpHvHf7tY1AuZ1lrX9NPCMg87PwzngMi+VNbe4ilCApmePeuKT869RTcyCQ==" crossorigin="anonymous"></script>
-		<script type="text/javascript" data-cfasync="false" src="js/base-x-3.0.7.js" integrity="sha512-/Bi1AJIP0TtxEB+Jh6Hk809H1G7vn4iJV80qagslf0+Hm0UjUi1s3qNrn1kZULjzUYuaf6ck0ndLGJ7MxWLmgQ==" crossorigin="anonymous"></script>
-		<script type="text/javascript" data-cfasync="false" src="js/rawinflate-0.3.js" integrity="sha512-g8uelGgJW9A/Z1tB6Izxab++oj5kdD7B4qC7DHwZkB6DGMXKyzx7v5mvap2HXueI2IIn08YlRYM56jwWdm2ucQ==" crossorigin="anonymous"></script>
-		<script type="text/javascript" data-cfasync="false" src="js/bootstrap-3.3.7.js" integrity="sha512-iztkobsvnjKfAtTNdHkGVjAYTrrtlC7mGp/54c40wowO7LhURYl3gVzzcEqGl/qKXQltJ2HwMrdLcNUdo+N/RQ==" crossorigin="anonymous"></script>
+		<script type="text/javascript" data-cfasync="false" src="js/zlib-1.2.11.js" integrity="sha512-ltQiYRTMNyL8c4rObU3wsq1IY9qXWlw3ev19xbLZywKhzLy9Ys3QWkUfbokF8V1yZPGdfFqCPLGpbj+D4NhtDA==" crossorigin="anonymous"></script>
+		<script type="text/javascript" data-cfasync="false" src="js/base-x-3.0.7.js" integrity="sha512-1PEa62gwxcuweDJX3y/hE5hqV1WwUcKWdXnCPVBPu2J0QoONNH90gJSfKqdQCnsJhjMGNUWH6/UFQs1D3ufczQ==" crossorigin="anonymous"></script>
+		<script type="text/javascript" data-cfasync="false" src="js/rawinflate-0.3.js" integrity="sha512-oC3qyjPVFoECDz+NY8EWEweqMF9Aobh+bxwfQsWTO+75CzsvHkZUZHiFI1iWPnCymurCZ8N1IRiA1lQstakAjw==" crossorigin="anonymous"></script>
+		<script type="text/javascript" data-cfasync="false" src="js/bootstrap-3.3.7.js" integrity="sha512-4nvga8iY3PiT8GzEnK/LtrpuOmkQaomlAPaZPldgCzY2OSeEgRI3oaeDln2+BdV6B2nHj4B0oMOlmxa2VbHTUA==" crossorigin="anonymous"></script>
 <?php
 if ($SYNTAXHIGHLIGHTING):
 ?>
-		<script type="text/javascript" data-cfasync="false" src="js/prettify.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-puO0Ogy++IoA2Pb9IjSxV1n4+kQkKXYAEUtVzfZpQepyDPyXk8hokiYDS7ybMogYlyyEIwMLpZqVhCkARQWLMg==" crossorigin="anonymous"></script>
+		<script type="text/javascript" data-cfasync="false" src="js/prettify.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-8Yo8AyWGdIAIogswah43R44ykWSTkNhgYaR4fsn49WSIsZ6GQF8HgO5ZbomYG7N459Rd2Ycl+JZTmJWovIy5TA==" crossorigin="anonymous"></script>
 <?php
 endif;
 if ($MARKDOWN):
 ?>
-		<script type="text/javascript" data-cfasync="false" src="js/showdown-1.9.1.js" integrity="sha512-nRri7kqh3iRLdHbhtjfe8w9eAQPmt+ubH5U88UZyKbz6O9Q0q4haaXF0krOUclKmRJou/kKZYulgBHvHXPqOvg==" crossorigin="anonymous"></script>
+		<script type="text/javascript" data-cfasync="false" src="js/showdown-1.9.1.js" integrity="sha512-XaY4Yp8taiarnpsT49pd5AWWq9BfheHGV7MTt7ER2N5/rcq3v2DK7lbhdAhMic9eCoOD1cnBIgMCcV85ew4OSA==" crossorigin="anonymous"></script>
 <?php
 endif;
 ?>
-		<script type="text/javascript" data-cfasync="false" src="js/purify-2.0.8.js" integrity="sha512-QwcEKGuEmKtMguCO9pqNtUtZqq9b/tJ8gNr5qhY8hykq3zKTlDOvpZAmf6Rs8yH35Bz1ZdctUjj2qEWxT5aXCg==" crossorigin="anonymous"></script>
-		<script type="text/javascript" data-cfasync="false" src="js/legacy.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-LYos+qXHIRqFf5ZPNphvtTB0cgzHUizu2wwcOwcwz/VIpRv9lpcBgPYz4uq6jx0INwCAj6Fbnl5HoKiLufS2jg==" crossorigin="anonymous"></script>
-		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-5GFThJ8KstWT1bNvB5JTAAXA+5QCNDv21foF7hSNoAc0oOxrHiUCP1ZlZs9zk4SbdIsmTSGL12Ecdj5CRISYxg==" crossorigin="anonymous"></script>
+		<script type="text/javascript" data-cfasync="false" src="js/purify-2.0.8.js" integrity="sha512-x2Kev3A7fqc/QKCzRHoJ7qCiglgxXtY8WDUMPOUBI6jVueqRkRMGjP1IqD9iUWVuND81ckCCS27Br5M11tw0IA==" crossorigin="anonymous"></script>
+		<script type="text/javascript" data-cfasync="false" src="js/legacy.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-3L/E22cdC3wDFXKM1i32bw4HdrfX14du2xswUKanOY6CLrD+e0hykmLvES+zfBKF1GFQFKr3OmdCVH2y+zHlsA==" crossorigin="anonymous"></script>
+		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-0Gt+x+QenVjex80M6AXnrJIOqVV19nV+s8P9T9K68+vyvFGW/Fx34viKK8zzu1ME2GYctsJlNB4I1x75P095ZQ==" crossorigin="anonymous"></script>
 		<link rel="apple-touch-icon" href="img/apple-touch-icon.png?<?php echo rawurlencode($VERSION); ?>" sizes="180x180" />
 		<link rel="icon" type="image/png" href="img/favicon-32x32.png?<?php echo rawurlencode($VERSION); ?>" sizes="32x32" />
 		<link rel="icon" type="image/png" href="img/favicon-16x16.png?<?php echo rawurlencode($VERSION); ?>" sizes="16x16" />

--- a/tpl/bootstrap.php
+++ b/tpl/bootstrap.php
@@ -72,7 +72,7 @@ endif;
 ?>
 		<script type="text/javascript" data-cfasync="false" src="js/purify-2.0.8.js" integrity="sha512-x2Kev3A7fqc/QKCzRHoJ7qCiglgxXtY8WDUMPOUBI6jVueqRkRMGjP1IqD9iUWVuND81ckCCS27Br5M11tw0IA==" crossorigin="anonymous"></script>
 		<script type="text/javascript" data-cfasync="false" src="js/legacy.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-3L/E22cdC3wDFXKM1i32bw4HdrfX14du2xswUKanOY6CLrD+e0hykmLvES+zfBKF1GFQFKr3OmdCVH2y+zHlsA==" crossorigin="anonymous"></script>
-		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-oFz+/zZ/kgeaA2BnbXgGhb74k9E13EiyA/TXGeWRoGo/7ZK+eScOHZfw8+GRNGqDq/d5EVMXwh9OcftfjHnNmA==" crossorigin="anonymous"></script>
+		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-orzZ0Xa2whu2x2rgs9pUPD3cbbw2kMK9GeCIQPC50/H66tgobl3LjsGNREI6s0porBoJ+Wp6icp+Z1FqyQ/bxA==" crossorigin="anonymous"></script>
 		<link rel="apple-touch-icon" href="img/apple-touch-icon.png?<?php echo rawurlencode($VERSION); ?>" sizes="180x180" />
 		<link rel="icon" type="image/png" href="img/favicon-32x32.png?<?php echo rawurlencode($VERSION); ?>" sizes="32x32" />
 		<link rel="icon" type="image/png" href="img/favicon-16x16.png?<?php echo rawurlencode($VERSION); ?>" sizes="16x16" />

--- a/tpl/bootstrap.php
+++ b/tpl/bootstrap.php
@@ -72,7 +72,7 @@ endif;
 ?>
 		<script type="text/javascript" data-cfasync="false" src="js/purify-2.0.8.js" integrity="sha512-x2Kev3A7fqc/QKCzRHoJ7qCiglgxXtY8WDUMPOUBI6jVueqRkRMGjP1IqD9iUWVuND81ckCCS27Br5M11tw0IA==" crossorigin="anonymous"></script>
 		<script type="text/javascript" data-cfasync="false" src="js/legacy.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-3L/E22cdC3wDFXKM1i32bw4HdrfX14du2xswUKanOY6CLrD+e0hykmLvES+zfBKF1GFQFKr3OmdCVH2y+zHlsA==" crossorigin="anonymous"></script>
-		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-0Gt+x+QenVjex80M6AXnrJIOqVV19nV+s8P9T9K68+vyvFGW/Fx34viKK8zzu1ME2GYctsJlNB4I1x75P095ZQ==" crossorigin="anonymous"></script>
+		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-5l2RuILQ59Go14jKwavtCpGEnUhzIkYyLF1ctlOaYxD5HVuBg4IAj5svkFQ4rirruhw88REZ6swax3CuLHeftg==" crossorigin="anonymous"></script>
 		<link rel="apple-touch-icon" href="img/apple-touch-icon.png?<?php echo rawurlencode($VERSION); ?>" sizes="180x180" />
 		<link rel="icon" type="image/png" href="img/favicon-32x32.png?<?php echo rawurlencode($VERSION); ?>" sizes="32x32" />
 		<link rel="icon" type="image/png" href="img/favicon-16x16.png?<?php echo rawurlencode($VERSION); ?>" sizes="16x16" />

--- a/tpl/page.php
+++ b/tpl/page.php
@@ -50,7 +50,7 @@ endif;
 ?>
 		<script type="text/javascript" data-cfasync="false" src="js/purify-2.0.8.js" integrity="sha512-x2Kev3A7fqc/QKCzRHoJ7qCiglgxXtY8WDUMPOUBI6jVueqRkRMGjP1IqD9iUWVuND81ckCCS27Br5M11tw0IA==" crossorigin="anonymous"></script>
 		<script type="text/javascript" data-cfasync="false" src="js/legacy.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-3L/E22cdC3wDFXKM1i32bw4HdrfX14du2xswUKanOY6CLrD+e0hykmLvES+zfBKF1GFQFKr3OmdCVH2y+zHlsA==" crossorigin="anonymous"></script>
-		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-0Gt+x+QenVjex80M6AXnrJIOqVV19nV+s8P9T9K68+vyvFGW/Fx34viKK8zzu1ME2GYctsJlNB4I1x75P095ZQ==" crossorigin="anonymous"></script>
+		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-5l2RuILQ59Go14jKwavtCpGEnUhzIkYyLF1ctlOaYxD5HVuBg4IAj5svkFQ4rirruhw88REZ6swax3CuLHeftg==" crossorigin="anonymous"></script>
 		<link rel="apple-touch-icon" href="img/apple-touch-icon.png?<?php echo rawurlencode($VERSION); ?>" sizes="180x180" />
 		<link rel="icon" type="image/png" href="img/favicon-32x32.png?<?php echo rawurlencode($VERSION); ?>" sizes="32x32" />
 		<link rel="icon" type="image/png" href="img/favicon-16x16.png?<?php echo rawurlencode($VERSION); ?>" sizes="16x16" />

--- a/tpl/page.php
+++ b/tpl/page.php
@@ -50,7 +50,7 @@ endif;
 ?>
 		<script type="text/javascript" data-cfasync="false" src="js/purify-2.0.8.js" integrity="sha512-x2Kev3A7fqc/QKCzRHoJ7qCiglgxXtY8WDUMPOUBI6jVueqRkRMGjP1IqD9iUWVuND81ckCCS27Br5M11tw0IA==" crossorigin="anonymous"></script>
 		<script type="text/javascript" data-cfasync="false" src="js/legacy.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-3L/E22cdC3wDFXKM1i32bw4HdrfX14du2xswUKanOY6CLrD+e0hykmLvES+zfBKF1GFQFKr3OmdCVH2y+zHlsA==" crossorigin="anonymous"></script>
-		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-5l2RuILQ59Go14jKwavtCpGEnUhzIkYyLF1ctlOaYxD5HVuBg4IAj5svkFQ4rirruhw88REZ6swax3CuLHeftg==" crossorigin="anonymous"></script>
+		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-oFz+/zZ/kgeaA2BnbXgGhb74k9E13EiyA/TXGeWRoGo/7ZK+eScOHZfw8+GRNGqDq/d5EVMXwh9OcftfjHnNmA==" crossorigin="anonymous"></script>
 		<link rel="apple-touch-icon" href="img/apple-touch-icon.png?<?php echo rawurlencode($VERSION); ?>" sizes="180x180" />
 		<link rel="icon" type="image/png" href="img/favicon-32x32.png?<?php echo rawurlencode($VERSION); ?>" sizes="32x32" />
 		<link rel="icon" type="image/png" href="img/favicon-16x16.png?<?php echo rawurlencode($VERSION); ?>" sizes="16x16" />

--- a/tpl/page.php
+++ b/tpl/page.php
@@ -20,37 +20,37 @@ if ($SYNTAXHIGHLIGHTING):
     endif;
 endif;
 ?>
-		<script type="text/javascript" data-cfasync="false" src="js/jquery-3.4.1.js" integrity="sha512-bnIvzh6FU75ZKxp0GXLH9bewza/OIw6dLVh9ICg0gogclmYGguQJWl8U30WpbsGTqbIiAwxTsbe76DErLq5EDQ==" crossorigin="anonymous"></script>
+		<script type="text/javascript" data-cfasync="false" src="js/jquery-3.4.1.js" integrity="sha512-9anGruNHwVXk3XlsUXFrdEe8Iq5EdB/Otrz+4C+VWtQGPThhPyQRCKPh8+H1QPyu2NmEi5oPuCPACVXPmhnvrQ==" crossorigin="anonymous"></script>
 <?php
 if ($QRCODE):
 ?>
-		<script async type="text/javascript" data-cfasync="false" src="js/kjua-0.6.0.js" integrity="sha512-GEEIHvphDt1NmaxzX8X1ZkBiGKXCv+Ofzwi8SMEH5wQVWqdGIvBO/fnxxKZ90RU1bVp6srS68nHIpZo6iVcG9g==" crossorigin="anonymous"></script>
+		<script async type="text/javascript" data-cfasync="false" src="js/kjua-0.6.0.js" integrity="sha512-mS5pSr1OST+Q29k4J4epdY+UFR9EmQ/mm96tV4QN22NHQPaWAXuDOAEAA9RAPpmY5jY2SDz8lMHN9CPysV/Dsg==" crossorigin="anonymous"></script>
 <?php
 endif;
 if ($ZEROBINCOMPATIBILITY):
 ?>
-		<script type="text/javascript" data-cfasync="false" src="js/base64-1.7.js" integrity="sha512-JdwsSP3GyHR+jaCkns9CL9NTt4JUJqm/BsODGmYhBcj5EAPKcHYh+OiMfyHbcDLECe17TL0hjXADFkusAqiYgA==" crossorigin="anonymous"></script>
+		<script type="text/javascript" data-cfasync="false" src="js/base64-1.7.js" integrity="sha512-V6V3jxySWm/c62rSuY64hIU1/xYwaeQ+RJQyOzUMiZEMMlZXlnbif6/v/4v3Nck/cch7LylQU8lMplZUnIhSoA==" crossorigin="anonymous"></script>
 <?php
 endif;
 ?>
-		<script type="text/javascript" data-cfasync="false" src="js/zlib-1.2.11.js" integrity="sha512-Yey/0yoaVmSbqMEyyff3DIu8kCPwpHvHf7tY1AuZ1lrX9NPCMg87PwzngMi+VNbe4ilCApmePeuKT869RTcyCQ==" crossorigin="anonymous"></script>
-		<script type="text/javascript" data-cfasync="false" src="js/base-x-3.0.7.js" integrity="sha512-/Bi1AJIP0TtxEB+Jh6Hk809H1G7vn4iJV80qagslf0+Hm0UjUi1s3qNrn1kZULjzUYuaf6ck0ndLGJ7MxWLmgQ==" crossorigin="anonymous"></script>
-		<script type="text/javascript" data-cfasync="false" src="js/rawinflate-0.3.js" integrity="sha512-g8uelGgJW9A/Z1tB6Izxab++oj5kdD7B4qC7DHwZkB6DGMXKyzx7v5mvap2HXueI2IIn08YlRYM56jwWdm2ucQ==" crossorigin="anonymous"></script>
+		<script type="text/javascript" data-cfasync="false" src="js/zlib-1.2.11.js" integrity="sha512-ltQiYRTMNyL8c4rObU3wsq1IY9qXWlw3ev19xbLZywKhzLy9Ys3QWkUfbokF8V1yZPGdfFqCPLGpbj+D4NhtDA==" crossorigin="anonymous"></script>
+		<script type="text/javascript" data-cfasync="false" src="js/base-x-3.0.7.js" integrity="sha512-1PEa62gwxcuweDJX3y/hE5hqV1WwUcKWdXnCPVBPu2J0QoONNH90gJSfKqdQCnsJhjMGNUWH6/UFQs1D3ufczQ==" crossorigin="anonymous"></script>
+		<script type="text/javascript" data-cfasync="false" src="js/rawinflate-0.3.js" integrity="sha512-oC3qyjPVFoECDz+NY8EWEweqMF9Aobh+bxwfQsWTO+75CzsvHkZUZHiFI1iWPnCymurCZ8N1IRiA1lQstakAjw==" crossorigin="anonymous"></script>
 <?php
 if ($SYNTAXHIGHLIGHTING):
 ?>
-		<script type="text/javascript" data-cfasync="false" src="js/prettify.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-puO0Ogy++IoA2Pb9IjSxV1n4+kQkKXYAEUtVzfZpQepyDPyXk8hokiYDS7ybMogYlyyEIwMLpZqVhCkARQWLMg==" crossorigin="anonymous"></script>
+		<script type="text/javascript" data-cfasync="false" src="js/prettify.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-8Yo8AyWGdIAIogswah43R44ykWSTkNhgYaR4fsn49WSIsZ6GQF8HgO5ZbomYG7N459Rd2Ycl+JZTmJWovIy5TA==" crossorigin="anonymous"></script>
 <?php
 endif;
 if ($MARKDOWN):
 ?>
-		<script type="text/javascript" data-cfasync="false" src="js/showdown-1.9.1.js" integrity="sha512-nRri7kqh3iRLdHbhtjfe8w9eAQPmt+ubH5U88UZyKbz6O9Q0q4haaXF0krOUclKmRJou/kKZYulgBHvHXPqOvg==" crossorigin="anonymous"></script>
+		<script type="text/javascript" data-cfasync="false" src="js/showdown-1.9.1.js" integrity="sha512-XaY4Yp8taiarnpsT49pd5AWWq9BfheHGV7MTt7ER2N5/rcq3v2DK7lbhdAhMic9eCoOD1cnBIgMCcV85ew4OSA==" crossorigin="anonymous"></script>
 <?php
 endif;
 ?>
-		<script type="text/javascript" data-cfasync="false" src="js/purify-2.0.8.js" integrity="sha512-QwcEKGuEmKtMguCO9pqNtUtZqq9b/tJ8gNr5qhY8hykq3zKTlDOvpZAmf6Rs8yH35Bz1ZdctUjj2qEWxT5aXCg==" crossorigin="anonymous"></script>
-		<script type="text/javascript" data-cfasync="false" src="js/legacy.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-LYos+qXHIRqFf5ZPNphvtTB0cgzHUizu2wwcOwcwz/VIpRv9lpcBgPYz4uq6jx0INwCAj6Fbnl5HoKiLufS2jg==" crossorigin="anonymous"></script>
-		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-5GFThJ8KstWT1bNvB5JTAAXA+5QCNDv21foF7hSNoAc0oOxrHiUCP1ZlZs9zk4SbdIsmTSGL12Ecdj5CRISYxg==" crossorigin="anonymous"></script>
+		<script type="text/javascript" data-cfasync="false" src="js/purify-2.0.8.js" integrity="sha512-x2Kev3A7fqc/QKCzRHoJ7qCiglgxXtY8WDUMPOUBI6jVueqRkRMGjP1IqD9iUWVuND81ckCCS27Br5M11tw0IA==" crossorigin="anonymous"></script>
+		<script type="text/javascript" data-cfasync="false" src="js/legacy.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-3L/E22cdC3wDFXKM1i32bw4HdrfX14du2xswUKanOY6CLrD+e0hykmLvES+zfBKF1GFQFKr3OmdCVH2y+zHlsA==" crossorigin="anonymous"></script>
+		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-0Gt+x+QenVjex80M6AXnrJIOqVV19nV+s8P9T9K68+vyvFGW/Fx34viKK8zzu1ME2GYctsJlNB4I1x75P095ZQ==" crossorigin="anonymous"></script>
 		<link rel="apple-touch-icon" href="img/apple-touch-icon.png?<?php echo rawurlencode($VERSION); ?>" sizes="180x180" />
 		<link rel="icon" type="image/png" href="img/favicon-32x32.png?<?php echo rawurlencode($VERSION); ?>" sizes="32x32" />
 		<link rel="icon" type="image/png" href="img/favicon-16x16.png?<?php echo rawurlencode($VERSION); ?>" sizes="16x16" />

--- a/tpl/page.php
+++ b/tpl/page.php
@@ -50,7 +50,7 @@ endif;
 ?>
 		<script type="text/javascript" data-cfasync="false" src="js/purify-2.0.8.js" integrity="sha512-x2Kev3A7fqc/QKCzRHoJ7qCiglgxXtY8WDUMPOUBI6jVueqRkRMGjP1IqD9iUWVuND81ckCCS27Br5M11tw0IA==" crossorigin="anonymous"></script>
 		<script type="text/javascript" data-cfasync="false" src="js/legacy.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-3L/E22cdC3wDFXKM1i32bw4HdrfX14du2xswUKanOY6CLrD+e0hykmLvES+zfBKF1GFQFKr3OmdCVH2y+zHlsA==" crossorigin="anonymous"></script>
-		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-oFz+/zZ/kgeaA2BnbXgGhb74k9E13EiyA/TXGeWRoGo/7ZK+eScOHZfw8+GRNGqDq/d5EVMXwh9OcftfjHnNmA==" crossorigin="anonymous"></script>
+		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-orzZ0Xa2whu2x2rgs9pUPD3cbbw2kMK9GeCIQPC50/H66tgobl3LjsGNREI6s0porBoJ+Wp6icp+Z1FqyQ/bxA==" crossorigin="anonymous"></script>
 		<link rel="apple-touch-icon" href="img/apple-touch-icon.png?<?php echo rawurlencode($VERSION); ?>" sizes="180x180" />
 		<link rel="icon" type="image/png" href="img/favicon-32x32.png?<?php echo rawurlencode($VERSION); ?>" sizes="32x32" />
 		<link rel="icon" type="image/png" href="img/favicon-16x16.png?<?php echo rawurlencode($VERSION); ?>" sizes="16x16" />


### PR DESCRIPTION
If special characters were included the source code (HTML-like ones like < and >) is was not rendered.

Fixes https://github.com/PrivateBin/PrivateBin/issues/588

It includes a change in the RegEx for URLs because that was broken when a
& character later followed at any time after a link (even after a newline).
(with a negative lookahead)

Test with https://regex101.com/r/i7bZ73/1

Now the RegEx does not check for _all_ chars after a link, but just for the
one following the link.
(So the lookahead is not * anymore. I guess thisbehaviour was
the expectation when it has been implemented.)

Supersedes https://github.com/PrivateBin/PrivateBin/pull/589/
This is just way simpler and does less "magic".

It encodes the one bad char that may make DomPurify think it is HTML, so DomPurify knows, it is not.

 ### tests

I did use this code to check whether it renders correctly:
````
<?php

```
<?php
```

https://test.de

### headline

</code>
````

![grafik](https://user-images.githubusercontent.com/11966684/75872496-8c065600-5e0e-11ea-8e75-27ab7b3ea0ef.png)

It even works in the prettified source code view (which is not really neccessary IMHO).
![grafik](https://user-images.githubusercontent.com/11966684/75872707-f1f2dd80-5e0e-11ea-8561-a2479ee24d06.png)
