### PR TITLE
Add CI for automatic PHP8 updates

### DIFF
--- a/.github/workflows/refresh-php8.yml
+++ b/.github/workflows/refresh-php8.yml
@@ -1,0 +1,40 @@
+# This is a basic workflow to help you get started with Actions
+
+name: Refresh PHP 8 branch
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the master branch
+  push:
+    branches: [ master ]
+    
+  schedule:
+      - cron: '42 2 * * *'  
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      - name: Checkout php8 branch 
+        run: git checkout php8
+
+      - name: Merge master changes into php8
+        run: git merge master
+      
+      - name: Push new changes
+        uses: github-actions-x/commit@v2.8
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          push-branch: 'php8'
+


### PR DESCRIPTION
Adds a simple CI for pushing the master branches changes to the php8 branch.

Useful/discussed for https://github.com/PrivateBin/PrivateBin/issues/707
