### PR TITLE
Replace FLoC Header with browsing-topics header

### DIFF
--- a/lib/Controller.php
+++ b/lib/Controller.php
@@ -342,6 +342,7 @@ class Controller
         header('Cross-Origin-Resource-Policy: same-origin');
         header('Cross-Origin-Embedder-Policy: require-corp');
         header('Cross-Origin-Opener-Policy: same-origin');
+        header('Permissions-Policy: browsing-topics=()');
         header('Referrer-Policy: no-referrer');
         header('X-Content-Type-Options: nosniff');
         header('X-Frame-Options: deny');

--- a/lib/Controller.php
+++ b/lib/Controller.php
@@ -342,7 +342,6 @@ class Controller
         header('Cross-Origin-Resource-Policy: same-origin');
         header('Cross-Origin-Embedder-Policy: require-corp');
         header('Cross-Origin-Opener-Policy: same-origin');
-        header('Permissions-Policy: interest-cohort=()');
         header('Referrer-Policy: no-referrer');
         header('X-Content-Type-Options: nosniff');
         header('X-Frame-Options: deny');


### PR DESCRIPTION
Sorry guys but you are a bit late to the party. 
Google [announced](https://blog.google/products/chrome/get-know-new-topics-api-privacy-sandbox/) in January that it is [discontinuing FLoC](https://www.theregister.com/2022/01/26/google_floc_topics/?td=keepreading-top) and replacing it with Privacy Sandbox.

This PR Removes the interest-cohort setting from the Permissions-Policy header.