### PR TITLE
Add/enable Dependabot to keep dependencies up-to-date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  # src: https://github.com/marketplace/actions/build-and-push-docker-images#keep-up-to-date-with-github-dependabot
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  # Also keep PHP (Composer) dependencies up-to-date
+  # see: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
This enables dependabot and let's it/GitHub check for outdated dependencies automatically. See [their documentation for more information](https://docs.github.com/code-security/dependabot).

Enabled update checking via Dependabot for
* GitHub Actions for updates or in case you are going to use that (just my default)
* PHP aka Composer

We successfully use it [for our Docker container](https://github.com/PrivateBin/docker-nginx-fpm-alpine/blob/master/.github/dependabot.yml) and IMHO that has worked quite well, so IMHO, we can also use it here now.

<!-- This is a template for your Pull Request. This are just some suggestions for you. You do not have to use all of them. -->

<!-- If your PR fixes an issue, mention it here. You can also just copy the URL - GitHub will convert it for you.
If this PR fixes several issues, please prepend each issue url/number with the word "fix"/"fixes" or "close"/"closes" as this automatically closes the issues you mentioned when the PR is merged.
-->
