### PR TITLE
improve configuration wording, adjust self check

### DIFF
--- a/cfg/conf.sample.php
+++ b/cfg/conf.sample.php
@@ -7,9 +7,10 @@
 ; (optional) set a project name to be displayed on the website
 ; name = "PrivateBin"
 
-; The full URL, with the domain name and directories that point to the PrivateBin files
-; This URL is essential to allow Opengraph images to be displayed on social networks
-; basepath = ""
+; The full URL, with the domain name and directories that point to the
+; PrivateBin files, including an ending slash (/). This URL is essential to
+; allow Opengraph images to be displayed on social networks.
+; basepath = "https://privatebin.example.com/"
 
 ; enable or disable the discussion feature, defaults to true
 discussion = true
@@ -55,9 +56,9 @@ languageselection = false
 ; if this is set and language selection is disabled, this will be the only language
 ; languagedefault = "en"
 
-; (optional) URL shortener address to offer after a new paste is created
-; it is suggested to only use this with self-hosted shorteners as this will leak
-; the pastes encryption key
+; (optional) URL shortener address to offer after a new paste is created.
+; It is suggested to only use this with self-hosted shorteners as this will leak
+; the pastes encryption key.
 ; urlshortener = "https://shortener.example.com/api?link="
 
 ; (optional) Let users create a QR code for sharing the paste URL with one click.
@@ -229,18 +230,18 @@ dir = PATH "data"
 ;secretkey = "secret access key"
 
 [yourls]
-; don't mix this up with "urlshortener" config item:
-; - when using a standard configuration, "urlshortener" will point to the YOURLS
-;   API, including access credentials, and will be part of the PrivateBin public
-;   web page (insecure!)
-; - when using the parameters in this section ("signature" and "apiurl"),
-;   "urlshortener" will point to a fixed PrivateBin page
-;   ("$basepath/shortenviayourls?link=") and that URL will in turn call YOURLS
-;   server-side, using the URL from "apiurl" and the "access signature" from the
-;   "signature" parameters below.
+; When using YOURLS as a "urlshortener" config item:
+; - By default, "urlshortener" will point to the YOURLS API URL, with or without
+;   credentials, and will be visible in public on the PrivateBin web page.
+;   Only use this if you allow short URL creation without credentials.
+; - Alternatively, using the parameters in this section ("signature" and
+;   "apiurl"), "urlshortener" needs to point to the base URL of your PrivateBin
+;   instance with "shortenviayourls?link=" appended. For example:
+;   urlshortener = "${basepath}shortenviayourls?link="
+;   This URL will in turn call YOURLS on the server side, using the URL from
+;   "apiurl" and the "access signature" from the "signature" parameters below.
 
 ; (optional) the "signature" (access key) issued by YOURLS for the using account
 ; signature = ""
-
 ; (optional) the URL of the YOURLS API, called to shorten a PrivateBin URL
-; apiurl = ""
+; apiurl = "https://yourls.example.com/yourls-api.php"

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -236,6 +236,14 @@ class Configuration
         if (!array_key_exists($this->_configuration['expire']['default'], $this->_configuration['expire_options'])) {
             $this->_configuration['expire']['default'] = key($this->_configuration['expire_options']);
         }
+
+        // ensure the basepath ends in a slash, if one is set
+        if (
+            strlen($this->_configuration['main']['basepath']) &&
+            substr_compare($this->_configuration['main']['basepath'], '/', -1) !== 0
+        ) {
+            $this->_configuration['main']['basepath'] .= '/';
+        }
     }
 
     /**

--- a/lib/YourlsProxy.php
+++ b/lib/YourlsProxy.php
@@ -48,7 +48,7 @@ class YourlsProxy
      */
     public function __construct(Configuration $conf, $link)
     {
-        if (strpos($link, $conf->getKey('basepath') . '/?') === false) {
+        if (strpos($link, $conf->getKey('basepath') . '?') === false) {
             $this->_error = 'Trying to shorten a URL that isn\'t pointing at our instance.';
             return;
         }

--- a/tst/JsonApiTest.php
+++ b/tst/JsonApiTest.php
@@ -272,7 +272,7 @@ class JsonApiTest extends PHPUnit_Framework_TestCase
     {
         $mock_yourls_service                = $this->_path . DIRECTORY_SEPARATOR . 'yourls.json';
         $options                            = parse_ini_file(CONF, true);
-        $options['main']['basepath']        = 'https://example.com/path/';
+        $options['main']['basepath']        = 'https://example.com/path'; // missing slash gets added by Configuration constructor
         $options['main']['urlshortener']    = 'https://example.com/path/shortenviayourls?link=';
         $options['yourls']['apiurl']        = $mock_yourls_service;
         Helper::createIniFile(CONF, $options);

--- a/tst/JsonApiTest.php
+++ b/tst/JsonApiTest.php
@@ -272,7 +272,7 @@ class JsonApiTest extends PHPUnit_Framework_TestCase
     {
         $mock_yourls_service                = $this->_path . DIRECTORY_SEPARATOR . 'yourls.json';
         $options                            = parse_ini_file(CONF, true);
-        $options['main']['basepath']        = 'https://example.com/path';
+        $options['main']['basepath']        = 'https://example.com/path/';
         $options['main']['urlshortener']    = 'https://example.com/path/shortenviayourls?link=';
         $options['yourls']['apiurl']        = $mock_yourls_service;
         Helper::createIniFile(CONF, $options);

--- a/tst/YourlsProxyTest.php
+++ b/tst/YourlsProxyTest.php
@@ -20,7 +20,7 @@ class YourlsProxyTest extends PHPUnit_Framework_TestCase
         }
         $this->_mock_yourls_service         = $this->_path . DIRECTORY_SEPARATOR . 'yourls.json';
         $options                            = parse_ini_file(CONF_SAMPLE, true);
-        $options['main']['basepath']        = 'https://example.com';
+        $options['main']['basepath']        = 'https://example.com/';
         $options['main']['urlshortener']    = 'https://example.com/shortenviayourls?link=';
         $options['yourls']['apiurl']        = $this->_mock_yourls_service;
         Helper::confBackup();


### PR DESCRIPTION
This PR fixes #1002

## Changes
* improved wording of configuration items around YOURLS and basepath, as discussed in #1002
* adjust the YOURLS proxy check to detect if the passed URL is originating from the basepath

Please review and start discussions here or on the lines of code in the "files changed" view with any suggestions - this is mostly about the wording of the document and I'm not a native English speaker.

I have re-tested this and do get the shortened URL in the browser in my view after pressing the button. It was near instantaneous on my test system, so at first I didn't notice that the URL with key had gotten replaced with the short-URL, but the button did get disabled, so you can only click it once.