### PR TITLE
Transmit cookie only over HTTPS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
   * **1.4 (not yet released)**
     * ADDED: Translation for Estonian
     * ADDED: new HTTP headers improving security (#765)
+    * CHANGED: Language selection cookie only transmitted over HTTPS (#472)
   * **1.3.5 (2021-04-05)**
     * ADDED: Translation for Hebrew, Lithuanian, Indonesian and Catalan
     * ADDED: Make the project info configurable (#681)

--- a/js/privatebin.js
+++ b/js/privatebin.js
@@ -3676,7 +3676,7 @@ jQuery.PrivateBin = (function($, RawDeflate) {
          */
         function setLanguage(event)
         {
-            document.cookie = 'lang=' + $(event.target).data('lang');
+            document.cookie = 'lang=' + $(event.target).data('lang') + ';secure';
             UiHelper.reloadHome();
         }
 

--- a/lib/Controller.php
+++ b/lib/Controller.php
@@ -170,7 +170,7 @@ class Controller
         // force default language, if language selection is disabled and a default is set
         if (!$this->_conf->getKey('languageselection') && strlen($lang) == 2) {
             $_COOKIE['lang'] = $lang;
-            setcookie('lang', $lang);
+            setcookie('lang', $lang, 0, '', '', true);
         }
     }
 
@@ -367,7 +367,7 @@ class Controller
         $languageselection = '';
         if ($this->_conf->getKey('languageselection')) {
             $languageselection = I18n::getLanguage();
-            setcookie('lang', $languageselection);
+            setcookie('lang', $languageselection, 0, '', '', true);
         }
 
         $page = new View;

--- a/tpl/bootstrap.php
+++ b/tpl/bootstrap.php
@@ -72,7 +72,7 @@ endif;
 ?>
 		<script type="text/javascript" data-cfasync="false" src="js/purify-2.2.7.js" integrity="sha512-7Ka1I/nJuR2CL8wzIS5PJS4HgEMd0HJ6kfAl6fFhwFBB27rhztFbe0tS+Ex+Qg+5n4nZIT4lty4k4Di3+X9T4A==" crossorigin="anonymous"></script>
 		<script type="text/javascript" data-cfasync="false" src="js/legacy.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-LYos+qXHIRqFf5ZPNphvtTB0cgzHUizu2wwcOwcwz/VIpRv9lpcBgPYz4uq6jx0INwCAj6Fbnl5HoKiLufS2jg==" crossorigin="anonymous"></script>
-		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-/7gEqgCgQA9cgLUf5rBj+nfJptVm92LAYxvBN7mmeG+xkq9lQ+eY7DWQY47TGXXA7HqkCwk7424mnBiYZvCAUQ==" crossorigin="anonymous"></script>
+		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-BAc7Bcew+3hIQ84bibDMcMjr5ShiJU0jUnHX4x14ySB7yq/dh+LsbMobBOCBJbOWsndK0sDxpIeA3kWMW0/lrQ==" crossorigin="anonymous"></script>
 		<!-- icon -->
 		<link rel="apple-touch-icon" href="<?php echo I18n::encode($BASEPATH); ?>img/apple-touch-icon.png" sizes="180x180" />
 		<link rel="icon" type="image/png" href="img/favicon-32x32.png" sizes="32x32" />

--- a/tpl/page.php
+++ b/tpl/page.php
@@ -50,7 +50,7 @@ endif;
 ?>
 		<script type="text/javascript" data-cfasync="false" src="js/purify-2.2.7.js" integrity="sha512-7Ka1I/nJuR2CL8wzIS5PJS4HgEMd0HJ6kfAl6fFhwFBB27rhztFbe0tS+Ex+Qg+5n4nZIT4lty4k4Di3+X9T4A==" crossorigin="anonymous"></script>
 		<script type="text/javascript" data-cfasync="false" src="js/legacy.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-LYos+qXHIRqFf5ZPNphvtTB0cgzHUizu2wwcOwcwz/VIpRv9lpcBgPYz4uq6jx0INwCAj6Fbnl5HoKiLufS2jg==" crossorigin="anonymous"></script>
-		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-/7gEqgCgQA9cgLUf5rBj+nfJptVm92LAYxvBN7mmeG+xkq9lQ+eY7DWQY47TGXXA7HqkCwk7424mnBiYZvCAUQ==" crossorigin="anonymous"></script>
+		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-BAc7Bcew+3hIQ84bibDMcMjr5ShiJU0jUnHX4x14ySB7yq/dh+LsbMobBOCBJbOWsndK0sDxpIeA3kWMW0/lrQ==" crossorigin="anonymous"></script>
 		<!-- icon -->
 		<link rel="apple-touch-icon" href="img/apple-touch-icon.png?<?php echo rawurlencode($VERSION); ?>" sizes="180x180" />
 		<link rel="icon" type="image/png" href="img/favicon-32x32.png?<?php echo rawurlencode($VERSION); ?>" sizes="32x32" />


### PR DESCRIPTION
This PR fixes #472 

## Changes
* adds the `secure` flag to the cookie when set in JS and refreshed in PHP

This tells browsers only to transmit the cookie in a secure context. Apart from HTTPS, at least in Firefox, this also applies to local testing as 127.0.0.1 / localhost / ::1 are considered secure even when accessed over plain HTTP.

For live sites, this means that if they enable the `languageselection` feature, they do have to offer HTTPS or other secure means - would be interesting to know if e.g. tor is counted as such.