### PR TITLE
more flexible & robust configuration file path handling

### DIFF
--- a/cfg/conf.sample.php
+++ b/cfg/conf.sample.php
@@ -161,7 +161,7 @@ class = Filesystem
 [model_options]
 dir = PATH "data"
 
-[model]
+;[model]
 ; example of a Google Cloud Storage configuration
 ;class = GoogleCloudStorage
 ;[model_options]

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -101,15 +101,20 @@ class Configuration
      */
     public function __construct()
     {
-        $config     = array();
-        $basePath   = (getenv('CONFIG_PATH') !== false ? getenv('CONFIG_PATH') : PATH . 'cfg') . DIRECTORY_SEPARATOR;
-        $configFile = $basePath . 'conf.php';
-
-        if (is_readable($configFile)) {
-            $config = parse_ini_file($configFile, true);
-            foreach (array('main', 'model', 'model_options') as $section) {
-                if (!array_key_exists($section, $config)) {
-                    throw new Exception(I18n::_('PrivateBin requires configuration section [%s] to be present in configuration file.', $section), 2);
+        $config = $basePaths = array();
+        $configPath = getenv('CONFIG_PATH');
+        if ($configPath !== false && !empty($configPath)) {
+            $basePaths[] = $configPath;
+        }
+        $basePaths[] = PATH . 'cfg';
+        foreach ($basePaths as $basePath) {
+            $configFile = $basePath . DIRECTORY_SEPARATOR . 'conf.php';
+            if (is_readable($configFile)) {
+                $config = parse_ini_file($configFile, true);
+                foreach (array('main', 'model', 'model_options') as $section) {
+                    if (!array_key_exists($section, $config)) {
+                        throw new Exception(I18n::_('PrivateBin requires configuration section [%s] to be present in configuration file.', $section), 2);
+                    }
                 }
             }
         }

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -101,7 +101,8 @@ class Configuration
      */
     public function __construct()
     {
-        $config     = $basePaths     = array();
+        $basePaths  = array();
+        $config     = array();
         $configPath = getenv('CONFIG_PATH');
         if ($configPath !== false && !empty($configPath)) {
             $basePaths[] = $configPath;

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -101,7 +101,7 @@ class Configuration
      */
     public function __construct()
     {
-        $config = $basePaths = array();
+        $config     = $basePaths     = array();
         $configPath = getenv('CONFIG_PATH');
         if ($configPath !== false && !empty($configPath)) {
             $basePaths[] = $configPath;
@@ -116,6 +116,7 @@ class Configuration
                         throw new Exception(I18n::_('PrivateBin requires configuration section [%s] to be present in configuration file.', $section), 2);
                     }
                 }
+                break;
             }
         }
 


### PR DESCRIPTION
Over with the docker container image project, we did now get bitten twice (https://github.com/PrivateBin/docker-nginx-fpm-alpine/issues/50 & https://github.com/PrivateBin/docker-nginx-fpm-alpine/issues/62) by a combination of common settings in the PHP stack and this branch attempts to alleviate that for future releases.

## Details

Because of many ([[1]](https://searchsecurity.techtarget.com/blog/Security-Bytes/Environment-variables-Should-they-be-considered-harmful), [[2]](https://en.wikipedia.org/wiki/Shellshock_(software_bug)), [[3]](https://owasp.org/www-community/attacks/Buffer_Overflow_via_Environment_Variables)) past issues around environment variables being a source of security vulnerabilities, many components used with our application limit them from being passed down into sub-processes inadvertently. Specifically, php-fpm, s6-overlay and s6-linux-init will by default clear the environment.

The `CONFIG_PATH` environment variable handling got introduced in #553. The intent was to make it possible to provide a different location for configuration files from the data or for hosting multiple instances with different configurations on the same software stack.

When this is used with php-fpm, that service needs to be told to pass down that variable from it's environment or a different php-fpm configuration would need to be written for each privatebin installation (see [example configuration](https://github.com/PrivateBin/docker-nginx-fpm-alpine/blob/9e7cc388b770a5a7f6e508bbec5048630508f7be/etc/php8/php-fpm.d/zz-docker.conf#L19) of our container image). Unfortunately, when done this way and the variable is not set, php-fpm will set it to an empty string. With the current implementation that means that the file gets searched for in the root directory and when not found it doesn't fall back to search the default location and so the default configuration values apply instead.

## Changes
* only consider the `CONFIG_PATH` environment variable, if non-empty, so it won't fall back to search in `/` (except if it got set to `/` explicitly)
* fall back to search in `PATH` (as defined in the index.php), if `CONFIG_PATH` doesn't contain a readable configuration file

This change will avoid some of the pitfalls and let's us [remove a workaround line](https://github.com/PrivateBin/docker-nginx-fpm-alpine/blob/9e7cc388b770a5a7f6e508bbec5048630508f7be/Dockerfile#L8) in the container image, once this change gets included in a future privatebin release.

Please review and let me know of any further improvements that could be made on this part of the logic.