### PR TITLE
Add download button (for paste text)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
   * **1.4 (not yet released)**
     * ADDED: Translation for Estonian
     * ADDED: new HTTP headers improving security (#765)
+    * ADDED: Download button for paste text (#774)
     * ADDED: Opt-out of federated learning of cohorts (FLoC) (#776)
     * CHANGED: Language selection cookie only transmitted over HTTPS (#472)
   * **1.3.5 (2021-04-05)**

--- a/css/privatebin.css
+++ b/css/privatebin.css
@@ -249,6 +249,10 @@ button img {
 	padding: 1px 0 1px 0;
 }
 
+#downloadtextbutton img {
+	padding: 1px 0 1px 0;
+}
+
 #remainingtime, #password {
 	color: #94a3b4;
 	display: inline;

--- a/i18n/ar.json
+++ b/i18n/ar.json
@@ -185,5 +185,5 @@
     "Encrypted note on PrivateBin": "Encrypted note on PrivateBin",
     "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.": "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.",
     "URL shortener may expose your decrypt key in URL.": "URL shortener may expose your decrypt key in URL.",
-    "Download": "Download"
+    "Save paste": "Save paste"
 }

--- a/i18n/ar.json
+++ b/i18n/ar.json
@@ -184,5 +184,6 @@
     "Close": "Close",
     "Encrypted note on PrivateBin": "Encrypted note on PrivateBin",
     "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.": "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.",
-    "URL shortener may expose your decrypt key in URL.": "URL shortener may expose your decrypt key in URL."
+    "URL shortener may expose your decrypt key in URL.": "URL shortener may expose your decrypt key in URL.",
+    "Download": "Download"
 }

--- a/i18n/bg.json
+++ b/i18n/bg.json
@@ -185,5 +185,5 @@
     "Encrypted note on PrivateBin": "Encrypted note on PrivateBin",
     "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.": "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.",
     "URL shortener may expose your decrypt key in URL.": "URL shortener may expose your decrypt key in URL.",
-    "Download": "Download"
+    "Save paste": "Save paste"
 }

--- a/i18n/bg.json
+++ b/i18n/bg.json
@@ -184,5 +184,6 @@
     "Close": "Close",
     "Encrypted note on PrivateBin": "Encrypted note on PrivateBin",
     "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.": "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.",
-    "URL shortener may expose your decrypt key in URL.": "URL shortener may expose your decrypt key in URL."
+    "URL shortener may expose your decrypt key in URL.": "URL shortener may expose your decrypt key in URL.",
+    "Download": "Download"
 }

--- a/i18n/ca.json
+++ b/i18n/ca.json
@@ -185,5 +185,5 @@
     "Encrypted note on PrivateBin": "Encrypted note on PrivateBin",
     "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.": "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.",
     "URL shortener may expose your decrypt key in URL.": "URL shortener may expose your decrypt key in URL.",
-    "Download": "Download"
+    "Save paste": "Save paste"
 }

--- a/i18n/ca.json
+++ b/i18n/ca.json
@@ -184,5 +184,6 @@
     "Close": "Close",
     "Encrypted note on PrivateBin": "Encrypted note on PrivateBin",
     "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.": "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.",
-    "URL shortener may expose your decrypt key in URL.": "URL shortener may expose your decrypt key in URL."
+    "URL shortener may expose your decrypt key in URL.": "URL shortener may expose your decrypt key in URL.",
+    "Download": "Download"
 }

--- a/i18n/cs.json
+++ b/i18n/cs.json
@@ -185,5 +185,5 @@
     "Encrypted note on PrivateBin": "Encrypted note on PrivateBin",
     "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.": "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.",
     "URL shortener may expose your decrypt key in URL.": "URL shortener may expose your decrypt key in URL.",
-    "Download": "Download"
+    "Save paste": "Save paste"
 }

--- a/i18n/cs.json
+++ b/i18n/cs.json
@@ -184,5 +184,6 @@
     "Close": "Close",
     "Encrypted note on PrivateBin": "Encrypted note on PrivateBin",
     "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.": "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.",
-    "URL shortener may expose your decrypt key in URL.": "URL shortener may expose your decrypt key in URL."
+    "URL shortener may expose your decrypt key in URL.": "URL shortener may expose your decrypt key in URL.",
+    "Download": "Download"
 }

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -184,5 +184,6 @@
     "Close": "Schliessen",
     "Encrypted note on PrivateBin": "Verschlüsselte Notiz auf PrivateBin",
     "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.": "Besuche diese Verknüpfung um das Dokument zu sehen. Wird die URL an eine andere Person gegeben, so kann diese Person ebenfalls auf dieses Dokument zugreifen.",
-    "URL shortener may expose your decrypt key in URL.": "Der URL-Verkürzer kann den Schlüssel in der URL enthüllen."
+    "URL shortener may expose your decrypt key in URL.": "Der URL-Verkürzer kann den Schlüssel in der URL enthüllen.",
+    "Download": "Download"
 }

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -185,5 +185,5 @@
     "Encrypted note on PrivateBin": "Verschlüsselte Notiz auf PrivateBin",
     "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.": "Besuche diese Verknüpfung um das Dokument zu sehen. Wird die URL an eine andere Person gegeben, so kann diese Person ebenfalls auf dieses Dokument zugreifen.",
     "URL shortener may expose your decrypt key in URL.": "Der URL-Verkürzer kann den Schlüssel in der URL enthüllen.",
-    "Download": "Download"
+    "Save paste": "Save paste"
 }

--- a/i18n/el.json
+++ b/i18n/el.json
@@ -185,5 +185,5 @@
     "Encrypted note on PrivateBin": "Encrypted note on PrivateBin",
     "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.": "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.",
     "URL shortener may expose your decrypt key in URL.": "URL shortener may expose your decrypt key in URL.",
-    "Download": "Download"
+    "Save paste": "Save paste"
 }

--- a/i18n/el.json
+++ b/i18n/el.json
@@ -184,5 +184,6 @@
     "Close": "Close",
     "Encrypted note on PrivateBin": "Encrypted note on PrivateBin",
     "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.": "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.",
-    "URL shortener may expose your decrypt key in URL.": "URL shortener may expose your decrypt key in URL."
+    "URL shortener may expose your decrypt key in URL.": "URL shortener may expose your decrypt key in URL.",
+    "Download": "Download"
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -185,5 +185,5 @@
     "Encrypted note on PrivateBin": "Encrypted note on PrivateBin",
     "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.": "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.",
     "URL shortener may expose your decrypt key in URL.": "URL shortener may expose your decrypt key in URL.",
