### PR TITLE
Avoid SUPER privilege when setting the sql_mode for MariaDB/MySQL, fixes #919

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # PrivateBin version history
 
+  * **1.4.1 (not yet released)**
+    * CHANGED: Avoid `SUPER` privilege for setting the `sql_mode` for MariaDB/MySQL (#919)
   * **1.4 (2022-04-09)**
     * ADDED: Translations for Corsican, Estonian, Finnish and Lojban
     * ADDED: new HTTP headers improving security (#765)

--- a/lib/Data/Database.php
+++ b/lib/Data/Database.php
@@ -100,7 +100,7 @@ class Database extends AbstractData
             // MySQL uses backticks to quote identifiers by default,
             // tell it to expect ANSI SQL double quotes
             if (self::$_type === 'mysql' && defined('PDO::MYSQL_ATTR_INIT_COMMAND')) {
-                $options['opt'][PDO::MYSQL_ATTR_INIT_COMMAND] = "SET sql_mode='ANSI_QUOTES'";
+                $options['opt'][PDO::MYSQL_ATTR_INIT_COMMAND] = "SET SESSION sql_mode='ANSI_QUOTES'";
             }
             $tableQuery = self::_getTableQuery(self::$_type);
             self::$_db  = new PDO(


### PR DESCRIPTION
This PR fixes #919, kudos to @devnull-hub-lab for reporting this.

## Changes
* Avoid `SUPER` privilege when setting the `sql_mode` for MariaDB/MySQL