### PR TITLE
Allow short subnet notation

### DIFF
--- a/cfg/conf.sample.php
+++ b/cfg/conf.sample.php
@@ -135,7 +135,7 @@ markdown = "Markdown"
 ; Set this to 0 to disable rate limiting.
 limit = 10
 
-; (optional) Set IPs adresses (v4 or v6) or subnets (CIDR) which are exempted
+; (optional) Set IPs addresses (v4 or v6) or subnets (CIDR) which are exempted
 ; from the rate-limit. Invalid IPs will be ignored. If multiple values are to
 ; be exempted, the list needs to be comma separated. Leave unset to disable
 ; exemptions.

--- a/lib/Persistence/TrafficLimiter.php
+++ b/lib/Persistence/TrafficLimiter.php
@@ -146,7 +146,10 @@ class TrafficLimiter extends AbstractPersistence
             $ipRange = trim($ipRange);
         }
         $address = Factory::parseAddressString($_SERVER[self::$_ipKey]);
-        $range   = Factory::parseRangeString($ipRange, ParseStringFlag::IPV4_MAYBE_NON_DECIMAL);
+        $range   = Factory::parseRangeString(
+            $ipRange,
+            ParseStringFlag::IPV4_MAYBE_NON_DECIMAL | ParseStringFlag::IPV4SUBNET_MAYBE_COMPACT | ParseStringFlag::IPV4ADDRESS_MAYBE_NON_QUAD_DOTTED
+        );
 
         // address could not be parsed, we might not be in IP space and try a string comparison instead
         if (is_null($address)) {

--- a/tst/Persistence/TrafficLimiterTest.php
+++ b/tst/Persistence/TrafficLimiterTest.php
@@ -57,7 +57,7 @@ class TrafficLimiterTest extends PHPUnit_Framework_TestCase
 
     public function testTrafficLimitExempted()
     {
-        TrafficLimiter::setExempted('1.2.3.4,10.10.10.0/24,2001:1620:2057::/48');
+        TrafficLimiter::setExempted('1.2.3.4,10.10.10/24,2001:1620:2057::/48');
         $_SERVER['REMOTE_ADDR'] = '127.0.0.1';
         $this->assertTrue(TrafficLimiter::canPass(), 'first request may pass');
         try {
@@ -85,7 +85,7 @@ class TrafficLimiterTest extends PHPUnit_Framework_TestCase
 
     public function testTrafficLimitCreators()
     {
-        TrafficLimiter::setCreators('1.2.3.4,10.10.10.0/24,2001:1620:2057::/48');
+        TrafficLimiter::setCreators('1.2.3.4,10.10.10/24,2001:1620:2057::/48');
         $_SERVER['REMOTE_ADDR'] = '127.0.0.1';
         try {
             $this->assertFalse(TrafficLimiter::canPass(), 'expected an exception');


### PR DESCRIPTION
Minor improvement to the trafficlimiter.

## Changes
* enable support for short CIDR subnet notation, as had been documented in conf.sample.php
* fix typo in conf.sample.php