-    "Download": "Download"
+    "Save paste": "Save paste"
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -184,5 +184,6 @@
     "Close": "Close",
     "Encrypted note on PrivateBin": "Encrypted note on PrivateBin",
     "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.": "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.",
-    "URL shortener may expose your decrypt key in URL.": "URL shortener may expose your decrypt key in URL."
+    "URL shortener may expose your decrypt key in URL.": "URL shortener may expose your decrypt key in URL.",
+    "Download": "Download"
 }

--- a/i18n/es.json
+++ b/i18n/es.json
@@ -184,5 +184,6 @@
     "Close": "Cerrar",
     "Encrypted note on PrivateBin": "Nota cifrada en PrivateBin",
     "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.": "Visite este enlace para ver la nota. Dar la URL a cualquier persona también les permite acceder a la nota.",
-    "URL shortener may expose your decrypt key in URL.": "URL shortener may expose your decrypt key in URL."
+    "URL shortener may expose your decrypt key in URL.": "URL shortener may expose your decrypt key in URL.",
+    "Download": "Download"
 }

--- a/i18n/es.json
+++ b/i18n/es.json
@@ -185,5 +185,5 @@
     "Encrypted note on PrivateBin": "Nota cifrada en PrivateBin",
     "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.": "Visite este enlace para ver la nota. Dar la URL a cualquier persona también les permite acceder a la nota.",
     "URL shortener may expose your decrypt key in URL.": "URL shortener may expose your decrypt key in URL.",
-    "Download": "Download"
+    "Save paste": "Save paste"
 }

--- a/i18n/et.json
+++ b/i18n/et.json
@@ -185,5 +185,5 @@
     "Encrypted note on PrivateBin": "Krüpteeritud kiri PrivateBin-is",
     "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.": "Kirja nägemiseks külasta seda linki. Teistele URL-i andmine lubab ka neil ligi pääseda kirjale.",
     "URL shortener may expose your decrypt key in URL.": "URL-i lühendaja võib paljastada sinu dekrüpteerimisvõtme URL-is.",
-    "Download": "Download"
+    "Save paste": "Save paste"
 }

--- a/i18n/et.json
+++ b/i18n/et.json
@@ -184,5 +184,6 @@
     "Close": "Sulge",
     "Encrypted note on PrivateBin": "Krüpteeritud kiri PrivateBin-is",
     "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.": "Kirja nägemiseks külasta seda linki. Teistele URL-i andmine lubab ka neil ligi pääseda kirjale.",
-    "URL shortener may expose your decrypt key in URL.": "URL-i lühendaja võib paljastada sinu dekrüpteerimisvõtme URL-is."
+    "URL shortener may expose your decrypt key in URL.": "URL-i lühendaja võib paljastada sinu dekrüpteerimisvõtme URL-is.",
+    "Download": "Download"
 }

--- a/i18n/fr.json
+++ b/i18n/fr.json
@@ -185,5 +185,5 @@
     "Encrypted note on PrivateBin": "Message chiffré sur PrivateBin",
     "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.": "Visiter ce lien pour voir la note. Donner l'URL à une autre personne lui permet également d'accéder à la note.",
     "URL shortener may expose your decrypt key in URL.": "Raccourcir l'URL peut exposer votre clé de déchiffrement dans l'URL.",
-    "Download": "Download"
+    "Save paste": "Save paste"
 }

--- a/i18n/fr.json
+++ b/i18n/fr.json
@@ -184,5 +184,6 @@
     "Close": "Fermer",
     "Encrypted note on PrivateBin": "Message chiffré sur PrivateBin",
     "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.": "Visiter ce lien pour voir la note. Donner l'URL à une autre personne lui permet également d'accéder à la note.",
-    "URL shortener may expose your decrypt key in URL.": "Raccourcir l'URL peut exposer votre clé de déchiffrement dans l'URL."
+    "URL shortener may expose your decrypt key in URL.": "Raccourcir l'URL peut exposer votre clé de déchiffrement dans l'URL.",
+    "Download": "Download"
 }

--- a/i18n/he.json
+++ b/i18n/he.json
@@ -184,5 +184,6 @@
     "Close": "סגירה",
     "Encrypted note on PrivateBin": "הערה מוצפנת ב־PrivateBin",
     "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.": "נא לבקר בקישור כדי לצפות בהערה. מסירת הקישור לאנשים כלשהם תאפשר גם להם לגשת להערה.",
-    "URL shortener may expose your decrypt key in URL.": "URL shortener may expose your decrypt key in URL."
+    "URL shortener may expose your decrypt key in URL.": "URL shortener may expose your decrypt key in URL.",
+    "Download": "Download"
 }

--- a/i18n/he.json
+++ b/i18n/he.json
@@ -185,5 +185,5 @@
     "Encrypted note on PrivateBin": "הערה מוצפנת ב־PrivateBin",
     "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.": "נא לבקר בקישור כדי לצפות בהערה. מסירת הקישור לאנשים כלשהם תאפשר גם להם לגשת להערה.",
     "URL shortener may expose your decrypt key in URL.": "URL shortener may expose your decrypt key in URL.",
-    "Download": "Download"
+    "Save paste": "Save paste"
 }

--- a/i18n/hi.json
+++ b/i18n/hi.json
@@ -185,5 +185,5 @@
     "Encrypted note on PrivateBin": "Encrypted note on PrivateBin",
     "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.": "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.",
     "URL shortener may expose your decrypt key in URL.": "URL shortener may expose your decrypt key in URL.",
-    "Download": "Download"
+    "Save paste": "Save paste"
 }

--- a/i18n/hi.json
+++ b/i18n/hi.json
@@ -184,5 +184,6 @@
     "Close": "Close",
     "Encrypted note on PrivateBin": "Encrypted note on PrivateBin",
     "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.": "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.",
-    "URL shortener may expose your decrypt key in URL.": "URL shortener may expose your decrypt key in URL."
+    "URL shortener may expose your decrypt key in URL.": "URL shortener may expose your decrypt key in URL.",
+    "Download": "Download"
 }

--- a/i18n/hu.json
+++ b/i18n/hu.json
@@ -185,5 +185,5 @@
     "Encrypted note on PrivateBin": "Titkosított jegyzet a PrivateBinen",
     "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.": "Látogasd meg ezt a hivatkozást a bejegyzés megtekintéséhez. Ha mások számára is megadod ezt a linket, azzal hozzáférnek ők is.",
     "URL shortener may expose your decrypt key in URL.": "URL shortener may expose your decrypt key in URL.",
