### PR TITLE
php warning in templates, fixes #875

### DIFF
--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -44,7 +44,7 @@ class Configuration
             'fileupload'               => false,
             'burnafterreadingselected' => false,
             'defaultformatter'         => 'plaintext',
-            'syntaxhighlightingtheme'  => null,
+            'syntaxhighlightingtheme'  => '',
             'sizelimit'                => 10485760,
             'template'                 => 'bootstrap',
             'info'                     => 'More information on the <a href=\'https://privatebin.info/\'>project page</a>.',


### PR DESCRIPTION
While I couldn't reproduce this myself, we have a report that former default setting of `null` caused the `strlen()` in both templates to cause a warning under PHP 8.1 or with stricter PHP configurations.