### PR TITLE
Make Opengraph really functional

### DIFF
--- a/cfg/conf.sample.php
+++ b/cfg/conf.sample.php
@@ -9,7 +9,7 @@
 
 ; The full URL, with the domain name and directories that point to the PrivateBin files
 ; This URL is essential to allow Opengraph images to be displayed on social networks
-; path = ""
+; basepath = ""
 
 ; enable or disable the discussion feature, defaults to true
 discussion = true

--- a/cfg/conf.sample.php
+++ b/cfg/conf.sample.php
@@ -7,6 +7,10 @@
 ; (optional) set a project name to be displayed on the website
 ; name = "PrivateBin"
 
+; The full URL, with the domain name and directories that point to the PrivateBin files
+; This URL is essential to allow Opengraph images to be displayed on social networks
+; path = ""
+
 ; enable or disable the discussion feature, defaults to true
 discussion = true
 

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -38,7 +38,7 @@ class Configuration
     private static $_defaults = array(
         'main' => array(
             'name'                     => 'PrivateBin',
-            'path'                     => '',
+            'basepath'                     => '',
             'discussion'               => true,
             'opendiscussion'           => false,
             'password'                 => true,

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -38,6 +38,7 @@ class Configuration
     private static $_defaults = array(
         'main' => array(
             'name'                     => 'PrivateBin',
+            'path'                     => '',
             'discussion'               => true,
             'opendiscussion'           => false,
             'password'                 => true,

--- a/lib/Controller.php
+++ b/lib/Controller.php
@@ -369,7 +369,7 @@ class Controller
 
         $page = new View;
         $page->assign('NAME', $this->_conf->getKey('name'));
-        $page->assign('PATH', I18n::_($this->_conf->getKey('path')));
+        $page->assign('BASEPATH', I18n::_($this->_conf->getKey('basepath')));
         $page->assign('ERROR', I18n::_($this->_error));
         $page->assign('STATUS', I18n::_($this->_status));
         $page->assign('VERSION', self::VERSION);

--- a/lib/Controller.php
+++ b/lib/Controller.php
@@ -369,6 +369,7 @@ class Controller
 
         $page = new View;
         $page->assign('NAME', $this->_conf->getKey('name'));
+        $page->assign('PATH', I18n::_($this->_conf->getKey('path')));
         $page->assign('ERROR', I18n::_($this->_error));
         $page->assign('STATUS', I18n::_($this->_status));
         $page->assign('VERSION', self::VERSION);

--- a/tpl/bootstrap.php
+++ b/tpl/bootstrap.php
@@ -74,7 +74,7 @@ endif;
 		<script type="text/javascript" data-cfasync="false" src="js/legacy.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-LYos+qXHIRqFf5ZPNphvtTB0cgzHUizu2wwcOwcwz/VIpRv9lpcBgPYz4uq6jx0INwCAj6Fbnl5HoKiLufS2jg==" crossorigin="anonymous"></script>
 		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-GCiSgkYlcyJq3SOMOAh52rIlUAoGH8yDJzOm/NkzBorbk2qiBSjc289/RxpeZJcdu36fQObFTzLvz4Do/2LFsA==" crossorigin="anonymous"></script>
 		<!-- icon -->
-		<link rel="apple-touch-icon" href="<?php echo I18n::encode($PATH); ?>img/apple-touch-icon.png" sizes="180x180" />
+		<link rel="apple-touch-icon" href="<?php echo I18n::encode($BASEPATH); ?>img/apple-touch-icon.png" sizes="180x180" />
 		<link rel="icon" type="image/png" href="img/favicon-32x32.png" sizes="32x32" />
 		<link rel="icon" type="image/png" href="img/favicon-16x16.png" sizes="16x16" />
 		<link rel="manifest" href="manifest.json?<?php echo rawurlencode($VERSION); ?>" />
@@ -86,11 +86,11 @@ endif;
 		<meta name="twitter:card" content="summary" />
 		<meta name="twitter:title" content="<?php echo I18n::_('Encrypted note on PrivateBin') ?>" />
 		<meta name="twitter:description" content="<?php echo I18n::_('Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.') ?>" />
-		<meta name="twitter:image" content="<?php echo I18n::encode($PATH); ?>img/apple-touch-icon.png" />
+		<meta name="twitter:image" content="<?php echo I18n::encode($BASEPATH); ?>img/apple-touch-icon.png" />
 		<meta property="og:title" content="<?php echo I18n::_($NAME); ?>" />
 		<meta property="og:site_name" content="<?php echo I18n::_($NAME); ?>" />
 		<meta property="og:description" content="<?php echo I18n::_('Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.') ?>" />
-		<meta property="og:image" content="<?php echo I18n::encode($PATH); ?>img/apple-touch-icon.png" />
+		<meta property="og:image" content="<?php echo I18n::encode($BASEPATH); ?>img/apple-touch-icon.png" />
 		<meta property="og:image:type" content="image/png" />
 		<meta property="og:image:width" content="180" />
 		<meta property="og:image:height" content="180" />

--- a/tpl/bootstrap.php
+++ b/tpl/bootstrap.php
@@ -74,11 +74,11 @@ endif;
 		<script type="text/javascript" data-cfasync="false" src="js/legacy.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-LYos+qXHIRqFf5ZPNphvtTB0cgzHUizu2wwcOwcwz/VIpRv9lpcBgPYz4uq6jx0INwCAj6Fbnl5HoKiLufS2jg==" crossorigin="anonymous"></script>
 		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-GCiSgkYlcyJq3SOMOAh52rIlUAoGH8yDJzOm/NkzBorbk2qiBSjc289/RxpeZJcdu36fQObFTzLvz4Do/2LFsA==" crossorigin="anonymous"></script>
 		<!-- icon -->
-		<link rel="apple-touch-icon" href="img/apple-touch-icon.png?<?php echo rawurlencode($VERSION); ?>" sizes="180x180" />
-		<link rel="icon" type="image/png" href="img/favicon-32x32.png?<?php echo rawurlencode($VERSION); ?>" sizes="32x32" />
-		<link rel="icon" type="image/png" href="img/favicon-16x16.png?<?php echo rawurlencode($VERSION); ?>" sizes="16x16" />
+		<link rel="apple-touch-icon" href="<?php echo I18n::encode($PATH); ?>img/apple-touch-icon.png" sizes="180x180" />
+		<link rel="icon" type="image/png" href="img/favicon-32x32.png" sizes="32x32" />
+		<link rel="icon" type="image/png" href="img/favicon-16x16.png" sizes="16x16" />
 		<link rel="manifest" href="manifest.json?<?php echo rawurlencode($VERSION); ?>" />
-		<link rel="mask-icon" href="img/safari-pinned-tab.svg?<?php echo rawurlencode($VERSION); ?>" color="#ffcc00" />
+		<link rel="mask-icon" href="img/safari-pinned-tab.svg" color="#ffcc00" />
 		<link rel="shortcut icon" href="img/favicon.ico">
 		<meta name="msapplication-config" content="browserconfig.xml">
 		<meta name="theme-color" content="#ffe57e" />
@@ -86,11 +86,11 @@ endif;
 		<meta name="twitter:card" content="summary" />
 		<meta name="twitter:title" content="<?php echo I18n::_('Encrypted note on PrivateBin') ?>" />
 		<meta name="twitter:description" content="<?php echo I18n::_('Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.') ?>" />
-		<meta name="twitter:image" content="img/apple-touch-icon.png?<?php echo rawurlencode($VERSION); ?>" />
+		<meta name="twitter:image" content="<?php echo I18n::encode($PATH); ?>img/apple-touch-icon.png" />
 		<meta property="og:title" content="<?php echo I18n::_($NAME); ?>" />
 		<meta property="og:site_name" content="<?php echo I18n::_($NAME); ?>" />
 		<meta property="og:description" content="<?php echo I18n::_('Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.') ?>" />
-		<meta property="og:image" content="img/apple-touch-icon.png?<?php echo rawurlencode($VERSION); ?>" />
+		<meta property="og:image" content="<?php echo I18n::encode($PATH); ?>img/apple-touch-icon.png" />
 		<meta property="og:image:type" content="image/png" />
 		<meta property="og:image:width" content="180" />
 		<meta property="og:image:height" content="180" />

--- a/tst/ViewTest.php
+++ b/tst/ViewTest.php
@@ -34,6 +34,7 @@ class ViewTest extends PHPUnit_Framework_TestCase
         /* Setup Routine */
         $page = new View;
         $page->assign('NAME', 'PrivateBinTest');
+        $page->assign('BASEPATH', false);
         $page->assign('ERROR', self::$error);
         $page->assign('STATUS', self::$status);
         $page->assign('VERSION', self::$version);


### PR DESCRIPTION
3 URLs of images used on social networks are passed in absolute URL.

Note that I did not pass all the images in absolute URLs, but, it could be consistent to do so, but, if the images work, maybe a relative call is more efficient?

Remove the version of PrivateBin, at the end of each image. This apparently prevents the opengraph from working, and, so I deleted on all of the images, to remain consistent at this level. This will make fewer requests, and, anyway, the images are not intended to change with each version.