### PR TITLE
CORS support: enable cors by properly responding to CORS-preflight

### DIFF
--- a/lib/Controller.php
+++ b/lib/Controller.php
@@ -139,7 +139,7 @@ class Controller
         }
 
         // output JSON or HTML
-        if ($this->_request->isJsonApiCall()) {
+        if ($this->_request->isJsonApiCall() || $this->_request->isCorsPreflightCall()) {
             header('Content-type: ' . Request::MIME_JSON);
             header('Access-Control-Allow-Origin: *');
             header('Access-Control-Allow-Methods: GET, POST, PUT, DELETE');

--- a/lib/Request.php
+++ b/lib/Request.php
@@ -73,6 +73,14 @@ class Request
     private $_isJsonApi = false;
 
     /**
+     * If we are in a CORS-preflight fetch context
+     *
+     * @access private
+     * @var bool
+     */
+    private $_isCorsPreflight = false;
+
+    /**
      * Return the paste ID of the current paste.
      *
      * @access private
@@ -119,6 +127,7 @@ class Request
             case 'OPTIONS':
                 // likely CORS-preflight
                 $this->_operation = 'cors-preflight';
+                break;
             default:
                 $this->_params = $_GET;
         }
@@ -264,9 +273,9 @@ class Request
     private function _detectCorsPreflightFetch()
     {
         $hasSecFetchMode = array_key_exists('HTTP_SEC_FETCH_MODE', $_SERVER);
-        $secFetchMode = $secFetchMode ? SERVER['HTTP_SEC_FETCH_MODE'] : '';
+        $secFetchMode = $hasSecFetchMode ? $_SERVER['HTTP_SEC_FETCH_MODE'] : '';
         $hasSecFetchSite = array_key_exists('HTTP_SEC_FETCH_SITE', $_SERVER);
-        $secFetchSite = $secFetchSite ? SERVER['HTTP_SEC_FETCH_SITE'] : '';
+        $secFetchSite = $hasSecFetchSite ? $_SERVER['HTTP_SEC_FETCH_SITE'] : '';
         // simplest case
         if (
             ((mb_strtolower($secFetchMode) === 'cors') ||
@@ -274,8 +283,7 @@ class Request
             (array_key_exists('HTTP_ACCESS_CONTROL_REQUEST_METHOD', $_SERVER))
         ) {
             return true;
-        }
-        else {
+        } else {
             return false;
         }
     }


### PR DESCRIPTION
respond to OPTIONS method requests having cors-preflight indicators with cors policy.


Attempts to fix #889. Please verify. 

## Changes

- Added function to rudimentarily(?) detect [CORS-preflight]
- Created new request operation mode `cors-preflight` 
  (does nothing special, but indicates not to do anything else)
- Send CORS Access-Control-* headers identical to JsonApiCall reponses'

[CORS-preflight]: https://developer.mozilla.org/en-US/docs/Glossary/Preflight_request

## ToDo

* [x] Fix anything brought up during review or automatic test
* [ ] Provide any clarification sought during review
* [ ] Add more comments in the code if required

## Notice

This is my first time writing any PHP <sup>[disclaimer]</sup>. Please be kind.

[disclaimer]: data:text/plain,"Just syntactic pattern matching and search engine help tbh. Never formally/informally learnt it. 🤞"