### PR TITLE
Fix PHP refresh pipeline merge

### DIFF
--- a/.github/workflows/refresh-php8.yml
+++ b/.github/workflows/refresh-php8.yml
@@ -22,7 +22,7 @@ jobs:
           fetch-depth: 0
 
       - name: Merge master changes into php8
-        run: git merge master
+        run: git merge origin/master
       
       - name: Push new changes
         uses: github-actions-x/commit@v2.8


### PR DESCRIPTION
See https://github.com/PrivateBin/PrivateBin/pull/847#issuecomment-942580850

Now merging the origin as master is not yet pulled.

