### PR TITLE
addressing deprecation warnings in php 8.1

### DIFF
--- a/lib/Data/Database.php
+++ b/lib/Data/Database.php
@@ -277,9 +277,9 @@ class Database extends AbstractData
         }
 
         // support v1 attachments
-        if (array_key_exists('attachment', $paste) && strlen($paste['attachment'])) {
+        if (array_key_exists('attachment', $paste) && !empty($paste['attachment'])) {
             self::$_cache[$pasteid]['attachment'] = $paste['attachment'];
-            if (array_key_exists('attachmentname', $paste) && strlen($paste['attachmentname'])) {
+            if (array_key_exists('attachmentname', $paste) && !empty($paste['attachmentname'])) {
                 self::$_cache[$pasteid]['attachmentname'] = $paste['attachmentname'];
             }
         }
@@ -552,7 +552,7 @@ class Database extends AbstractData
             $position = $key + 1;
             if (is_int($parameter)) {
                 $statement->bindParam($position, $parameter, PDO::PARAM_INT);
-            } elseif (strlen($parameter) >= 4000) {
+            } elseif (is_string($parameter) && strlen($parameter) >= 4000) {
                 $statement->bindParam($position, $parameter, PDO::PARAM_STR, strlen($parameter));
             } else {
                 $statement->bindParam($position, $parameter);


### PR DESCRIPTION
I've enabled php 8.1 for the php8 unit test branch and got some deprecation errors I'd like to address, based on this: https://github.com/PrivateBin/PrivateBin/runs/6695868770

```
Deprecated: strlen(): Passing null to parameter #1 ($string) of type string is deprecated in lib/Data/Database.php on line 280 & 555
```