### PR TITLE
Jdenticons size and speed test results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
   * **1.4.1 (not yet released)**
     * ADDED: Translations for Turkish, Slovak and Greek
     * ADDED: S3 Storage backend (#994)
-    * CHANGED: Switched to Jdenticons as the default for comment icons (#793)
+    * ADDED: Jdenticons as an option for comment icons (#793)
     * CHANGED: Avoid `SUPER` privilege for setting the `sql_mode` for MariaDB/MySQL (#919)
     * CHANGED: Upgrading libraries to: zlib 1.2.13
     * FIXED: Revert to CREATE INDEX without IF NOT EXISTS clauses, to support MySQL (#943)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -26,7 +26,7 @@ install and configure PrivateBin on your server. It's available on
     - `open_basedir` access to `/dev/urandom`
     - mcrypt extension AND `open_basedir` access to `/dev/urandom`
     - com_dotnet extension
-- GD extension
+- GD extension (when using identicon or vizhash icons, jdenticon works without it)
 - zlib extension
 - some disk space or a database supported by [PDO](https://php.net/manual/book.pdo.php)
 - ability to create files and folders in the installation directory and the PATH

--- a/cfg/conf.sample.php
+++ b/cfg/conf.sample.php
@@ -69,7 +69,7 @@ languageselection = false
 ; used to get the IP of a comment poster if the server salt is leaked and a
 ; SHA512 HMAC rainbow table is generated for all (relevant) IPs.
 ; Can be set to one these values:
-; "none" / "vizhash" / "identicon" / "jdenticon" (default).
+; "none" / "identicon" (default) / "jdenticon" / "vizhash".
 ; icon = "none"
 
 ; Content Security Policy headers allow a website to restrict what sources are

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -53,7 +53,7 @@ class Configuration
             'languagedefault'          => '',
             'urlshortener'             => '',
             'qrcode'                   => true,
-            'icon'                     => 'jdenticon',
+            'icon'                     => 'identicon',
             'cspheader'                => 'default-src \'none\'; base-uri \'self\'; form-action \'none\'; manifest-src \'self\'; connect-src * blob:; script-src \'self\' \'unsafe-eval\'; style-src \'self\'; font-src \'self\'; frame-ancestors \'none\'; img-src \'self\' data: blob:; media-src blob:; object-src blob:; sandbox allow-same-origin allow-scripts allow-forms allow-popups allow-modals allow-downloads',
             'zerobincompatibility'     => false,
             'httpwarning'              => true,

--- a/lib/Model/Comment.php
+++ b/lib/Model/Comment.php
@@ -165,7 +165,10 @@ class Comment extends AbstractModel
         if ($icon != 'none') {
             $pngdata = '';
             $hmac    = TrafficLimiter::getHash();
-            if ($icon == 'jdenticon') {
+            if ($icon == 'identicon') {
+                $identicon = new Identicon();
+                $pngdata   = $identicon->getImageDataUri($hmac, 16);
+            } elseif ($icon == 'jdenticon') {
                 $jdenticon = new Jdenticon(array(
                     'hash'  => $hmac,
                     'size'  => 16,
@@ -175,9 +178,6 @@ class Comment extends AbstractModel
                     ),
                 ));
                 $pngdata   = $jdenticon->getImageDataUri('png');
-            } elseif ($icon == 'identicon') {
-                $identicon = new Identicon();
-                $pngdata   = $identicon->getImageDataUri($hmac, 16);
             } elseif ($icon == 'vizhash') {
                 $vh      = new Vizhash16x16();
                 $pngdata = 'data:image/png;base64,' . base64_encode(

--- a/tst/IconTest
+++ b/tst/IconTest
@@ -28,7 +28,8 @@ $jdenticon = new Jdenticon(array(
     ),
 ));
 $jdenticonGenerators = array(
-    'jdenticon PNG' => 'png',
+    'jdenticon' => 'png',
+    'jdenticon ImageMagick' => 'png',
     'jdenticon SVG' => 'svg',
 );
 $results = array(
@@ -48,7 +49,11 @@ $results = array(
         'lengths' => array(),
         'time' => 0
     ),
-    'jdenticon PNG' => array(
+    'jdenticon' => array(
+        'lengths' => array(),
+        'time' => 0
+    ),
+    'jdenticon ImageMagick' => array(
         'lengths' => array(),
         'time' => 0
     ),
@@ -89,6 +94,11 @@ foreach ($identiconGenerators as $key => $identicon) {
 
 foreach ($jdenticonGenerators as $key => $format) {
     echo 'run ', $key,' tests', PHP_EOL;
+    if ($key === 'jdenticon ImageMagick') {
+        $jdenticon->enableImageMagick = true;
+    } else {
+        $jdenticon->enableImageMagick = false;
+    }
     $start = microtime(true);
     foreach ($hmacs as $i => $hmac) {
         $jdenticon->setHash($hmac);

--- a/tst/IconTest
+++ b/tst/IconTest
@@ -9,6 +9,7 @@ use Identicon\Generator\GdGenerator;
 use Identicon\Generator\ImageMagickGenerator;
 use Identicon\Generator\SvgGenerator;
 use Identicon\Identicon;
+use Jdenticon\Identicon as Jdenticon;
 use PrivateBin\Vizhash16x16;
 
 
@@ -17,7 +18,18 @@ $vizhash = new Vizhash16x16();
 $identiconGenerators = array(
     'identicon GD' => new Identicon(new GdGenerator()),
     'identicon ImageMagick' => new Identicon(new ImageMagickGenerator()),
-    'identicon SVG' => new Identicon(new SvgGenerator())
+    'identicon SVG' => new Identicon(new SvgGenerator()),
+);
+$jdenticon = new Jdenticon(array(
+    'size'  => 16,
+    'style' => array(
+        'backgroundColor'   => '#fff0', // fully transparent, for dark mode
+        'padding'           => 0,
+    ),
+));
+$jdenticonGenerators = array(
+    'jdenticon GD' => 'png',
+    'jdenticon SVG' => 'svg',
 );
 $results = array(
     'vizhash' => array(
@@ -35,20 +47,25 @@ $results = array(
     'identicon SVG' => array(
         'lengths' => array(),
         'time' => 0
-    )
+    ),
+    'jdenticon GD' => array(
+        'lengths' => array(),
+        'time' => 0
+    ),
+    'jdenticon SVG' => array(
+        'lengths' => array(),
+        'time' => 0
+    ),
 );
 $hmacs = array();
 
 echo 'generate ', ITERATIONS, ' hmacs and pre-populate the result array, so tests wont be slowed down', PHP_EOL;
 for ($i = 0; $i < ITERATIONS; ++$i) {
     $hmacs[$i] = hash_hmac('sha512', '127.0.0.1', bin2hex(random_bytes(256)));
-    $results['vizhash']['lengths'][$i] = 0;
-    $results['identicon GD']['lengths'][$i] = 0;
-    $results['identicon ImageMagick']['lengths'][$i] = 0;
-    $results['identicon SVG']['lengths'][$i] = 0;
+    foreach (array_keys($results) as $test) {
+        $results[$test]['lengths'][$i] = 0;
+    }
 }
-
-
 
 echo 'run vizhash tests', PHP_EOL;
 $start = microtime(true);
@@ -60,7 +77,6 @@ foreach ($hmacs as $i => $hmac) {
 }
 $results['vizhash']['time'] = microtime(true) - $start;
 
-
 foreach ($identiconGenerators as $key => $identicon) {
     echo 'run ', $key,' tests', PHP_EOL;
     $start = microtime(true);
@@ -71,9 +87,30 @@ foreach ($identiconGenerators as $key => $identicon) {
     $results[$key]['time'] = microtime(true) - $start;
 }
 
+foreach ($jdenticonGenerators as $key => $format) {
+    echo 'run ', $key,' tests', PHP_EOL;
+    $start = microtime(true);
+    foreach ($hmacs as $i => $hmac) {
+        $jdenticon->setHash($hmac);
+        $data = $jdenticon->getImageDataUri($format);
+        $results[$key]['lengths'][$i] = strlen($data);
+    }
+    $results[$key]['time'] = microtime(true) - $start;
+}
 
 
-define('PADDING_LENGTH', max(array_map(function ($key) { return strlen($key); }, array_keys($results))) + 1);
+define(
+    'PADDING_LENGTH',
+    max(
+        array_map(
+            function ($key) {
+                return strlen($key);
+            },
+            array_keys($results)
+        )
+    ) + 1
+);
+
 function format_result_line($generator, $min, $max, $avg, $sec) {
     echo str_pad($generator, PADDING_LENGTH, ' '), "\t",
         str_pad($min, 4, ' ', STR_PAD_LEFT), "\t",
@@ -84,7 +121,10 @@ function format_result_line($generator, $min, $max, $avg, $sec) {
 
 echo PHP_EOL;
 format_result_line('Generator:', 'min', 'max', 'avg', 'seconds');
-format_result_line(str_repeat('─', PADDING_LENGTH), str_repeat('─', 4), str_repeat('─', 4), str_repeat('─', 4), str_repeat('─', 7));
+format_result_line(
+    str_repeat('─', PADDING_LENGTH), str_repeat('─', 4), str_repeat('─', 4),
+    str_repeat('─', 4), str_repeat('─', 7)
+);
 foreach ($results as $generator => $result) {
     sort($result['lengths']);
     format_result_line(

--- a/tst/IconTest
+++ b/tst/IconTest
@@ -28,7 +28,7 @@ $jdenticon = new Jdenticon(array(
     ),
 ));
 $jdenticonGenerators = array(
-    'jdenticon GD' => 'png',
+    'jdenticon PNG' => 'png',
     'jdenticon SVG' => 'svg',
 );
 $results = array(
@@ -48,7 +48,7 @@ $results = array(
         'lengths' => array(),
         'time' => 0
     ),
-    'jdenticon GD' => array(
+    'jdenticon PNG' => array(
         'lengths' => array(),
         'time' => 0
     ),

--- a/tst/ModelTest.php
+++ b/tst/ModelTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use Jdenticon\Identicon;
+use Identicon\Identicon;
 use PrivateBin\Configuration;
 use PrivateBin\Data\Database;
 use PrivateBin\Model;
@@ -314,15 +314,8 @@ class ModelTest extends PHPUnit_Framework_TestCase
         $comment->get();
         $comment->store();
 
-        $identicon = new Identicon(array(
-            'hash'  => TrafficLimiter::getHash(),
-            'size'  => 16,
-            'style' => array(
-                'backgroundColor'   => '#fff0', // fully transparent, for dark mode
-                'padding'           => 0,
-            ),
-        ));
-        $pngdata   = $identicon->getImageDataUri('png');
+        $identicon = new Identicon();
+        $pngdata   = $identicon->getImageDataUri(TrafficLimiter::getHash(), 16);
         $comment   = current($this->_model->getPaste(Helper::getPasteId())->get()['comments']);
         $this->assertEquals($pngdata, $comment['meta']['icon'], 'icon gets set');
     }


### PR DESCRIPTION
Sorry, in https://github.com/PrivateBin/PrivateBin/issues/793#issuecomment-856428488 I'd promised to also do the size and speed tests for Jdenticon, which I forgot in that PR.

I have to say that I am disappointed, having now done them and would like to revert making it the new default.

Obviously it is still good to have the extra option, so that folks can switch to it if they like the new look or an issue is discovered in one of the two older libraries.

## Changes
* updated the IconCheck script to include the new library (also for the unused SVG mode - for comparison)
* reverted making Jdenticon the default, sticking with Identicon for now

TL;DR: Jdenticon takes between 9 (PHP 8.1) and 14 (PHP 7.4) times as long to generate the PNGs over Identicon and they are about double the size, but still a little smaller then vizhash's.

Results for PHP 7.4:
```
$ docker run -ti -v ~/git/PrivateBin:/srv:ro alpine:3.13
# apk add php7 php7-gd php7-opcache php7-pecl-imagick
# cd /srv
# tst/IconTest
generate 100000 hmacs and pre-populate the result array, so tests wont be slowed down
run vizhash tests
run identicon GD tests
run identicon ImageMagick tests
run identicon SVG tests
run jdenticon GD tests
run jdenticon SVG tests

Generator:            	 min	 max	 avg	seconds
──────────────────────	────	────	────	───────
vizhash:              	 162	 734	 457	 13.588
identicon GD:         	 170	 270	 225	  8.639
identicon ImageMagick:	 222	 310	 283	385.331
identicon SVG:        	 370	 802	 643	  1.995
jdenticon GD:         	 286	 518	 418	120.633
jdenticon SVG:        	 934	1762	1261	 13.414
# php --version
PHP 7.4.26 (cli) (built: Nov 18 2021 21:41:28) ( NTS )
Copyright (c) The PHP Group
Zend Engine v3.4.0, Copyright (c) Zend Technologies
    with Zend OPcache v7.4.26, Copyright (c), by Zend Technologies
```

Results for PHP 8.1:
(I wanted to test it on PHP 8.2, but alpine doesn't yet provide a php82-pecl-imagick package)
```
$ docker run -ti -v ~/git/PrivateBin:/srv:ro alpine:edge
# apk add php81 php81-gd php81-opcache php81-pecl-imagick
# cd /srv
# tst/IconTest
generate 100000 hmacs and pre-populate the result array, so tests wont be slowed down
run vizhash tests
run identicon GD tests
run identicon ImageMagick tests
run identicon SVG tests
run jdenticon GD tests
run jdenticon SVG tests

Generator:            	 min	 max	 avg	seconds
──────────────────────	────	────	────	───────
vizhash:              	 162	 742	 456	 18.225
identicon GD:         	 170	 266	 225	  8.176
identicon ImageMagick:	 222	 310	 283	460.428
identicon SVG:        	 370	 802	 643	  1.332
jdenticon GD:         	 286	 518	 417	 74.391
jdenticon SVG:        	 934	1762	1260	  9.774
# php --version
PHP 8.1.12 (cli) (built: Oct 25 2022 19:18:03) (NTS)
Copyright (c) The PHP Group
Zend Engine v4.1.12, Copyright (c) Zend Technologies
    with Zend OPcache v8.1.12, Copyright (c), by Zend Technologies
```

Specs for reference:
```
$ lscpu | grep name
Modelname:                       AMD Ryzen 5 3400G with Radeon Vega Graphics
```

For reference, here are results from a different system and PHP 7.2, from when we considered switching to SVGs:
https://github.com/PrivateBin/PrivateBin/issues/148#issuecomment-502426961