### PR TITLE
Also test PHP 8.0 and 8.1/8.2 pre-releases in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['5.6', '7.0', '7.1', '7.2', '7.3', '7.4']
+        php-versions: ['5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
     name: PHP ${{ matrix.php-versions }} unit tests on ${{ matrix.operating-system }}
     steps:
     - name: Checkout


### PR DESCRIPTION
According to https://github.com/shivammathur/setup-php#tada-php-support the GitHub Action.

Of course the pre-releases are just a try, but we'll see how that works. Only the 8.0 should definitively be added.

Fixes https://github.com/PrivateBin/PrivateBin/issues/707 (?)