### PR TITLE
GCS Uniform ACL Support

### DIFF
--- a/cfg/conf.sample.php
+++ b/cfg/conf.sample.php
@@ -175,6 +175,7 @@ dir = PATH "data"
 ;[model_options]
 ;bucket = "my-private-bin"
 ;prefix = "pastes"
+;uniformacl = false
 
 ;[model]
 ; example of DB configuration for MySQL

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -153,8 +153,9 @@ class Configuration
                 )
             ) {
                 $values = array(
-                    'bucket' => getenv('PRIVATEBIN_GCS_BUCKET') ? getenv('PRIVATEBIN_GCS_BUCKET') : null,
-                    'prefix' => 'pastes',
+                    'bucket'     => getenv('PRIVATEBIN_GCS_BUCKET') ? getenv('PRIVATEBIN_GCS_BUCKET') : null,
+                    'prefix'     => 'pastes',
+                    'uniformacl' => false,
                 );
             }
 

--- a/lib/Data/GoogleCloudStorage.php
+++ b/lib/Data/GoogleCloudStorage.php
@@ -112,13 +112,18 @@ class GoogleCloudStorage extends AbstractData
      */
     private function _upload($key, $payload)
     {
+        $metadata = array_key_exists('meta', $payload) ? $payload['meta'] : array();
+        unset($metadata['attachment'], $metadata['attachmentname'], $metadata['salt']);
+        foreach ($metadata as $k => $v) {
+            $metadata[$k] = strval($v);
+        }
         try {
             $data = array(
                 'name'          => $key,
                 'chunkSize'     => 262144,
                 'metadata'      => array(
                     'content-type' => 'application/json',
-                    'metadata'     => $payload,
+                    'metadata'     => $metadata,
                 ),
             );
             if (!self::$_uniformacl) {


### PR DESCRIPTION
This PR aims to add support to GCS Buckets configured to use Uniform ACL.

List of changes:
- Added a model_options parameter for model `GoogleCloudStorage` named `uniformacl` defaulting to `false`. Aims to add support for GCS buckets using unform ACL