### PR TITLE
<i> markups included in translation messages are misinterpreted

### DIFF
--- a/lib/I18n.php
+++ b/lib/I18n.php
@@ -129,7 +129,7 @@ class I18n
         $argsCount = count($args);
         if ($argsCount > 1) {
             for ($i = 0; $i < $argsCount; ++$i) {
-                if (($i > 0 && !is_int($args[$i])) || strpos($args[0], '<a') === false) {
+                if (($i > 0 && !is_int($args[$i]))) {
                     $args[$i] = self::encode($args[$i]);
                 }
             }
@@ -147,7 +147,36 @@ class I18n
      */
     public static function encode($string)
     {
-        return htmlspecialchars($string, ENT_QUOTES | ENT_HTML5 | ENT_DISALLOWED, 'UTF-8', false);
+        $safeEncoded = htmlspecialchars($string, ENT_QUOTES | ENT_HTML5 | ENT_DISALLOWED, 'UTF-8', false);
+        return self::reactiveAuthorizedMarkup($safeEncoded);
+    }
+
+    /**
+     * reactive only some HTML markups
+     *
+     * @access private
+     * @static
+     * @param  string $encoded
+     * @return string
+     */
+    function reactiveAuthorizedMarkup($encoded)
+    {
+        $replacementRegexpMap = array(
+            '#&lt;i&gt;(.*)&lt;/i&gt;#iU'
+            => '<i>$1</i>',
+            '#&lt;a href=&quot;(.*)&quot;&gt;(.*)&lt;/a&gt;#iU'
+            => '<a href="$1">$2</a>',
+            '#&lt;a id=&quot;(.*)&quot; href=&quot;(.*)&quot;&gt;(.*)&lt;/a&gt;#iU'
+            => '<a id="$1" href="$2">$3</a>',
+            '#&lt;span id=&quot;copyhint&quot;&gt;(.*)&lt;/span&gt;#iU'
+            => '<span id="copyhint">$1</span>',
+        );
+        $partiallyDecoded = preg_replace(
+            array_keys($replacementRegexpMap), 
+            array_values($replacementRegexpMap),
+            $encoded
+        );
+        return $partiallyDecoded;
     }
 
     /**


### PR DESCRIPTION
<!-- This is a template for your Pull Request. This are just some suggestions for you. You do not have to use all of them. -->

<!-- If your PR fixes an issue, mention it here. You can also just copy the URL - GitHub will convert it for you.
If this PR fixes several issues, please prepend each issue url/number with the word "fix"/"fixes" or "close"/"closes" as this automatically closes the issues you mentioned when the PR is merged.
-->
This PR fixes a problem introduced with the commit eb32ea141956c0ed72e3186956895333f62e271c.
In the sentence "Data is encrypted/decrypted in the browser using 256 bits AES.", we saw "&lt;i&gt;in the browser&lt;/i&gt;" in normal font style in place of "<i>in the browser</i>" in italic.

## Changes
<!-- List all the changes you have done -->
I suppose that if there is a system to escape HTML code, it's important. So I keep it and I create a simple method to authorize only such markups (with only a certain order of attributes). Normally, it's cover all sentences available in i18n/*.js files. I make several grep commands to verify that.