-    "Download": "Download"
+    "Save paste": "Save paste"
 }

--- a/i18n/hu.json
+++ b/i18n/hu.json
@@ -184,5 +184,6 @@
     "Close": "Bezárás",
     "Encrypted note on PrivateBin": "Titkosított jegyzet a PrivateBinen",
     "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.": "Látogasd meg ezt a hivatkozást a bejegyzés megtekintéséhez. Ha mások számára is megadod ezt a linket, azzal hozzáférnek ők is.",
-    "URL shortener may expose your decrypt key in URL.": "URL shortener may expose your decrypt key in URL."
+    "URL shortener may expose your decrypt key in URL.": "URL shortener may expose your decrypt key in URL.",
+    "Download": "Download"
 }

--- a/i18n/id.json
+++ b/i18n/id.json
@@ -184,5 +184,6 @@
     "Close": "Tutup",
     "Encrypted note on PrivateBin": "Catatan ter-ekrip di PrivateBin",
     "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.": "Kunjungi tautan ini untuk melihat catatan. Memberikan alamat URL pada siapapun juga, akan mengizinkan mereka untuk mengakses catatan, so pasti gitu loh Kaka.",
-    "URL shortener may expose your decrypt key in URL.": "URL shortener may expose your decrypt key in URL."
+    "URL shortener may expose your decrypt key in URL.": "URL shortener may expose your decrypt key in URL.",
+    "Download": "Download"
 }

--- a/i18n/id.json
+++ b/i18n/id.json
@@ -185,5 +185,5 @@
     "Encrypted note on PrivateBin": "Catatan ter-ekrip di PrivateBin",
     "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.": "Kunjungi tautan ini untuk melihat catatan. Memberikan alamat URL pada siapapun juga, akan mengizinkan mereka untuk mengakses catatan, so pasti gitu loh Kaka.",
     "URL shortener may expose your decrypt key in URL.": "URL shortener may expose your decrypt key in URL.",
-    "Download": "Download"
+    "Save paste": "Save paste"
 }

--- a/i18n/it.json
+++ b/i18n/it.json
@@ -185,5 +185,5 @@
     "Encrypted note on PrivateBin": "Nota crittografata su PrivateBin",
     "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.": "Visita questo collegamento per vedere la nota. Dare l'URL a chiunque consente anche a loro di accedere alla nota.",
     "URL shortener may expose your decrypt key in URL.": "URL shortener may expose your decrypt key in URL.",
-    "Download": "Download"
+    "Save paste": "Save paste"
 }

--- a/i18n/it.json
+++ b/i18n/it.json
@@ -184,5 +184,6 @@
     "Close": "Chiudi",
     "Encrypted note on PrivateBin": "Nota crittografata su PrivateBin",
     "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.": "Visita questo collegamento per vedere la nota. Dare l'URL a chiunque consente anche a loro di accedere alla nota.",
-    "URL shortener may expose your decrypt key in URL.": "URL shortener may expose your decrypt key in URL."
+    "URL shortener may expose your decrypt key in URL.": "URL shortener may expose your decrypt key in URL.",
+    "Download": "Download"
 }

--- a/i18n/ja.json
+++ b/i18n/ja.json
@@ -185,5 +185,5 @@
     "Encrypted note on PrivateBin": "Encrypted note on PrivateBin",
     "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.": "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.",
     "URL shortener may expose your decrypt key in URL.": "URL shortener may expose your decrypt key in URL.",
-    "Download": "Download"
+    "Save paste": "Save paste"
 }

--- a/i18n/ja.json
+++ b/i18n/ja.json
@@ -184,5 +184,6 @@
     "Close": "Close",
     "Encrypted note on PrivateBin": "Encrypted note on PrivateBin",
     "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.": "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.",
-    "URL shortener may expose your decrypt key in URL.": "URL shortener may expose your decrypt key in URL."
+    "URL shortener may expose your decrypt key in URL.": "URL shortener may expose your decrypt key in URL.",
+    "Download": "Download"
 }

--- a/i18n/ku.json
+++ b/i18n/ku.json
@@ -185,5 +185,5 @@
     "Encrypted note on PrivateBin": "Encrypted note on PrivateBin",
     "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.": "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.",
     "URL shortener may expose your decrypt key in URL.": "URL shortener may expose your decrypt key in URL.",
-    "Download": "Download"
+    "Save paste": "Save paste"
 }

--- a/i18n/ku.json
+++ b/i18n/ku.json
@@ -184,5 +184,6 @@
     "Close": "Close",
     "Encrypted note on PrivateBin": "Encrypted note on PrivateBin",
     "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.": "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.",
-    "URL shortener may expose your decrypt key in URL.": "URL shortener may expose your decrypt key in URL."
+    "URL shortener may expose your decrypt key in URL.": "URL shortener may expose your decrypt key in URL.",
+    "Download": "Download"
 }

--- a/i18n/la.json
+++ b/i18n/la.json
@@ -185,5 +185,5 @@
     "Encrypted note on PrivateBin": "Encrypted note on PrivateBin",
     "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.": "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.",
     "URL shortener may expose your decrypt key in URL.": "URL shortener may expose your decrypt key in URL.",
-    "Download": "Download"
+    "Save paste": "Save paste"
 }

--- a/i18n/la.json
+++ b/i18n/la.json
@@ -184,5 +184,6 @@
     "Close": "Close",
     "Encrypted note on PrivateBin": "Encrypted note on PrivateBin",
     "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.": "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.",
-    "URL shortener may expose your decrypt key in URL.": "URL shortener may expose your decrypt key in URL."
+    "URL shortener may expose your decrypt key in URL.": "URL shortener may expose your decrypt key in URL.",
+    "Download": "Download"
 }

--- a/i18n/lt.json
+++ b/i18n/lt.json
@@ -185,5 +185,5 @@
     "Encrypted note on PrivateBin": "Šifruoti užrašai ties PrivateBin",
     "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.": "Norėdami matyti užrašus, aplankykite šį tinklalapį. Pasidalinus šiuo URL adresu su kitais žmonėmis, jiems taip pat bus leidžiama prieiga prie šių užrašų.",
     "URL shortener may expose your decrypt key in URL.": "URL trumpinimo įrankis gali atskleisti URL adrese jūsų iššifravimo raktą.",
-    "Download": "Download"
+    "Save paste": "Save paste"
 }

