### PR TITLE
Add whitelist capability

### DIFF
--- a/cfg/conf.sample.php
+++ b/cfg/conf.sample.php
@@ -127,6 +127,10 @@ markdown = "Markdown"
 ; Set this to 0 to disable rate limiting.
 limit = 10
 
+; (optional) if you only want some source IP addresses to create pastes
+; enter their IPv4 address(es) here, separated by commas
+; whitelist = "12.34.56.78,99.88.77.66"
+
 ; (optional) if your website runs behind a reverse proxy or load balancer,
 ; set the HTTP header containing the visitors IP address, i.e. X_FORWARDED_FOR
 ; header = "X_FORWARDED_FOR"

--- a/cfg/conf.sample.php
+++ b/cfg/conf.sample.php
@@ -129,7 +129,7 @@ limit = 10
 
 ; (optional) if you only want some source IP addresses to create pastes
 ; enter their IPv4 address(es) here, separated by commas
-; whitelist = "12.34.56.78,99.88.77.66"
+; whitelist_paste_creation = "12.34.56.78,99.88.77.66"
 
 ; (optional) if your website runs behind a reverse proxy or load balancer,
 ; set the HTTP header containing the visitors IP address, i.e. X_FORWARDED_FOR

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -78,6 +78,7 @@ class Configuration
         ),
         'traffic' => array(
             'limit'  => 10,
+            'whitelist' => null,
             'header' => null,
             'dir'    => 'data',
         ),

--- a/lib/Controller.php
+++ b/lib/Controller.php
@@ -196,6 +196,19 @@ class Controller
      */
     private function _create()
     {
+        // Check whitelist if allowed to create
+        $whitelist = explode(',', $this->_conf->getKey('whitelist', 'traffic'));
+        if (($option = $this->_conf->getKey('header', 'traffic')) !== null) {
+            $httpHeader = 'HTTP_' . $option;
+            if (array_key_exists($httpHeader, $_SERVER) && !empty($_SERVER[$httpHeader])) {
+                $remoteip = $_SERVER[$httpHeader];
+            }
+        }
+        if( !in_array($remoteip, $whitelist) ) {
+            $this->_return_message(1, I18n::_('Your IP is not authorized'));
+            return;
+        }
+        
         // Ensure last paste from visitors IP address was more than configured amount of seconds ago.
         TrafficLimiter::setConfiguration($this->_conf);
         if (!TrafficLimiter::canPass()) {

--- a/lib/Controller.php
+++ b/lib/Controller.php
@@ -205,7 +205,7 @@ class Controller
             }
         }
         if( !in_array($remoteip, $whitelist) ) {
-            $this->_return_message(1, I18n::_('Your IP is not authorized'));
+            $this->_return_message(1, I18n::_('Your IP is not authorized to create pastes.'));
             return;
         }
         

--- a/lib/Controller.php
+++ b/lib/Controller.php
@@ -204,7 +204,7 @@ class Controller
                 $remoteip = $_SERVER[$httpHeader];
             }
         }
-        if( !in_array($remoteip, $whitelist) ) {
+        if(!in_array($remoteip, $whitelist)) {
             $this->_return_message(1, I18n::_('Your IP is not authorized to create pastes.'));
             return;
         }


### PR DESCRIPTION
This PR adds a whitelist functionality such that you want only certain source IP addresses to be able to create pastes (but allow everyone to read pastes).

It's been years since I contributed to open source so I'm certain I've violated some coding standard. But it does work on my local install so I'd love some feedback.