### PR TITLE
chore: run tests with NodeJS 14

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -116,6 +116,6 @@ jobs:
       working-directory: js
       
     - name: Run unit tests
-      run: mocha
+      run: npm test
       working-directory: js
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -104,7 +104,7 @@ jobs:
     - name: Setup Node
       uses: actions/setup-node@v3
       with:
-        node-version: '12'
+        node-version: '14'
         cache: 'npm'
         cache-dependency-path: 'js/package.json'
         


### PR DESCRIPTION
I expect no stuff to break or so, so let's just try to use the current recommend LTS version. (v14 will also die at some time, but Fedora e.g. still seems to use it for now by default. Likely we may upgrade soon even more.)

Ref https://nodejs.org/en/about/releases/