--- a/i18n/lt.json
+++ b/i18n/lt.json
@@ -184,5 +184,6 @@
     "Close": "Užverti",
     "Encrypted note on PrivateBin": "Šifruoti užrašai ties PrivateBin",
     "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.": "Norėdami matyti užrašus, aplankykite šį tinklalapį. Pasidalinus šiuo URL adresu su kitais žmonėmis, jiems taip pat bus leidžiama prieiga prie šių užrašų.",
-    "URL shortener may expose your decrypt key in URL.": "URL trumpinimo įrankis gali atskleisti URL adrese jūsų iššifravimo raktą."
+    "URL shortener may expose your decrypt key in URL.": "URL trumpinimo įrankis gali atskleisti URL adrese jūsų iššifravimo raktą.",
+    "Download": "Download"
 }

--- a/i18n/nl.json
+++ b/i18n/nl.json
@@ -185,5 +185,5 @@
     "Encrypted note on PrivateBin": "Encrypted note on PrivateBin",
     "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.": "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.",
     "URL shortener may expose your decrypt key in URL.": "URL shortener may expose your decrypt key in URL.",
-    "Download": "Download"
+    "Save paste": "Save paste"
 }

--- a/i18n/nl.json
+++ b/i18n/nl.json
@@ -184,5 +184,6 @@
     "Close": "Close",
     "Encrypted note on PrivateBin": "Encrypted note on PrivateBin",
     "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.": "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.",
-    "URL shortener may expose your decrypt key in URL.": "URL shortener may expose your decrypt key in URL."
+    "URL shortener may expose your decrypt key in URL.": "URL shortener may expose your decrypt key in URL.",
+    "Download": "Download"
 }

--- a/i18n/no.json
+++ b/i18n/no.json
@@ -184,5 +184,6 @@
     "Close": "Steng",
     "Encrypted note on PrivateBin": "Kryptert notat på PrivateBin",
     "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.": "Besøk denne lenken for å se notatet. Hvis lenken deles med andre, vil de også kunne se notatet.",
-    "URL shortener may expose your decrypt key in URL.": "URL shortener may expose your decrypt key in URL."
+    "URL shortener may expose your decrypt key in URL.": "URL shortener may expose your decrypt key in URL.",
+    "Download": "Download"
 }

--- a/i18n/no.json
+++ b/i18n/no.json
@@ -185,5 +185,5 @@
     "Encrypted note on PrivateBin": "Kryptert notat på PrivateBin",
     "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.": "Besøk denne lenken for å se notatet. Hvis lenken deles med andre, vil de også kunne se notatet.",
     "URL shortener may expose your decrypt key in URL.": "URL shortener may expose your decrypt key in URL.",
-    "Download": "Download"
+    "Save paste": "Save paste"
 }

--- a/i18n/oc.json
+++ b/i18n/oc.json
@@ -185,5 +185,5 @@
     "Encrypted note on PrivateBin": "Nòtas chifradas sus PrivateBin",
     "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.": "Visitatz aqueste ligam per veire la nòta. Fornir lo ligam a qualqu’un mai li permet tanben d’accedir a la nòta.",
     "URL shortener may expose your decrypt key in URL.": "URL shortener may expose your decrypt key in URL.",
-    "Download": "Download"
+    "Save paste": "Save paste"
 }

--- a/i18n/oc.json
+++ b/i18n/oc.json
@@ -184,5 +184,6 @@
     "Close": "Tampar",
     "Encrypted note on PrivateBin": "Nòtas chifradas sus PrivateBin",
     "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.": "Visitatz aqueste ligam per veire la nòta. Fornir lo ligam a qualqu’un mai li permet tanben d’accedir a la nòta.",
-    "URL shortener may expose your decrypt key in URL.": "URL shortener may expose your decrypt key in URL."
+    "URL shortener may expose your decrypt key in URL.": "URL shortener may expose your decrypt key in URL.",
+    "Download": "Download"
 }

--- a/i18n/pl.json
+++ b/i18n/pl.json
@@ -185,5 +185,5 @@
     "Encrypted note on PrivateBin": "Encrypted note on PrivateBin",
     "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.": "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.",
     "URL shortener may expose your decrypt key in URL.": "URL shortener may expose your decrypt key in URL.",
-    "Download": "Download"
+    "Save paste": "Save paste"
 }

--- a/i18n/pl.json
+++ b/i18n/pl.json
@@ -184,5 +184,6 @@
     "Close": "Close",
     "Encrypted note on PrivateBin": "Encrypted note on PrivateBin",
     "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.": "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.",
-    "URL shortener may expose your decrypt key in URL.": "URL shortener may expose your decrypt key in URL."
+    "URL shortener may expose your decrypt key in URL.": "URL shortener may expose your decrypt key in URL.",
+    "Download": "Download"
 }

--- a/i18n/pt.json
+++ b/i18n/pt.json
@@ -184,5 +184,6 @@
     "Close": "Fechar",
     "Encrypted note on PrivateBin": "Nota criptografada no PrivateBin",
     "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.": "Visite esse link para ver a nota. Dar a URL para qualquer um permite que eles também acessem a nota.",
-    "URL shortener may expose your decrypt key in URL.": "URL shortener may expose your decrypt key in URL."
+    "URL shortener may expose your decrypt key in URL.": "URL shortener may expose your decrypt key in URL.",
+    "Download": "Download"
 }

--- a/i18n/pt.json
+++ b/i18n/pt.json
@@ -185,5 +185,5 @@
     "Encrypted note on PrivateBin": "Nota criptografada no PrivateBin",
     "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.": "Visite esse link para ver a nota. Dar a URL para qualquer um permite que eles também acessem a nota.",
     "URL shortener may expose your decrypt key in URL.": "URL shortener may expose your decrypt key in URL.",
-    "Download": "Download"
+    "Save paste": "Save paste"
 }

--- a/i18n/ru.json
+++ b/i18n/ru.json
@@ -184,5 +184,6 @@
     "Close": "Закрыть",
     "Encrypted note on PrivateBin": "Зашифрованная запись на PrivateBin",
     "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.": "Посетите эту ссылку чтобы просмотреть запись. Передача ссылки кому либо позволит им получить доступ к записи тоже.",
-    "URL shortener may expose your decrypt key in URL.": "URL shortener may expose your decrypt key in URL."
+    "URL shortener may expose your decrypt key in URL.": "URL shortener may expose your decrypt key in URL.",
+    "Download": "Download"
 }

--- a/i18n/ru.json
+++ b/i18n/ru.json
@@ -185,5 +185,5 @@
     "Encrypted note on PrivateBin": "Зашифрованная запись на PrivateBin",
     "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.": "Посетите эту ссылку чтобы просмотреть запись. Передача ссылки кому либо позволит им получить доступ к записи тоже.",
     "URL shortener may expose your decrypt key in URL.": "URL shortener may expose your decrypt key in URL.",
