### PR TITLE
Set GitHub Bot as author for PHP8 merge commits

### DIFF
--- a/.github/workflows/refresh-php8.yml
+++ b/.github/workflows/refresh-php8.yml
@@ -27,6 +27,8 @@ jobs:
       - name: Push new changes
         uses: github-actions-x/commit@v2.8
         with:
+          name: github-actions[bot]
+          email: 41898282+github-actions[bot]@users.noreply.github.com
           github-token: ${{ secrets.GITHUB_TOKEN }}
           push-branch: 'php8'
 


### PR DESCRIPTION
Follow-up of https://github.com/PrivateBin/PrivateBin/pull/848

Let's see whether this finally fixes it… :sweat_smile: 
