### PR TITLE
CREATE INDEX IF NOT EXISTS is not supported as of MySQL <= 8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
   * **1.4.1 (not yet released)**
     * ADDED: Translations for Turkish
     * CHANGED: Avoid `SUPER` privilege for setting the `sql_mode` for MariaDB/MySQL (#919)
+    * FIXED: Revert to CREATE INDEX without IF NOT EXISTS clauses, to support MySQL (#943)
+    * FIXED: Apply table prefix to indexes as well, to support multiple instances sharing a single database (#943)
   * **1.4 (2022-04-09)**
     * ADDED: Translations for Corsican, Estonian, Finnish and Lojban
     * ADDED: new HTTP headers improving security (#765)

--- a/lib/Data/Database.php
+++ b/lib/Data/Database.php
@@ -837,8 +837,9 @@ class Database extends AbstractData
                 end;'
             );
         } else {
+            // CREATE INDEX IF NOT EXISTS not supported as of MySQL <= 8.0
             self::$_db->exec(
-                'CREATE INDEX IF NOT EXISTS "comment_parent" ON "' .
+                'CREATE INDEX "comment_parent" ON "' .
                 self::_sanitizeIdentifier('comment') . '" ("pasteid")'
             );
         }
@@ -949,8 +950,9 @@ class Database extends AbstractData
                         self::_sanitizeIdentifier('comment') . '" ("dataid")'
                     );
                 }
+                // CREATE INDEX IF NOT EXISTS not supported as of MySQL <= 8.0
                 self::$_db->exec(
-                    'CREATE INDEX IF NOT EXISTS "comment_parent" ON "' .
+                    'CREATE INDEX "comment_parent" ON "' .
                     self::_sanitizeIdentifier('comment') . '" ("pasteid")'
                 );
                 // no break, continue with updates for 0.22 and later

--- a/lib/Data/Database.php
+++ b/lib/Data/Database.php
@@ -839,7 +839,8 @@ class Database extends AbstractData
         } else {
             // CREATE INDEX IF NOT EXISTS not supported as of MySQL <= 8.0
             self::$_db->exec(
-                'CREATE INDEX "comment_parent" ON "' .
+                'CREATE INDEX "' .
+                self::_sanitizeIdentifier('comment_parent') . '" ON "' .
                 self::_sanitizeIdentifier('comment') . '" ("pasteid")'
             );
         }
@@ -942,17 +943,20 @@ class Database extends AbstractData
                     );
                 } else {
                     self::$_db->exec(
-                        'CREATE UNIQUE INDEX IF NOT EXISTS "paste_dataid" ON "' .
+                        'CREATE UNIQUE INDEX IF NOT EXISTS "' .
+                        self::_sanitizeIdentifier('paste_dataid') . '" ON "' .
                         self::_sanitizeIdentifier('paste') . '" ("dataid")'
                     );
                     self::$_db->exec(
-                        'CREATE UNIQUE INDEX IF NOT EXISTS "comment_dataid" ON "' .
+                        'CREATE UNIQUE INDEX IF NOT EXISTS "' .
+                        self::_sanitizeIdentifier('comment_dataid') . '" ON "' .
                         self::_sanitizeIdentifier('comment') . '" ("dataid")'
                     );
                 }
                 // CREATE INDEX IF NOT EXISTS not supported as of MySQL <= 8.0
                 self::$_db->exec(
-                    'CREATE INDEX "comment_parent" ON "' .
+                    'CREATE INDEX "' .
+                    self::_sanitizeIdentifier('comment_parent') . '" ON "' .
                     self::_sanitizeIdentifier('comment') . '" ("pasteid")'
                 );
                 // no break, continue with updates for 0.22 and later

--- a/lib/Data/Database.php
+++ b/lib/Data/Database.php
@@ -837,7 +837,7 @@ class Database extends AbstractData
                 end;'
             );
         } else {
-            // CREATE INDEX IF NOT EXISTS not supported as of MySQL <= 8.0
+            // CREATE INDEX IF NOT EXISTS not supported as of Oracle MySQL <= 8.0
             self::$_db->exec(
                 'CREATE INDEX "' .
                 self::_sanitizeIdentifier('comment_parent') . '" ON "' .
@@ -953,7 +953,7 @@ class Database extends AbstractData
                         self::_sanitizeIdentifier('comment') . '" ("dataid")'
                     );
                 }
-                // CREATE INDEX IF NOT EXISTS not supported as of MySQL <= 8.0
+                // CREATE INDEX IF NOT EXISTS not supported as of Oracle MySQL <= 8.0
                 self::$_db->exec(
                     'CREATE INDEX "' .
                     self::_sanitizeIdentifier('comment_parent') . '" ON "' .


### PR DESCRIPTION
This PR fixes #943

## Changes
* revert to `CREATE INDEX` without `IF NOT EXISTS` clauses, to support MySQL

This issue didn't affect MariaDB, Postgres, SQLite (same code paths, different data types) or Oracle support (different logic in those areas).