-    "Download": "Download"
+    "Save paste": "Save paste"
 }

--- a/i18n/sl.json
+++ b/i18n/sl.json
@@ -185,5 +185,5 @@
     "Encrypted note on PrivateBin": "Encrypted note on PrivateBin",
     "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.": "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.",
     "URL shortener may expose your decrypt key in URL.": "URL shortener may expose your decrypt key in URL.",
-    "Download": "Download"
+    "Save paste": "Save paste"
 }

--- a/i18n/sl.json
+++ b/i18n/sl.json
@@ -184,5 +184,6 @@
     "Close": "Close",
     "Encrypted note on PrivateBin": "Encrypted note on PrivateBin",
     "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.": "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.",
-    "URL shortener may expose your decrypt key in URL.": "URL shortener may expose your decrypt key in URL."
+    "URL shortener may expose your decrypt key in URL.": "URL shortener may expose your decrypt key in URL.",
+    "Download": "Download"
 }

--- a/i18n/sv.json
+++ b/i18n/sv.json
@@ -185,5 +185,5 @@
     "Encrypted note on PrivateBin": "Encrypted note on PrivateBin",
     "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.": "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.",
     "URL shortener may expose your decrypt key in URL.": "URL shortener may expose your decrypt key in URL.",
-    "Download": "Download"
+    "Save paste": "Save paste"
 }

--- a/i18n/sv.json
+++ b/i18n/sv.json
@@ -184,5 +184,6 @@
     "Close": "Close",
     "Encrypted note on PrivateBin": "Encrypted note on PrivateBin",
     "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.": "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.",
-    "URL shortener may expose your decrypt key in URL.": "URL shortener may expose your decrypt key in URL."
+    "URL shortener may expose your decrypt key in URL.": "URL shortener may expose your decrypt key in URL.",
+    "Download": "Download"
 }

--- a/i18n/tr.json
+++ b/i18n/tr.json
@@ -185,5 +185,5 @@
     "Encrypted note on PrivateBin": "Encrypted note on PrivateBin",
     "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.": "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.",
     "URL shortener may expose your decrypt key in URL.": "URL shortener may expose your decrypt key in URL.",
-    "Download": "Download"
+    "Save paste": "Save paste"
 }

--- a/i18n/tr.json
+++ b/i18n/tr.json
@@ -184,5 +184,6 @@
     "Close": "Close",
     "Encrypted note on PrivateBin": "Encrypted note on PrivateBin",
     "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.": "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.",
-    "URL shortener may expose your decrypt key in URL.": "URL shortener may expose your decrypt key in URL."
+    "URL shortener may expose your decrypt key in URL.": "URL shortener may expose your decrypt key in URL.",
+    "Download": "Download"
 }

--- a/i18n/uk.json
+++ b/i18n/uk.json
@@ -185,5 +185,5 @@
     "Encrypted note on PrivateBin": "Encrypted note on PrivateBin",
     "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.": "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.",
     "URL shortener may expose your decrypt key in URL.": "URL shortener may expose your decrypt key in URL.",
-    "Download": "Download"
+    "Save paste": "Save paste"
 }

--- a/i18n/uk.json
+++ b/i18n/uk.json
@@ -184,5 +184,6 @@
     "Close": "Close",
     "Encrypted note on PrivateBin": "Encrypted note on PrivateBin",
     "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.": "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.",
-    "URL shortener may expose your decrypt key in URL.": "URL shortener may expose your decrypt key in URL."
+    "URL shortener may expose your decrypt key in URL.": "URL shortener may expose your decrypt key in URL.",
+    "Download": "Download"
 }

--- a/i18n/zh.json
+++ b/i18n/zh.json
@@ -184,5 +184,6 @@
     "Close": "关闭",
     "Encrypted note on PrivateBin": "PrivateBin上的加密笔记",
     "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.": "访问这个链接来查看该笔记。 将这个URL发送给任何人即可允许其访问该笔记。",
-    "URL shortener may expose your decrypt key in URL.": "URL 缩短可能会暴露您在 URL 中的解密密钥。"
+    "URL shortener may expose your decrypt key in URL.": "URL 缩短可能会暴露您在 URL 中的解密密钥。",
+    "Download": "Download"
 }

--- a/i18n/zh.json
+++ b/i18n/zh.json
@@ -185,5 +185,5 @@
     "Encrypted note on PrivateBin": "PrivateBin上的加密笔记",
     "Visit this link to see the note. Giving the URL to anyone allows them to access the note, too.": "访问这个链接来查看该笔记。 将这个URL发送给任何人即可允许其访问该笔记。",
     "URL shortener may expose your decrypt key in URL.": "URL 缩短可能会暴露您在 URL 中的解密密钥。",
-    "Download": "Download"
+    "Save paste": "Save paste"
 }

