### PR TITLE
allow for Lojban (jbo) to be the "any" language pick

### DIFF
--- a/tst/I18nTest.php
+++ b/tst/I18nTest.php
@@ -145,7 +145,7 @@ class I18nTest extends PHPUnit_Framework_TestCase
     {
         $_SERVER['HTTP_ACCEPT_LANGUAGE'] = '*';
         I18n::loadTranslations();
-        $this->assertTrue(strlen(I18n::_('en')) == 2, 'browser language any');
+        $this->assertTrue(strlen(I18n::_('en')) >= 2, 'browser language any');
     }
 
     public function testVariableInjection()


### PR DESCRIPTION
The available language list is generated by reading the i18n directory
descriptor one entry at a time, so if the jbo.json happens to be the first
file written to the directory it will be on top of the list and get picked.
https://github.com/PrivateBin/PrivateBin/blob/6307c01cc66df165207bd92a98e3158146c70c82/lib/I18n.php#L196-L199

I have to assume that scrutinizer has started hitting that case, while I failed to reproduce it locally.

This is testing for an edge case. Most users browsers won't be set to "any" language, but we need
to cover this allowed and valid use case in the language detection. Or at least not fail badly.