### PR TITLE
New Docker Image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM registry.access.redhat.com/ubi7/php-73
+USER root
+COPY . /tmp/src
+RUN chown -R 1001:0 /tmp/src
+USER 1001
+RUN /usr/libexec/s2i/assemble
+CMD /usr/libexec/s2i/run

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM registry.access.redhat.com/ubi7/php-73
+#FROM registry.access.redhat.com/ubi7/php-73
+FROM registry.access.redhat.com/ubi8/php-74
 USER root
 COPY . /tmp/src
 RUN chown -R 1001:0 /tmp/src


### PR DESCRIPTION
in order to replace https://github.com/PrivateBin/docker-nginx-fpm-alpine you can use the images provided from redhat.