--- a/js/privatebin.js
+++ b/js/privatebin.js
@@ -3676,7 +3676,7 @@ jQuery.PrivateBin = (function($, RawDeflate) {
          */
         function downloadText()
         {
-            var filename='paste.txt';
+            var filename='paste-' + Model.getPasteId() + '.txt';
             var text = PasteViewer.getText();
 
             var element = document.createElement('a');

--- a/js/privatebin.js
+++ b/js/privatebin.js
@@ -3525,6 +3525,7 @@ jQuery.PrivateBin = (function($, RawDeflate) {
             $password,
             $passwordInput,
             $rawTextButton,
+	    $downloadTextButton,
             $qrCodeLink,
             $emailLink,
             $sendButton,
@@ -3665,6 +3666,30 @@ jQuery.PrivateBin = (function($, RawDeflate) {
             newDoc.write('</head><body><pre>' + DOMPurify.sanitize(Helper.htmlEntities(paste)) + '</pre></body></html>');
             newDoc.close();
         }
+
+        /**
+         * download text
+         *
+         * @name   TopNav.downloadText
+         * @private
+         * @function
+         */
+        function downloadText()
+        {
+	    var filename='paste.txt';
+	    var text = PasteViewer.getText();
+
+	    var element = document.createElement('a');
+	    element.setAttribute('href', 'data:text/plain;charset=utf-8,' + encodeURIComponent(text));
+	    element.setAttribute('download', filename);
+
+	    element.style.display = 'none';
+	    document.body.appendChild(element);
+
+	    element.click();
+
+	    document.body.removeChild(element);
+	}
 
         /**
          * saves the language in a cookie and reloads the page
@@ -3892,6 +3917,7 @@ jQuery.PrivateBin = (function($, RawDeflate) {
             $newButton.removeClass('hidden');
             $cloneButton.removeClass('hidden');
             $rawTextButton.removeClass('hidden');
+            $downloadTextButton.removeClass('hidden');
             $qrCodeLink.removeClass('hidden');
 
             viewButtonsDisplayed = true;
@@ -3912,6 +3938,7 @@ jQuery.PrivateBin = (function($, RawDeflate) {
             $cloneButton.addClass('hidden');
             $newButton.addClass('hidden');
             $rawTextButton.addClass('hidden');
+            $downloadTextButton.addClass('hidden');
             $qrCodeLink.addClass('hidden');
             me.hideEmailButton();
 
@@ -4071,6 +4098,17 @@ jQuery.PrivateBin = (function($, RawDeflate) {
         me.hideRawButton = function()
         {
             $rawTextButton.addClass('hidden');
+        };
+
+        /**
+         * only hides the download text button
+         *
+         * @name   TopNav.hideRawButton
+         * @function
+         */
+        me.hideDownloadButton = function()
+        {
+            $downloadTextButton.addClass('hidden');
         };
 
         /**
@@ -4334,6 +4372,7 @@ jQuery.PrivateBin = (function($, RawDeflate) {
             $password = $('#password');
             $passwordInput = $('#passwordinput');
             $rawTextButton = $('#rawtextbutton');
+            $downloadTextButton = $('#downloadtextbutton');
             $retryButton = $('#retrybutton');
             $sendButton = $('#sendbutton');
             $qrCodeLink = $('#qrcodelink');
@@ -4351,6 +4390,7 @@ jQuery.PrivateBin = (function($, RawDeflate) {
             $sendButton.click(PasteEncrypter.sendPaste);
             $cloneButton.click(Controller.clonePaste);
             $rawTextButton.click(rawText);
+            $downloadTextButton.click(downloadText);
             $retryButton.click(clickRetryButton);
             $fileRemoveButton.click(removeAttachment);
             $qrCodeLink.click(displayQrCode);
@@ -4689,6 +4729,7 @@ jQuery.PrivateBin = (function($, RawDeflate) {
             TopNav.showEmailButton();
 
             TopNav.hideRawButton();
+	    TopNav.hideDownloadButton();
             Editor.hide();
 
             // parse and show text

--- a/js/privatebin.js
+++ b/js/privatebin.js
@@ -3525,7 +3525,7 @@ jQuery.PrivateBin = (function($, RawDeflate) {
             $password,
             $passwordInput,
             $rawTextButton,
-	    $downloadTextButton,
+            $downloadTextButton,
             $qrCodeLink,
             $emailLink,
             $sendButton,
@@ -3676,20 +3676,20 @@ jQuery.PrivateBin = (function($, RawDeflate) {
          */
         function downloadText()
         {
-	    var filename='paste.txt';
-	    var text = PasteViewer.getText();
+            var filename='paste.txt';
+            var text = PasteViewer.getText();
 
-	    var element = document.createElement('a');
-	    element.setAttribute('href', 'data:text/plain;charset=utf-8,' + encodeURIComponent(text));
-	    element.setAttribute('download', filename);
+            var element = document.createElement('a');
+            element.setAttribute('href', 'data:text/plain;charset=utf-8,' + encodeURIComponent(text));
+            element.setAttribute('download', filename);
 
-	    element.style.display = 'none';
-	    document.body.appendChild(element);
+            element.style.display = 'none';
+            document.body.appendChild(element);
 
-	    element.click();
+            element.click();
 
-	    document.body.removeChild(element);
-	}
+            document.body.removeChild(element);
+        }
 
         /**
          * saves the language in a cookie and reloads the page
@@ -4729,7 +4729,7 @@ jQuery.PrivateBin = (function($, RawDeflate) {
             TopNav.showEmailButton();
 
             TopNav.hideRawButton();
-	    TopNav.hideDownloadButton();
+            TopNav.hideDownloadButton();
             Editor.hide();
 
             // parse and show text

--- a/tpl/bootstrap.php
+++ b/tpl/bootstrap.php
@@ -72,7 +72,7 @@ endif;
 ?>
 		<script type="text/javascript" data-cfasync="false" src="js/purify-2.2.7.js" integrity="sha512-7Ka1I/nJuR2CL8wzIS5PJS4HgEMd0HJ6kfAl6fFhwFBB27rhztFbe0tS+Ex+Qg+5n4nZIT4lty4k4Di3+X9T4A==" crossorigin="anonymous"></script>
 		<script type="text/javascript" data-cfasync="false" src="js/legacy.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-LYos+qXHIRqFf5ZPNphvtTB0cgzHUizu2wwcOwcwz/VIpRv9lpcBgPYz4uq6jx0INwCAj6Fbnl5HoKiLufS2jg==" crossorigin="anonymous"></script>
-		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-aro4zOmrXSR8u8UJ3OvapTAWEGNx/o5Leob2ovfRDfKRl6Z6eNuIs+ZNS5CrPUSilwsLAtOqVprFe+obin5y6w==" crossorigin="anonymous"></script>
+		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-If/o3E8yZm6/GaC1HCcBKhVzlmJM5ngYyEgPoRBFECBq7ffx8b11sI319kI2RLuibDBga+AUvmfODLdA3LuiNw==" crossorigin="anonymous"></script>
 		<!-- icon -->
 		<link rel="apple-touch-icon" href="<?php echo I18n::encode($BASEPATH); ?>img/apple-touch-icon.png" sizes="180x180" />
 		<link rel="icon" type="image/png" href="img/favicon-32x32.png" sizes="32x32" />

--- a/tpl/bootstrap.php
+++ b/tpl/bootstrap.php
@@ -213,7 +213,7 @@ endif;
 							<span class="glyphicon glyphicon-text-background" aria-hidden="true"></span> <?php echo I18n::_('Raw text'), PHP_EOL; ?>
 						</button>
 						<button id="downloadtextbutton" type="button" class="hidden btn btn-<?php echo $isDark ? 'warning' : 'default'; ?> navbar-btn">
-							<span class="glyphicon glyphicon glyphicon-download-alt" aria-hidden="true"></span> <?php echo I18n::_('Download'), PHP_EOL; ?>
+							<span class="glyphicon glyphicon glyphicon-download-alt" aria-hidden="true"></span> <?php echo I18n::_('Save paste'), PHP_EOL; ?>
 						</button>
 						<button id="emaillink" type="button" class="hidden btn btn-<?php echo $isDark ? 'warning' : 'default'; ?> navbar-btn">
 							<span class="glyphicon glyphicon-envelope" aria-hidden="true"></span> <?php echo I18n::_('Email'), PHP_EOL; ?>

--- a/tpl/bootstrap.php
+++ b/tpl/bootstrap.php
@@ -72,7 +72,7 @@ endif;
 ?>
 		<script type="text/javascript" data-cfasync="false" src="js/purify-2.2.7.js" integrity="sha512-7Ka1I/nJuR2CL8wzIS5PJS4HgEMd0HJ6kfAl6fFhwFBB27rhztFbe0tS+Ex+Qg+5n4nZIT4lty4k4Di3+X9T4A==" crossorigin="anonymous"></script>
 		<script type="text/javascript" data-cfasync="false" src="js/legacy.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-LYos+qXHIRqFf5ZPNphvtTB0cgzHUizu2wwcOwcwz/VIpRv9lpcBgPYz4uq6jx0INwCAj6Fbnl5HoKiLufS2jg==" crossorigin="anonymous"></script>
-		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-If/o3E8yZm6/GaC1HCcBKhVzlmJM5ngYyEgPoRBFECBq7ffx8b11sI319kI2RLuibDBga+AUvmfODLdA3LuiNw==" crossorigin="anonymous"></script>
+		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-lJwDAY69TQuYQZ7FjUFPfhgYeZ2L6y5bmGt1hR+d3kMm2sddivGr7ZDdLLSe/CBgn1JrsKMj3th9dPyXN3dLHw==" crossorigin="anonymous"></script>
 		<!-- icon -->
 		<link rel="apple-touch-icon" href="<?php echo I18n::encode($BASEPATH); ?>img/apple-touch-icon.png" sizes="180x180" />
 		<link rel="icon" type="image/png" href="img/favicon-32x32.png" sizes="32x32" />

--- a/tpl/bootstrap.php
+++ b/tpl/bootstrap.php
@@ -213,7 +213,7 @@ endif;
 							<span class="glyphicon glyphicon-text-background" aria-hidden="true"></span> <?php echo I18n::_('Raw text'), PHP_EOL; ?>
 						</button>
 						<button id="downloadtextbutton" type="button" class="hidden btn btn-<?php echo $isDark ? 'warning' : 'default'; ?> navbar-btn">
-							<span class="glyphicon glyphicon glyphicon-download-alt" aria-hidden="true"></span> Download
+							<span class="glyphicon glyphicon glyphicon-download-alt" aria-hidden="true"></span> <?php echo I18n::_('Download'), PHP_EOL; ?>
 						</button>
 						<button id="emaillink" type="button" class="hidden btn btn-<?php echo $isDark ? 'warning' : 'default'; ?> navbar-btn">
 							<span class="glyphicon glyphicon-envelope" aria-hidden="true"></span> <?php echo I18n::_('Email'), PHP_EOL; ?>

--- a/tpl/bootstrap.php
+++ b/tpl/bootstrap.php
@@ -72,7 +72,7 @@ endif;
 ?>
 		<script type="text/javascript" data-cfasync="false" src="js/purify-2.2.7.js" integrity="sha512-7Ka1I/nJuR2CL8wzIS5PJS4HgEMd0HJ6kfAl6fFhwFBB27rhztFbe0tS+Ex+Qg+5n4nZIT4lty4k4Di3+X9T4A==" crossorigin="anonymous"></script>
 		<script type="text/javascript" data-cfasync="false" src="js/legacy.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-LYos+qXHIRqFf5ZPNphvtTB0cgzHUizu2wwcOwcwz/VIpRv9lpcBgPYz4uq6jx0INwCAj6Fbnl5HoKiLufS2jg==" crossorigin="anonymous"></script>
-		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-/7gEqgCgQA9cgLUf5rBj+nfJptVm92LAYxvBN7mmeG+xkq9lQ+eY7DWQY47TGXXA7HqkCwk7424mnBiYZvCAUQ==" crossorigin="anonymous"></script>
+		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-mouOfFQR5Gn4RQLPg0PJmO/7tSXUrr1ohq+qDHNMXrKCKTZCvY9XcPYhIZjC3Pd6ClZ4eZ57da+EbnFX0m6Byg==" crossorigin="anonymous"></script>
 		<!-- icon -->
 		<link rel="apple-touch-icon" href="<?php echo I18n::encode($BASEPATH); ?>img/apple-touch-icon.png" sizes="180x180" />
 		<link rel="icon" type="image/png" href="img/favicon-32x32.png" sizes="32x32" />
@@ -211,6 +211,9 @@ endif;
 						</button>
 						<button id="rawtextbutton" type="button" class="hidden btn btn-<?php echo $isDark ? 'warning' : 'default'; ?> navbar-btn">
 							<span class="glyphicon glyphicon-text-background" aria-hidden="true"></span> <?php echo I18n::_('Raw text'), PHP_EOL; ?>
+						</button>
+						<button id="downloadtextbutton" type="button" class="hidden btn btn-<?php echo $isDark ? 'warning' : 'default'; ?> navbar-btn">
+							<span class="glyphicon glyphicon glyphicon-download-alt" aria-hidden="true"></span> Download
 						</button>
 						<button id="emaillink" type="button" class="hidden btn btn-<?php echo $isDark ? 'warning' : 'default'; ?> navbar-btn">
 							<span class="glyphicon glyphicon-envelope" aria-hidden="true"></span> <?php echo I18n::_('Email'), PHP_EOL; ?>

--- a/tpl/page.php
+++ b/tpl/page.php
@@ -50,7 +50,7 @@ endif;
 ?>
 		<script type="text/javascript" data-cfasync="false" src="js/purify-2.2.7.js" integrity="sha512-7Ka1I/nJuR2CL8wzIS5PJS4HgEMd0HJ6kfAl6fFhwFBB27rhztFbe0tS+Ex+Qg+5n4nZIT4lty4k4Di3+X9T4A==" crossorigin="anonymous"></script>
 		<script type="text/javascript" data-cfasync="false" src="js/legacy.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-LYos+qXHIRqFf5ZPNphvtTB0cgzHUizu2wwcOwcwz/VIpRv9lpcBgPYz4uq6jx0INwCAj6Fbnl5HoKiLufS2jg==" crossorigin="anonymous"></script>
-		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-If/o3E8yZm6/GaC1HCcBKhVzlmJM5ngYyEgPoRBFECBq7ffx8b11sI319kI2RLuibDBga+AUvmfODLdA3LuiNw==" crossorigin="anonymous"></script>
+		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-lJwDAY69TQuYQZ7FjUFPfhgYeZ2L6y5bmGt1hR+d3kMm2sddivGr7ZDdLLSe/CBgn1JrsKMj3th9dPyXN3dLHw==" crossorigin="anonymous"></script>
 		<!-- icon -->
 		<link rel="apple-touch-icon" href="img/apple-touch-icon.png?<?php echo rawurlencode($VERSION); ?>" sizes="180x180" />
 		<link rel="icon" type="image/png" href="img/favicon-32x32.png?<?php echo rawurlencode($VERSION); ?>" sizes="32x32" />

--- a/tpl/page.php
+++ b/tpl/page.php
@@ -127,6 +127,7 @@ endif;
 					<button id="sendbutton" class="hidden"><img src="img/icon_send.png" width="18" height="15" alt="" /><?php echo I18n::_('Send'); ?></button>
 					<button id="clonebutton" class="hidden"><img src="img/icon_clone.png" width="15" height="17" alt="" /><?php echo I18n::_('Clone'); ?></button>
 					<button id="rawtextbutton" class="hidden"><img src="img/icon_raw.png" width="15" height="15" alt="" /><?php echo I18n::_('Raw text'); ?></button>
+					<button id="downloadtextbutton" class="hidden"><?php echo I18n::_('Download'), PHP_EOL; ?></button>
 					<button id="emaillink" class="hidden"><img src="img/icon_email.png" width="15" height="15" alt="" /><?php echo I18n::_('Email'); ?></button>
 <?php
 if ($QRCODE):

--- a/tpl/page.php
+++ b/tpl/page.php
@@ -50,7 +50,7 @@ endif;
 ?>
 		<script type="text/javascript" data-cfasync="false" src="js/purify-2.2.7.js" integrity="sha512-7Ka1I/nJuR2CL8wzIS5PJS4HgEMd0HJ6kfAl6fFhwFBB27rhztFbe0tS+Ex+Qg+5n4nZIT4lty4k4Di3+X9T4A==" crossorigin="anonymous"></script>
 		<script type="text/javascript" data-cfasync="false" src="js/legacy.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-LYos+qXHIRqFf5ZPNphvtTB0cgzHUizu2wwcOwcwz/VIpRv9lpcBgPYz4uq6jx0INwCAj6Fbnl5HoKiLufS2jg==" crossorigin="anonymous"></script>
-		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-/7gEqgCgQA9cgLUf5rBj+nfJptVm92LAYxvBN7mmeG+xkq9lQ+eY7DWQY47TGXXA7HqkCwk7424mnBiYZvCAUQ==" crossorigin="anonymous"></script>
+		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-mouOfFQR5Gn4RQLPg0PJmO/7tSXUrr1ohq+qDHNMXrKCKTZCvY9XcPYhIZjC3Pd6ClZ4eZ57da+EbnFX0m6Byg==" crossorigin="anonymous"></script>
 		<!-- icon -->
 		<link rel="apple-touch-icon" href="img/apple-touch-icon.png?<?php echo rawurlencode($VERSION); ?>" sizes="180x180" />
 		<link rel="icon" type="image/png" href="img/favicon-32x32.png?<?php echo rawurlencode($VERSION); ?>" sizes="32x32" />

--- a/tpl/page.php
+++ b/tpl/page.php
@@ -50,7 +50,7 @@ endif;
 ?>
 		<script type="text/javascript" data-cfasync="false" src="js/purify-2.2.7.js" integrity="sha512-7Ka1I/nJuR2CL8wzIS5PJS4HgEMd0HJ6kfAl6fFhwFBB27rhztFbe0tS+Ex+Qg+5n4nZIT4lty4k4Di3+X9T4A==" crossorigin="anonymous"></script>
 		<script type="text/javascript" data-cfasync="false" src="js/legacy.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-LYos+qXHIRqFf5ZPNphvtTB0cgzHUizu2wwcOwcwz/VIpRv9lpcBgPYz4uq6jx0INwCAj6Fbnl5HoKiLufS2jg==" crossorigin="anonymous"></script>
-		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-aro4zOmrXSR8u8UJ3OvapTAWEGNx/o5Leob2ovfRDfKRl6Z6eNuIs+ZNS5CrPUSilwsLAtOqVprFe+obin5y6w==" crossorigin="anonymous"></script>
+		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-If/o3E8yZm6/GaC1HCcBKhVzlmJM5ngYyEgPoRBFECBq7ffx8b11sI319kI2RLuibDBga+AUvmfODLdA3LuiNw==" crossorigin="anonymous"></script>
 		<!-- icon -->
 		<link rel="apple-touch-icon" href="img/apple-touch-icon.png?<?php echo rawurlencode($VERSION); ?>" sizes="180x180" />
 		<link rel="icon" type="image/png" href="img/favicon-32x32.png?<?php echo rawurlencode($VERSION); ?>" sizes="32x32" />

--- a/tpl/page.php
+++ b/tpl/page.php
@@ -127,7 +127,7 @@ endif;
 					<button id="sendbutton" class="hidden"><img src="img/icon_send.png" width="18" height="15" alt="" /><?php echo I18n::_('Send'); ?></button>
 					<button id="clonebutton" class="hidden"><img src="img/icon_clone.png" width="15" height="17" alt="" /><?php echo I18n::_('Clone'); ?></button>
 					<button id="rawtextbutton" class="hidden"><img src="img/icon_raw.png" width="15" height="15" alt="" /><?php echo I18n::_('Raw text'); ?></button>
-					<button id="downloadtextbutton" class="hidden"><?php echo I18n::_('Download'), PHP_EOL; ?></button>
+					<button id="downloadtextbutton" class="hidden"><?php echo I18n::_('Save paste'), PHP_EOL; ?></button>
 					<button id="emaillink" class="hidden"><img src="img/icon_email.png" width="15" height="15" alt="" /><?php echo I18n::_('Email'); ?></button>
 <?php
 if ($QRCODE):


### PR DESCRIPTION
I'm raising this request based on a conversation I had [via email](https://agir.april.org/issues/5318#note-6) on behalf of Didier Clermonté for your review.

The intent is to add a new button to the view of a paste that lets you download the raw contents as a paste.txt file. The change can be reviewed at https://paste.chapril.org/?ef6a1b876b5c4526#4a9cGPmXJMzZyPW4diMpvesvx3x8x1NqCuidn6raP8Kn

I am happy to apply small improvements, if you have any suggestions and agree it can be added. For example I see that the new button is missing in the page template. And of course we should translate the button label.