### PR TITLE
Cache PHP modules, composer and NodeJS stuff in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,7 +45,7 @@ jobs:
       with:
         path: ${{ steps.composer-cache.outputs.dir }}
         key: ${{ runner.os }}-composer-${{ steps.get-date.outputs.date }}-${{ hashFiles('**/composer.lock') }}
-        restore-keys: ${{ runner.os }}-composer-
+        restore-keys: ${{ runner.os }}-composer-${{ steps.get-date.outputs.date }}-
     
     # composer
     - name: Setup PHPunit

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
     name: PHP ${{ matrix.php-versions }} unit tests on ${{ matrix.operating-system }}
     env:
       extensions: gd, sqlite3
-      extensions-cache-key: ${{ runner.os }}-phpextensions
+      extensions-cache-key-name: phpextensions
       
     steps:
     
@@ -36,14 +36,14 @@ jobs:
       with:
         php-version: ${{ matrix.php-versions }}
         extensions: ${{ env.extensions }}
-        key: ${{ env.extensions-cache-key }}
+        key: ${{ runner.os }}-${{ env.extensions-cache-key }}
 
     - name: Cache extensions
       uses: actions/cache@v2
       with:
         path: ${{ steps.extcache.outputs.dir }}
         key: ${{ steps.extcache.outputs.key }}
-        restore-keys: ${{ env.extensions-cache-key }}
+        restore-keys: ${{ runner.os }}-${{ env.extensions-cache-key }}
       
     - name: Setup PHP
       uses: shivammathur/setup-php@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,6 +2,7 @@ name: Tests
 on: [push]
 
 jobs:
+
   Composer:
     runs-on: ubuntu-latest
     steps:
@@ -11,6 +12,7 @@ jobs:
       run: composer validate
     - name: Install dependencies
       run: composer install --prefer-dist --no-dev
+      
   PHPunit:
     runs-on: ubuntu-latest
     strategy:
@@ -19,7 +21,10 @@ jobs:
     name: PHP ${{ matrix.php-versions }} unit tests on ${{ matrix.operating-system }}
     env:
       extensions: gd, sqlite3
+      
     steps:
+    
+    # let's get started!
     - name: Checkout
       uses: actions/checkout@v2
       
@@ -48,9 +53,11 @@ jobs:
     # composer cache
     - name: Remove composer lock
       run: rm composer.lock
+      
     - name: Get composer cache directory
       id: composer-cache
       run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+    
     # http://man7.org/linux/man-pages/man1/date.1.html
     # https://github.com/actions/cache#creating-a-cache-key
     - name: Get Date
@@ -58,6 +65,7 @@ jobs:
       run: |
         echo "::set-output name=date::$(/bin/date -u "+%Y%m%d")"
       shell: bash
+    
     - name: Cache dependencies
       uses: actions/cache@v2
       with:
@@ -75,20 +83,26 @@ jobs:
     - name: Run unit tests
       run: ../vendor/bin/phpunit --no-coverage
       working-directory: tst
+      
   Mocha:
     runs-on: ubuntu-latest
     steps:
+    
     - name: Checkout
       uses: actions/checkout@v2
+      
     - name: Setup Node
       uses: actions/setup-node@v1
       with:
         node-version: '12'
+        
     - name: Setup Mocha
       run: npm install -g mocha
+      
     - name: Setup Node modules
       run: npm install
       working-directory: js
+      
     - name: Run unit tests
       run: mocha
       working-directory: js

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -74,9 +74,10 @@ jobs:
         key: ${{ runner.os }}-composer-${{ steps.get-date.outputs.date }}-${{ hashFiles('**/composer.json') }}
         restore-keys: ${{ runner.os }}-composer-${{ steps.get-date.outputs.date }}-
     
-    # composer
+    # composer installation
     - name: Setup PHPunit
       run: composer install -n
+
     - name: Install Google Cloud Storage
       run: composer require google/cloud-storage
     

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,15 +17,33 @@ jobs:
       matrix:
         php-versions: ['5.6', '7.0', '7.1', '7.2', '7.3', '7.4']
     name: PHP ${{ matrix.php-versions }} unit tests on ${{ matrix.operating-system }}
