### PR TITLE
handle github actions deprecation warnings

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,14 +65,13 @@ jobs:
       
     - name: Get composer cache directory
       id: composer-cache
-      run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+      run: echo "{dir}={$(composer config cache-files-dir)}" >> $GITHUB_OUTPUT
     
     # http://man7.org/linux/man-pages/man1/date.1.html
     # https://github.com/actions/cache#creating-a-cache-key
     - name: Get Date
       id: get-date
-      run: |
-        echo "::set-output name=date::$(/bin/date -u "+%Y%m%d")"
+      run: echo "{date}={$(/bin/date -u "+%Y%m%d")}" >> $GITHUB_OUTPUT
       shell: bash
     
     - name: Cache dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,13 +65,13 @@ jobs:
       
     - name: Get composer cache directory
       id: composer-cache
-      run: echo "{dir}={$(composer config cache-files-dir)}" >> $GITHUB_OUTPUT
+      run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
     
     # http://man7.org/linux/man-pages/man1/date.1.html
     # https://github.com/actions/cache#creating-a-cache-key
     - name: Get Date
       id: get-date
-      run: echo "{date}={$(/bin/date -u "+%Y%m%d")}" >> $GITHUB_OUTPUT
+      run: echo "date=$(/bin/date -u "+%Y%m%d")" >> $GITHUB_OUTPUT
       shell: bash
     
     - name: Cache dependencies


### PR DESCRIPTION
see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/