### PR TITLE
PHP 8.2 compatibility: Use of "self" in callables is deprecated

### DIFF
--- a/lib/Data/Database.php
+++ b/lib/Data/Database.php
@@ -584,7 +584,7 @@ class Database extends AbstractData
             // workaround for https://bugs.php.net/bug.php?id=46728
             $result = array();
             while ($row = $statement->fetch(PDO::FETCH_ASSOC)) {
-                $result[] = array_map('self::_sanitizeClob', $row);
+                $result[] = array_map('PrivateBin\Data\Database::_sanitizeClob', $row);
             }
         } else {
             $result = $statement->fetchAll(PDO::FETCH_ASSOC);
@@ -593,7 +593,7 @@ class Database extends AbstractData
         if (self::$_type === 'oci' && is_array($result)) {
             // returned CLOB values are streams, convert these into strings
             $result = $firstOnly ?
-                array_map('self::_sanitizeClob', $result) :
+                array_map('PrivateBin\Data\Database::_sanitizeClob', $result) :
                 $result;
         }
         return $result;

--- a/lib/Data/Filesystem.php
+++ b/lib/Data/Filesystem.php
@@ -351,7 +351,7 @@ class Filesystem extends AbstractData
         $pastes     = array();
         $firstLevel = array_filter(
             scandir(self::$_path),
-            'self::_isFirstLevelDir'
+            'PrivateBin\Data\Filesystem::_isFirstLevelDir'
         );
         if (count($firstLevel) > 0) {
             // try at most 10 times the $batchsize pastes before giving up
@@ -359,7 +359,7 @@ class Filesystem extends AbstractData
                 $firstKey    = array_rand($firstLevel);
                 $secondLevel = array_filter(
                     scandir(self::$_path . DIRECTORY_SEPARATOR . $firstLevel[$firstKey]),
-                    'self::_isSecondLevelDir'
+                    'PrivateBin\Data\Filesystem::_isSecondLevelDir'
                 );
 
                 // skip this folder in the next checks if it is empty

--- a/lib/I18n.php
+++ b/lib/I18n.php
@@ -84,7 +84,7 @@ class I18n
      */
     public static function _($messageId)
     {
-        return forward_static_call_array('self::translate', func_get_args());
+        return forward_static_call_array('PrivateBin\I18n::translate', func_get_args());
     }
 
     /**


### PR DESCRIPTION
While fixing the php8 unit testing branch, which broke with the recently introduced new unit tests in master, I've experimentally enabled PHP 8.2 and got lot's of deprecation warnings, that phpunit treats as errors (which I kinda like):

> Warning: PHP Deprecated:  Use of "self" in callables is deprecated in /home/runner/work/PrivateBin/PrivateBin/lib/I18n.php on line 87
> Warning: PHP Deprecated:  Use of "self" in callables is deprecated in /home/runner/work/PrivateBin/PrivateBin/lib/Data/Filesystem.php on line 360

-- https://github.com/PrivateBin/PrivateBin/actions/runs/3318278413/jobs/5482047185

This branch should fix this in a backwards compatible manner (as in, it works from PHP 5.6 - 8.2, which we currently support).