### PR TITLE
Opt-Out of Google FloC

### DIFF
--- a/lib/Controller.php
+++ b/lib/Controller.php
@@ -349,6 +349,7 @@ class Controller
         header('Cross-Origin-Resource-Policy: same-origin');
         header('Cross-Origin-Embedder-Policy: require-corp');
         header('Cross-Origin-Opener-Policy: same-origin');
+        header('Permissions-Policy: interest-cohort=()');
         header('Referrer-Policy: no-referrer');
         header('X-Content-Type-Options: nosniff');
         header('X-Frame-Options: deny');


### PR DESCRIPTION
This PR is one of several ways to address a new feature being rolled out in Google Chrome called FloC. It is intended to be a more privacy oriented tracking mechanism then what was previously possible with (now phased out) third-party cookies. IMHO this is still a tracking mechanism, even if it is supposed to be more benign then other tracking methods. Further background on FloC can be found at the [EFF](https://www.eff.org/deeplinks/2021/03/googles-floc-terrible-idea), [W3C](https://wicg.github.io/floc/) or [Google](https://github.com/google/ads-privacy/blob/master/proposals/FLoC/FLOC-Whitepaper-Google.pdf), to offer some different view points.

Things this project could do about FloC:
1. Not our department: We ignore it
2. Opt-Out: We set the [HTTP header](https://www.w3.org/TR/permissions-policy-1/) that is supposed to [disable this feature in Chrome](https://developer.chrome.com/blog/floc/#how-can-websites-opt-out-of-the-floc-computation) - this is what this PR implements
3. A more brutal reaction: We detect the Chrome user agent and suggest to use a different browser, for example redirecting these to https://www.floc-away-from-chrome.com/ - this would be similar to how older Internet Explorer versions got treated by PrivateBin before we switched to use feature detection to display more granular errors.

If this PR (=option 2) is accepted, I'd also like to implement this header for privatebin.info & .net.