+    env:
+      extensions: gd, sqlite3
     steps:
     - name: Checkout
       uses: actions/checkout@v2
+      
+    # cache PHP extensions
+    - name: Setup cache environment
+      id: extcache
+      uses: shivammathur/cache-extensions@v1
+      with:
+        php-version: ${{ matrix.php-versions }}
+        extensions: ${{ env.extensions }}
+        key: ${{ runner.os }}-phpextensions
+
+    - name: Cache extensions
+      uses: actions/cache@v2
+      with:
+        path: ${{ steps.extcache.outputs.dir }}
+        key: ${{ steps.extcache.outputs.key }}
+        restore-keys: ${{ env.extensions }}
       
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
       with:
         php-version: ${{ matrix.php-versions }}
-        extensions: gd, sqlite3
+        extensions: ${{ env.extensions }}
       
     # composer cache
     - name: Remove composer lock

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,17 +20,40 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
+      
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
       with:
         php-version: ${{ matrix.php-versions }}
         extensions: gd, sqlite3
+      
+    # composer cache
     - name: Remove composer lock
       run: rm composer.lock
+    - name: Get composer cache directory
+      id: composer-cache
+      run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+    # http://man7.org/linux/man-pages/man1/date.1.html
+    # https://github.com/actions/cache#creating-a-cache-key
+    - name: Get Date
+      id: get-date
+      run: |
+        echo "::set-output name=date::$(/bin/date -u "+%Y%m%d")"
+      shell: bash
+    - name: Cache dependencies
+      uses: actions/cache@v2
+      with:
+        path: ${{ steps.composer-cache.outputs.dir }}
+        key: ${{ runner.os }}-composer-${{ steps.get-date.outputs.date }}-${{ hashFiles('**/composer.lock') }}
+        restore-keys: ${{ runner.os }}-composer-
+    
+    # composer
     - name: Setup PHPunit
       run: composer install -n
     - name: Install Google Cloud Storage
       run: composer require google/cloud-storage
+    
+    # testing
     - name: Run unit tests
       run: ../vendor/bin/phpunit --no-coverage
       working-directory: tst

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,6 +21,7 @@ jobs:
     name: PHP ${{ matrix.php-versions }} unit tests on ${{ matrix.operating-system }}
     env:
       extensions: gd, sqlite3
+      extensions-cache-key: ${{ runner.os }}-phpextensions
       
     steps:
     
@@ -35,14 +36,14 @@ jobs:
       with:
         php-version: ${{ matrix.php-versions }}
         extensions: ${{ env.extensions }}
-        key: ${{ runner.os }}-phpextensions
+        key: ${{ env.extensions-cache-key }}
 
     - name: Cache extensions
       uses: actions/cache@v2
       with:
         path: ${{ steps.extcache.outputs.dir }}
         key: ${{ steps.extcache.outputs.key }}
-        restore-keys: ${{ env.extensions }}
+        restore-keys: ${{ env.extensions-cache-key }}
       
     - name: Setup PHP
       uses: shivammathur/setup-php@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -97,7 +97,7 @@ jobs:
       with:
         node-version: '12'
         cache: 'npm'
-        cache-dependency-path: 'js/package-lock.json'
+        cache-dependency-path: 'js/package.json'
         
     - name: Setup Mocha
       run: npm install -g mocha

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,7 +44,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ${{ steps.composer-cache.outputs.dir }}
-        key: ${{ runner.os }}-composer-${{ steps.get-date.outputs.date }}-${{ hashFiles('**/composer.lock') }}
+        key: ${{ runner.os }}-composer-${{ steps.get-date.outputs.date }}-${{ hashFiles('**/composer.json') }}
         restore-keys: ${{ runner.os }}-composer-${{ steps.get-date.outputs.date }}-
     
     # composer

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -93,9 +93,11 @@ jobs:
       uses: actions/checkout@v2
       
     - name: Setup Node
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v2
       with:
         node-version: '12'
+        cache: 'npm'
+        cache-dependency-path: 'js/package-lock.json'
         
     - name: Setup Mocha
       run: npm install -g mocha


### PR DESCRIPTION
Especially the GCM stuff may be quite large, so caching may be a good idea.

I tried following https://github.com/shivammathur/setup-php#cache-composer-dependencies
