### PR TITLE
script for storage backend migrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # PrivateBin version history
 
   * **1.4.1 (not yet released)**
+    * ADDED: script for data storage backend migrations (#1012)
     * ADDED: Translations for Turkish, Slovak and Greek
     * ADDED: S3 Storage backend (#994)
     * CHANGED: Avoid `SUPER` privilege for setting the `sql_mode` for MariaDB/MySQL (#919)

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -31,6 +31,7 @@
 * Austin Huang - Oracle database support
 * Felix J. Ogris - S3 Storage backend
 * Mounir Idrassi & J. Mozdzen - secure YOURLS integration
+* Felix J. Ogris - script for data backend migrations, dropped singleton behaviour of data backends
 
 ## Translations
 * Hexalyse - French

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -38,10 +38,10 @@ install and configure PrivateBin on your server. It's available on
 ### Changing the Path
 
 In the index.php you can define a different `PATH`. This is useful to secure
-your installation. You can move the configuration, data files, templates and PHP
-libraries (directories cfg, doc, data, lib, tpl, tst and vendor) outside of your
-document root. This new location must still be accessible to your webserver and
-PHP process (see also
+your installation. You can move the utilities, configuration, data files,
+templates and PHP libraries (directories bin, cfg, doc, data, lib, tpl, tst and
+vendor) outside of your document root. This new location must still be
+accessible to your webserver and PHP process (see also
 [open_basedir setting](https://secure.php.net/manual/en/ini.core.php#ini.open-basedir)).
 
 > #### PATH Example

--- a/bin/migrate.php
+++ b/bin/migrate.php
@@ -1,0 +1,194 @@
+<?php
+
+// change this, if your php files and data is outside of your webservers document root
+define('PATH', '..' . DIRECTORY_SEPARATOR);
+
+define('PUBLIC_PATH', __DIR__ . DIRECTORY_SEPARATOR);
+require PATH . 'vendor' . DIRECTORY_SEPARATOR . 'autoload.php';
+
+use PrivateBin\Configuration;
+use PrivateBin\Model;
+
+
+$longopts = array(
+    "delete-after",
+    "delete-during"
+);
+$opts_arr = getopt("fhnv", $longopts, $rest);
+if ($opts_arr === false) {
+    dieerr("Erroneous command line options. Please use -h");
+}
+if (array_key_exists("h", $opts_arr)) {
+    helpexit();
+}
+
+$delete_after    = array_key_exists("delete-after",  $opts_arr);
+$delete_during   = array_key_exists("delete-during", $opts_arr);
+$force_overwrite = array_key_exists("f", $opts_arr);
+$dryrun          = array_key_exists("n", $opts_arr);
+$verbose         = array_key_exists("v", $opts_arr);
+
+if ($rest >= $argc) {
+    dieerr("Missing source configuration directory");
+}
+if ($delete_after && $delete_during) {
+    dieerr("--delete-after and --delete-during are mutually exclusive");
+}
+
+$srcconf = getConfig("source", $argv[$rest]);
+$rest++;
+$dstconf = getConfig("destination", ($rest < $argc ? $argv[$rest] : ""));
+
+if (($srcconf->getSection("model")         == $dstconf->getSection("model")) &&
+    ($srcconf->getSection("model_options") == $dstconf->getSection("model_options"))) {
+    dieerr("Source and destination storage configurations are identical");
+}
+
+$srcmodel = new Model($srcconf);
+$srcstore = $srcmodel->getStore();
+$dstmodel = new Model($dstconf);
+$dststore = $dstmodel->getStore();
+$ids      = $srcstore->getAllPastes();
+
+foreach ($ids as $id) {
+    debug("Reading paste id " . $id);
+    $paste    = $srcstore->read($id);
+    $comments = $srcstore->readComments($id);
+
+    savePaste($force_overwrite, $dryrun, $id, $paste, $dststore);
+    foreach ($comments as $comment) {
+        saveComment($force_overwrite, $dryrun, $id, $comment, $dststore);
+    }
+    if ($delete_during) {
+        deletePaste($dryrun, $id, $srcstore);
+    }
+}
+
+if ($delete_after) {
+    foreach ($ids as $id) {
+        deletePaste($dryrun, $id, $srcstore);
+    }
+}
+
+debug("Done.");
+
+
+function deletePaste($dryrun, $pasteid, $srcstore)
+{
+    if (!$dryrun) {
+        debug("Deleting paste id " . $pasteid);
+        $srcstore->delete($pasteid);
+    } else {
+        debug("Would delete paste id " . $pasteid);
+    }
+}
+
+function saveComment ($force_overwrite, $dryrun, $pasteid, $comment, $dststore)
+{
+    $parentid  = $comment["parentid"];
+    $commentid = $comment["id"];
+
+    if (!$dststore->existsComment($pasteid, $parentid, $commentid)) {
+        if (!$dryrun) {
+            debug("Saving paste id " . $pasteid . ", parent id " .
+                  $parentid . ", comment id " . $commentid);
+            $dststore->createComment($pasteid, $parentid, $commentid, $comment);
+        } else {
+            debug("Would save paste id " . $pasteid . ", parent id " .
+                  $parentid . ", comment id " . $commentid);
+        }
+    } else if ($force_overwrite) {
+        if (!$dryrun) {
+            debug("Overwriting paste id " . $pasteid . ", parent id " .
+                  $parentid . ", comment id " . $commentid);
+            $dststore->createComment($pasteid, $parentid, $commentid, $comment);
+        } else {
+            debug("Would overwrite paste id " . $pasteid . ", parent id " .
+                  $parentid . ", comment id " . $commentid);
+        }
+    } else {
+        if (!$dryrun) {
+            dieerr("Not overwriting paste id " . $pasteid . ", parent id " .
+                   $parentid . ", comment id " . $commentid);
+        } else {
+            dieerr("Would not overwrite paste id " . $pasteid . ", parent id " .
+                   $parentid . ", comment id " . $commentid);
+        }
+    }
+}
+
+function savePaste ($force_overwrite, $dryrun, $pasteid, $paste, $dststore)
+{
+    if (!$dststore->exists($pasteid)) {
+        if (!$dryrun) {
+            debug("Saving paste id " . $pasteid);
+            $dststore->create($pasteid, $paste);
+        } else {
+            debug("Would save paste id " . $pasteid);
+        }
+    } else if ($force_overwrite) {
+        if (!$dryrun) {
+            debug("Overwriting paste id " . $pasteid);
+            $dststore->create($pasteid, $paste);
+        } else {
+            debug("Would overwrite paste id " . $pasteid);
+        }
+    } else {
+        if (!$dryrun) {
+            dieerr("Not overwriting paste id " . $pasteid);
+        } else {
+            dieerr("Would not overwrite paste id " . $pasteid);
+        }
+    }
+}
+
+function getConfig ($target, $confdir)
+{
+    debug("Trying to load " . $target . " conf.php" .
+          ($confdir === "" ? "" : " from " . $confdir));
+
+    putenv("CONFIG_PATH=" . $confdir);
+    $conf = new Configuration;
+    putenv("CONFIG_PATH=");
+
+    return $conf;
+}
+
+function dieerr ($text)
+{
+    fprintf(STDERR, "ERROR: %s" . PHP_EOL, $text);
+    die(1);
+}
+
+function debug ($text) {
+    if ($GLOBALS["verbose"]) {
+        printf("DEBUG: %s" . PHP_EOL, $text);
+    }
+}
+
+function helpexit ()
+{
+    print("migrate.php - Copy data between PrivateBin backends
+
+Usage:
+  php migrate.php [--delete-after] [--delete-during] [-f] [-n] [-v] srcconfdir
+                  [<dstconfdir>]
+  php migrate.php [-h]
+
+Options:
+  --delete-after   delete data from source after all pastes and comments have
+                   successfully been copied to the destination
+  --delete-during  delete data from source after the current paste and its
+                   comments have successfully been copied to the destination
+  -f               forcefully overwrite data which already exists at the
+                   destination
+  -n               dry run, do not copy data
+  -v               be verbose
+  <srcconfdir>     use storage backend configration from conf.php found in
+                   this directory as source
+  <dstconfdir>     optionally, use storage backend configration from conf.php
+                   found in this directory as destination; defaults to:
+                   " . PATH . "cfg" . DIRECTORY_SEPARATOR . "conf.php
+");
+    exit();
+}

--- a/lib/Data/AbstractData.php
+++ b/lib/Data/AbstractData.php
@@ -15,61 +15,17 @@ namespace PrivateBin\Data;
 /**
  * AbstractData
  *
- * Abstract model for data access, implemented as a singleton.
+ * Abstract model for data access
  */
 abstract class AbstractData
 {
     /**
-     * Singleton instance
-     *
-     * @access protected
-     * @static
-     * @var AbstractData
-     */
-    protected static $_instance = null;
-
-    /**
      * cache for the traffic limiter
      *
-     * @access private
-     * @static
+     * @access protected
      * @var    array
      */
-    protected static $_last_cache = array();
-
-    /**
-     * Enforce singleton, disable constructor
-     *
-     * Instantiate using {@link getInstance()}, this object implements the singleton pattern.
-     *
-     * @access protected
-     */
-    protected function __construct()
-    {
-    }
-
-    /**
-     * Enforce singleton, disable cloning
-     *
-     * Instantiate using {@link getInstance()}, this object implements the singleton pattern.
-     *
-     * @access private
-     */
-    private function __clone()
-    {
-    }
-
-    /**
-     * Get instance of singleton
-     *
-     * @access public
-     * @static
-     * @param  array $options
-     * @return AbstractData
-     */
-    public static function getInstance(array $options)
-    {
-    }
+    protected $_last_cache = array();
 
     /**
      * Create a paste.
@@ -150,9 +106,9 @@ abstract class AbstractData
     public function purgeValues($namespace, $time)
     {
         if ($namespace === 'traffic_limiter') {
-            foreach (self::$_last_cache as $key => $last_submission) {
+            foreach ($this->_last_cache as $key => $last_submission) {
                 if ($last_submission <= $time) {
-                    unset(self::$_last_cache[$key]);
+                    unset($thi->_last_cache[$key]);
                 }
             }
         }
@@ -206,6 +162,14 @@ abstract class AbstractData
             }
         }
     }
+
+    /**
+     * Returns all paste ids
+     *
+     * @access public
+     * @return array
+     */
+    abstract public function getAllPastes();
 
     /**
      * Get next free slot for comment from postdate.

--- a/lib/Data/AbstractData.php
+++ b/lib/Data/AbstractData.php
@@ -108,7 +108,7 @@ abstract class AbstractData
         if ($namespace === 'traffic_limiter') {
             foreach ($this->_last_cache as $key => $last_submission) {
                 if ($last_submission <= $time) {
-                    unset($thi->_last_cache[$key]);
+                    unset($this->_last_cache[$key]);
                 }
             }
         }

--- a/lib/Data/Database.php
+++ b/lib/Data/Database.php
@@ -481,7 +481,7 @@ class Database extends AbstractData
             // migrate filesystem based salt into database
             $file = 'data' . DIRECTORY_SEPARATOR . 'salt.php';
             if ($namespace === 'salt' && is_readable($file)) {
-                $fs = new Filesystem(array('dir' => 'data'));
+                $fs    = new Filesystem(array('dir' => 'data'));
                 $value = $fs->getValue('salt');
                 $this->setValue($value, 'salt');
                 @unlink($file);

--- a/lib/Data/Database.php
+++ b/lib/Data/Database.php
@@ -839,10 +839,11 @@ class Database extends AbstractData
      * From: https://stackoverflow.com/questions/36200534/pdo-oci-into-a-clob-field
      *
      * @access public
+     * @static
      * @param  int|string|resource $value
      * @return int|string
      */
-    public function _sanitizeClob($value)
+    public static function _sanitizeClob($value)
     {
         if (is_resource($value)) {
             $value = stream_get_contents($value);

--- a/lib/Data/Database.php
+++ b/lib/Data/Database.php
@@ -530,16 +530,9 @@ class Database extends AbstractData
      */
     public function getAllPastes()
     {
-        $pastes = array();
-        $rows   = $this->_select(
-            'SELECT "dataid" FROM "' . $this->_sanitizeIdentifier('paste') . '"',
-            array()
-        );
-        if (is_array($rows) && count($rows)) {
-            foreach ($rows as $row) {
-                $pastes[] = $row['dataid'];
-            }
-        }
+        $pastes = $this->_db->_query(
+            'SELECT "dataid" FROM "' . $this->_sanitizeIdentifier('paste') . '"'
+        )->fetchAll(PDO::FETCH_COLUMN, 0);
         return $pastes;
     }
 

--- a/lib/Data/Filesystem.php
+++ b/lib/Data/Filesystem.php
@@ -40,33 +40,26 @@ class Filesystem extends AbstractData
      * path in which to persist something
      *
      * @access private
-     * @static
      * @var    string
      */
-    private static $_path = 'data';
+    private $_path = 'data';
 
     /**
-     * get instance of singleton
+     * instantiates a new Filesystem data backend
      *
      * @access public
-     * @static
      * @param  array $options
-     * @return Filesystem
+     * @return
      */
-    public static function getInstance(array $options)
+    public function __construct(array $options)
     {
-        // if needed initialize the singleton
-        if (!(self::$_instance instanceof self)) {
-            self::$_instance = new self;
-        }
         // if given update the data directory
         if (
             is_array($options) &&
             array_key_exists('dir', $options)
         ) {
-            self::$_path = $options['dir'];
+            $this->_path = $options['dir'];
         }
-        return self::$_instance;
     }
 
     /**
@@ -79,7 +72,7 @@ class Filesystem extends AbstractData
      */
     public function create($pasteid, array $paste)
     {
-        $storagedir = self::_dataid2path($pasteid);
+        $storagedir = $this->_dataid2path($pasteid);
         $file       = $storagedir . $pasteid . '.php';
         if (is_file($file)) {
             return false;
@@ -87,7 +80,7 @@ class Filesystem extends AbstractData
         if (!is_dir($storagedir)) {
             mkdir($storagedir, 0700, true);
         }
-        return self::_store($file, $paste);
+        return $this->_store($file, $paste);
     }
 
     /**
@@ -101,7 +94,7 @@ class Filesystem extends AbstractData
     {
         if (
             !$this->exists($pasteid) ||
-            !$paste = self::_get(self::_dataid2path($pasteid) . $pasteid . '.php')
+            !$paste = $this->_get($this->_dataid2path($pasteid) . $pasteid . '.php')
         ) {
             return false;
         }
@@ -116,7 +109,7 @@ class Filesystem extends AbstractData
      */
     public function delete($pasteid)
     {
-        $pastedir = self::_dataid2path($pasteid);
+        $pastedir = $this->_dataid2path($pasteid);
         if (is_dir($pastedir)) {
             // Delete the paste itself.
             if (is_file($pastedir . $pasteid . '.php')) {
@@ -124,7 +117,7 @@ class Filesystem extends AbstractData
             }
 
             // Delete discussion if it exists.
-            $discdir = self::_dataid2discussionpath($pasteid);
+            $discdir = $this->_dataid2discussionpath($pasteid);
             if (is_dir($discdir)) {
                 // Delete all files in discussion directory
                 $dir = dir($discdir);
@@ -148,20 +141,20 @@ class Filesystem extends AbstractData
      */
     public function exists($pasteid)
     {
-        $basePath  = self::_dataid2path($pasteid) . $pasteid;
+        $basePath  = $this->_dataid2path($pasteid) . $pasteid;
         $pastePath = $basePath . '.php';
         // convert to PHP protected files if needed
         if (is_readable($basePath)) {
-            self::_prependRename($basePath, $pastePath);
+            $this->_prependRename($basePath, $pastePath);
 
             // convert comments, too
-            $discdir = self::_dataid2discussionpath($pasteid);
+            $discdir = $this->_dataid2discussionpath($pasteid);
             if (is_dir($discdir)) {
                 $dir = dir($discdir);
                 while (false !== ($filename = $dir->read())) {
                     if (substr($filename, -4) !== '.php' && strlen($filename) >= 16) {
                         $commentFilename = $discdir . $filename . '.php';
-                        self::_prependRename($discdir . $filename, $commentFilename);
+                        $this->_prependRename($discdir . $filename, $commentFilename);
                     }
                 }
                 $dir->close();
@@ -182,7 +175,7 @@ class Filesystem extends AbstractData
      */
     public function createComment($pasteid, $parentid, $commentid, array $comment)
     {
-        $storagedir = self::_dataid2discussionpath($pasteid);
+        $storagedir = $this->_dataid2discussionpath($pasteid);
         $file       = $storagedir . $pasteid . '.' . $commentid . '.' . $parentid . '.php';
         if (is_file($file)) {
             return false;
@@ -190,7 +183,7 @@ class Filesystem extends AbstractData
         if (!is_dir($storagedir)) {
             mkdir($storagedir, 0700, true);
         }
-        return self::_store($file, $comment);
+        return $this->_store($file, $comment);
     }
 
     /**
@@ -203,7 +196,7 @@ class Filesystem extends AbstractData
     public function readComments($pasteid)
     {
         $comments = array();
-        $discdir  = self::_dataid2discussionpath($pasteid);
+        $discdir  = $this->_dataid2discussionpath($pasteid);
         if (is_dir($discdir)) {
             $dir = dir($discdir);
             while (false !== ($filename = $dir->read())) {
@@ -212,7 +205,7 @@ class Filesystem extends AbstractData
                 // - commentid is the comment identifier itself.
                 // - parentid is the comment this comment replies to (It can be pasteid)
                 if (is_file($discdir . $filename)) {
-                    $comment = self::_get($discdir . $filename);
+                    $comment = $this->_get($discdir . $filename);
                     $items   = explode('.', $filename);
                     // Add some meta information not contained in file.
                     $comment['id']       = $items[1];
@@ -243,7 +236,7 @@ class Filesystem extends AbstractData
     public function existsComment($pasteid, $parentid, $commentid)
     {
         return is_file(
-            self::_dataid2discussionpath($pasteid) .
+            $this->_dataid2discussionpath($pasteid) .
             $pasteid . '.' . $commentid . '.' . $parentid . '.php'
         );
     }
@@ -261,20 +254,20 @@ class Filesystem extends AbstractData
     {
         switch ($namespace) {
             case 'purge_limiter':
-                return self::_storeString(
-                    self::$_path . DIRECTORY_SEPARATOR . 'purge_limiter.php',
+                return $this->_storeString(
+                    $this->_path . DIRECTORY_SEPARATOR . 'purge_limiter.php',
                     '<?php' . PHP_EOL . '$GLOBALS[\'purge_limiter\'] = ' . $value . ';'
                 );
             case 'salt':
-                return self::_storeString(
-                    self::$_path . DIRECTORY_SEPARATOR . 'salt.php',
+                return $this->_storeString(
+                    $this->_path . DIRECTORY_SEPARATOR . 'salt.php',
                     '<?php # |' . $value . '|'
                 );
             case 'traffic_limiter':
-                self::$_last_cache[$key] = $value;
-                return self::_storeString(
-                    self::$_path . DIRECTORY_SEPARATOR . 'traffic_limiter.php',
-                    '<?php' . PHP_EOL . '$GLOBALS[\'traffic_limiter\'] = ' . var_export(self::$_last_cache, true) . ';'
+                $this->_last_cache[$key] = $value;
+                return $this->_storeString(
+                    $this->_path . DIRECTORY_SEPARATOR . 'traffic_limiter.php',
+                    '<?php' . PHP_EOL . '$GLOBALS[\'traffic_limiter\'] = ' . var_export($this->_last_cache, true) . ';'
                 );
         }
         return false;
@@ -292,14 +285,14 @@ class Filesystem extends AbstractData
     {
         switch ($namespace) {
             case 'purge_limiter':
-                $file = self::$_path . DIRECTORY_SEPARATOR . 'purge_limiter.php';
+                $file = $this->_path . DIRECTORY_SEPARATOR . 'purge_limiter.php';
                 if (is_readable($file)) {
                     require $file;
                     return $GLOBALS['purge_limiter'];
                 }
                 break;
             case 'salt':
-                $file = self::$_path . DIRECTORY_SEPARATOR . 'salt.php';
+                $file = $this->_path . DIRECTORY_SEPARATOR . 'salt.php';
                 if (is_readable($file)) {
                     $items = explode('|', file_get_contents($file));
                     if (is_array($items) && count($items) == 3) {
@@ -308,12 +301,12 @@ class Filesystem extends AbstractData
                 }
                 break;
             case 'traffic_limiter':
-                $file = self::$_path . DIRECTORY_SEPARATOR . 'traffic_limiter.php';
+                $file = $this->_path . DIRECTORY_SEPARATOR . 'traffic_limiter.php';
                 if (is_readable($file)) {
                     require $file;
-                    self::$_last_cache = $GLOBALS['traffic_limiter'];
-                    if (array_key_exists($key, self::$_last_cache)) {
-                        return self::$_last_cache[$key];
+                    $this->_last_cache = $GLOBALS['traffic_limiter'];
+                    if (array_key_exists($key, $this->_last_cache)) {
+                        return $this->_last_cache[$key];
                     }
                 }
                 break;
@@ -325,11 +318,10 @@ class Filesystem extends AbstractData
      * get the data
      *
      * @access public
-     * @static
      * @param  string $filename
      * @return array|false $data
      */
-    private static function _get($filename)
+    private function _get($filename)
     {
         return Json::decode(
             substr(
@@ -350,7 +342,7 @@ class Filesystem extends AbstractData
     {
         $pastes     = array();
         $firstLevel = array_filter(
-            scandir(self::$_path),
+            scandir($this->_path),
             'PrivateBin\Data\Filesystem::_isFirstLevelDir'
         );
         if (count($firstLevel) > 0) {
@@ -358,7 +350,7 @@ class Filesystem extends AbstractData
             for ($i = 0, $max = $batchsize * 10; $i < $max; ++$i) {
                 $firstKey    = array_rand($firstLevel);
                 $secondLevel = array_filter(
-                    scandir(self::$_path . DIRECTORY_SEPARATOR . $firstLevel[$firstKey]),
+                    scandir($this->_path . DIRECTORY_SEPARATOR . $firstLevel[$firstKey]),
                     'PrivateBin\Data\Filesystem::_isSecondLevelDir'
                 );
 
@@ -369,7 +361,7 @@ class Filesystem extends AbstractData
                 }
 
                 $secondKey = array_rand($secondLevel);
-                $path      = self::$_path . DIRECTORY_SEPARATOR .
+                $path      = $this->_path . DIRECTORY_SEPARATOR .
                     $firstLevel[$firstKey] . DIRECTORY_SEPARATOR .
                     $secondLevel[$secondKey];
                 if (!is_dir($path)) {
@@ -413,6 +405,46 @@ class Filesystem extends AbstractData
     }
 
     /**
+     * @inheritDoc
+     */
+    public function getAllPastes()
+    {
+        $pastes = array();
+        $subdirs = scandir($this->_path);
+        if ($subdirs === false) {
+            dieerr("Unable to list directory " . $this->_path);
+        }
+        $subdirs = preg_grep("/^[^.].$/", $subdirs);
+
+        foreach ($subdirs as $subdir) {
+            $subpath = $this->_path . DIRECTORY_SEPARATOR . $subdir;
+
+            $subsubdirs = scandir($subpath);
+            if ($subsubdirs === false) {
+                dieerr("Unable to list directory " . $subpath);
+            }
+            $subsubdirs = preg_grep("/^[^.].$/", $subsubdirs);
+            foreach ($subsubdirs as $subsubdir) {
+                $subsubpath = $subpath . DIRECTORY_SEPARATOR . $subsubdir;
+
+                $files = scandir($subsubpath);
+                if ($files === false) {
+                    dieerr("Unable to list directory " . $subsubpath);
+                }
+                $files = preg_grep("/\.php$/", $files);
+
+                foreach ($files as $file) {
+                    if (substr($file, 0, 4) === $subdir . $subsubdir) {
+                        $pastes[] = substr($file, 0, strlen($file) - 4);
+                    }
+                }
+            }
+        }
+
+        return $pastes;
+    }
+
+    /**
      * Convert paste id to storage path.
      *
      * The idea is to creates subdirectories in order to limit the number of files per directory.
@@ -423,13 +455,12 @@ class Filesystem extends AbstractData
      * eg. input 'e3570978f9e4aa90' --> output 'data/e3/57/'
      *
      * @access private
-     * @static
      * @param  string $dataid
      * @return string
      */
-    private static function _dataid2path($dataid)
+    private function _dataid2path($dataid)
     {
-        return self::$_path . DIRECTORY_SEPARATOR .
+        return $this->_path . DIRECTORY_SEPARATOR .
             substr($dataid, 0, 2) . DIRECTORY_SEPARATOR .
             substr($dataid, 2, 2) . DIRECTORY_SEPARATOR;
     }
@@ -440,13 +471,12 @@ class Filesystem extends AbstractData
      * eg. input 'e3570978f9e4aa90' --> output 'data/e3/57/e3570978f9e4aa90.discussion/'
      *
      * @access private
-     * @static
      * @param  string $dataid
      * @return string
      */
-    private static function _dataid2discussionpath($dataid)
+    private function _dataid2discussionpath($dataid)
     {
-        return self::_dataid2path($dataid) . $dataid .
+        return $this->_dataid2path($dataid) . $dataid .
             '.discussion' . DIRECTORY_SEPARATOR;
     }
 
@@ -454,25 +484,23 @@ class Filesystem extends AbstractData
      * Check that the given element is a valid first level directory.
      *
      * @access private
-     * @static
      * @param  string $element
      * @return bool
      */
-    private static function _isFirstLevelDir($element)
+    private function _isFirstLevelDir($element)
     {
-        return self::_isSecondLevelDir($element) &&
-            is_dir(self::$_path . DIRECTORY_SEPARATOR . $element);
+        return $this->_isSecondLevelDir($element) &&
+            is_dir($this->_path . DIRECTORY_SEPARATOR . $element);
     }
 
     /**
      * Check that the given element is a valid second level directory.
      *
      * @access private
-     * @static
      * @param  string $element
      * @return bool
      */
-    private static function _isSecondLevelDir($element)
+    private function _isSecondLevelDir($element)
     {
         return (bool) preg_match('/^[a-f0-9]{2}$/', $element);
     }
@@ -481,15 +509,14 @@ class Filesystem extends AbstractData
      * store the data
      *
      * @access public
-     * @static
      * @param  string $filename
      * @param  array  $data
      * @return bool
      */
-    private static function _store($filename, array $data)
+    private function _store($filename, array $data)
     {
         try {
-            return self::_storeString(
+            return $this->_storeString(
                 $filename,
                 self::PROTECTION_LINE . PHP_EOL . Json::encode($data)
             );
@@ -502,20 +529,19 @@ class Filesystem extends AbstractData
      * store a string
      *
      * @access public
-     * @static
      * @param  string $filename
      * @param  string $data
      * @return bool
      */
-    private static function _storeString($filename, $data)
+    private function _storeString($filename, $data)
     {
         // Create storage directory if it does not exist.
-        if (!is_dir(self::$_path)) {
-            if (!@mkdir(self::$_path, 0700)) {
+        if (!is_dir($this->_path)) {
+            if (!@mkdir($this->_path, 0700)) {
                 return false;
             }
         }
-        $file = self::$_path . DIRECTORY_SEPARATOR . '.htaccess';
+        $file = $this->_path . DIRECTORY_SEPARATOR . '.htaccess';
         if (!is_file($file)) {
             $writtenBytes = 0;
             if ($fileCreated = @touch($file)) {
@@ -553,12 +579,11 @@ class Filesystem extends AbstractData
      * rename a file, prepending the protection line at the beginning
      *
      * @access public
-     * @static
      * @param  string $srcFile
      * @param  string $destFile
      * @return void
      */
-    private static function _prependRename($srcFile, $destFile)
+    private function _prependRename($srcFile, $destFile)
     {
         // don't overwrite already converted file
         if (!is_readable($destFile)) {

--- a/lib/Data/Filesystem.php
+++ b/lib/Data/Filesystem.php
@@ -409,29 +409,29 @@ class Filesystem extends AbstractData
      */
     public function getAllPastes()
     {
-        $pastes = array();
+        $pastes  = array();
         $subdirs = scandir($this->_path);
         if ($subdirs === false) {
-            dieerr("Unable to list directory " . $this->_path);
+            dieerr('Unable to list directory ' . $this->_path);
         }
-        $subdirs = preg_grep("/^[^.].$/", $subdirs);
+        $subdirs = preg_grep('/^[^.].$/', $subdirs);
 
         foreach ($subdirs as $subdir) {
             $subpath = $this->_path . DIRECTORY_SEPARATOR . $subdir;
 
             $subsubdirs = scandir($subpath);
             if ($subsubdirs === false) {
-                dieerr("Unable to list directory " . $subpath);
+                dieerr('Unable to list directory ' . $subpath);
             }
-            $subsubdirs = preg_grep("/^[^.].$/", $subsubdirs);
+            $subsubdirs = preg_grep('/^[^.].$/', $subsubdirs);
             foreach ($subsubdirs as $subsubdir) {
                 $subsubpath = $subpath . DIRECTORY_SEPARATOR . $subsubdir;
 
                 $files = scandir($subsubpath);
                 if ($files === false) {
-                    dieerr("Unable to list directory " . $subsubpath);
+                    dieerr('Unable to list directory ' . $subsubpath);
                 }
-                $files = preg_grep("/\.php$/", $files);
+                $files = preg_grep('/\.php$/', $files);
 
                 foreach ($files as $file) {
                     if (substr($file, 0, 4) === $subdir . $subsubdir) {

--- a/lib/Data/GoogleCloudStorage.php
+++ b/lib/Data/GoogleCloudStorage.php
@@ -14,54 +14,43 @@ class GoogleCloudStorage extends AbstractData
      * GCS client
      *
      * @access private
-     * @static
      * @var    StorageClient
      */
-    private static $_client = null;
+    private $_client = null;
 
     /**
      * GCS bucket
      *
      * @access private
-     * @static
      * @var    Bucket
      */
-    private static $_bucket = null;
+    private $_bucket = null;
 
     /**
      * object prefix
      *
      * @access private
-     * @static
      * @var    string
      */
-    private static $_prefix = 'pastes';
+    private $_prefix = 'pastes';
 
     /**
      * bucket acl type
      *
      * @access private
-     * @static
      * @var    bool
      */
-    private static $_uniformacl = false;
+    private $_uniformacl = false;
 
     /**
-     * returns a Google Cloud Storage data backend.
+     * instantiantes a new Google Cloud Storage data backend.
      *
      * @access public
-     * @static
      * @param array $options
-     * @return GoogleCloudStorage
+     * @return
      */
-    public static function getInstance(array $options)
+    public function __construct(array $options)
     {
-        // if needed initialize the singleton
-        if (!(self::$_instance instanceof self)) {
-            self::$_instance = new self;
-        }
-
-        $bucket = null;
         if (getenv('PRIVATEBIN_GCS_BUCKET')) {
             $bucket = getenv('PRIVATEBIN_GCS_BUCKET');
         }
@@ -69,24 +58,20 @@ class GoogleCloudStorage extends AbstractData
             $bucket = $options['bucket'];
         }
         if (is_array($options) && array_key_exists('prefix', $options)) {
-            self::$_prefix = $options['prefix'];
+            $this->_prefix = $options['prefix'];
         }
         if (is_array($options) && array_key_exists('uniformacl', $options)) {
-            self::$_uniformacl = $options['uniformacl'];
+            $this->_uniformacl = $options['uniformacl'];
         }
 
-        if (empty(self::$_client)) {
-            self::$_client = class_exists('StorageClientStub', false) ?
-                new \StorageClientStub(array()) :
-                new StorageClient(array('suppressKeyFileNotice' => true));
-        }
-        self::$_bucket = self::$_client->bucket($bucket);
-
-        return self::$_instance;
+        $this->_client = class_exists('StorageClientStub', false) ?
+            new \StorageClientStub(array()) :
+            new StorageClient(array('suppressKeyFileNotice' => true));
+        $this->_bucket = $this->_client->bucket($bucket);
     }
 
     /**
-     * returns the google storage object key for $pasteid in self::$_bucket.
+     * returns the google storage object key for $pasteid in $this->_bucket.
      *
      * @access private
      * @param $pasteid string to get the key for
@@ -94,14 +79,14 @@ class GoogleCloudStorage extends AbstractData
      */
     private function _getKey($pasteid)
     {
-        if (self::$_prefix != '') {
-            return self::$_prefix . '/' . $pasteid;
+        if ($this->_prefix != '') {
+            return $this->_prefix . '/' . $pasteid;
         }
         return $pasteid;
     }
 
     /**
-     * Uploads the payload in the self::$_bucket under the specified key.
+     * Uploads the payload in the $this->_bucket under the specified key.
      * The entire payload is stored as a JSON document. The metadata is replicated
      * as the GCS object's metadata except for the fields attachment, attachmentname
      * and salt.
@@ -126,12 +111,12 @@ class GoogleCloudStorage extends AbstractData
                     'metadata'     => $metadata,
                 ),
             );
-            if (!self::$_uniformacl) {
+            if (!$this->_uniformacl) {
                 $data['predefinedAcl'] = 'private';
             }
-            self::$_bucket->upload(Json::encode($payload), $data);
+            $this->_bucket->upload(Json::encode($payload), $data);
         } catch (Exception $e) {
-            error_log('failed to upload ' . $key . ' to ' . self::$_bucket->name() . ', ' .
+            error_log('failed to upload ' . $key . ' to ' . $this->_bucket->name() . ', ' .
                 trim(preg_replace('/\s\s+/', ' ', $e->getMessage())));
             return false;
         }
@@ -156,13 +141,13 @@ class GoogleCloudStorage extends AbstractData
     public function read($pasteid)
     {
         try {
-            $o    = self::$_bucket->object($this->_getKey($pasteid));
+            $o    = $this->_bucket->object($this->_getKey($pasteid));
             $data = $o->downloadAsString();
             return Json::decode($data);
         } catch (NotFoundException $e) {
             return false;
         } catch (Exception $e) {
-            error_log('failed to read ' . $pasteid . ' from ' . self::$_bucket->name() . ', ' .
+            error_log('failed to read ' . $pasteid . ' from ' . $this->_bucket->name() . ', ' .
                 trim(preg_replace('/\s\s+/', ' ', $e->getMessage())));
             return false;
         }
@@ -176,9 +161,9 @@ class GoogleCloudStorage extends AbstractData
         $name = $this->_getKey($pasteid);
 
         try {
-            foreach (self::$_bucket->objects(array('prefix' => $name . '/discussion/')) as $comment) {
+            foreach ($this->_bucket->objects(array('prefix' => $name . '/discussion/')) as $comment) {
                 try {
-                    self::$_bucket->object($comment->name())->delete();
+                    $this->_bucket->object($comment->name())->delete();
                 } catch (NotFoundException $e) {
                     // ignore if already deleted.
                 }
@@ -188,7 +173,7 @@ class GoogleCloudStorage extends AbstractData
         }
 
         try {
-            self::$_bucket->object($name)->delete();
+            $this->_bucket->object($name)->delete();
         } catch (NotFoundException $e) {
             // ignore if already deleted
         }
@@ -199,7 +184,7 @@ class GoogleCloudStorage extends AbstractData
      */
     public function exists($pasteid)
     {
-        $o = self::$_bucket->object($this->_getKey($pasteid));
+        $o = $this->_bucket->object($this->_getKey($pasteid));
         return $o->exists();
     }
 
@@ -223,8 +208,8 @@ class GoogleCloudStorage extends AbstractData
         $comments = array();
         $prefix   = $this->_getKey($pasteid) . '/discussion/';
         try {
-            foreach (self::$_bucket->objects(array('prefix' => $prefix)) as $key) {
-                $comment         = JSON::decode(self::$_bucket->object($key->name())->downloadAsString());
+            foreach ($this->_bucket->objects(array('prefix' => $prefix)) as $key) {
+                $comment         = JSON::decode($this->_bucket->object($key->name())->downloadAsString());
                 $comment['id']   = basename($key->name());
                 $slot            = $this->getOpenSlot($comments, (int) $comment['meta']['created']);
                 $comments[$slot] = $comment;
@@ -241,7 +226,7 @@ class GoogleCloudStorage extends AbstractData
     public function existsComment($pasteid, $parentid, $commentid)
     {
         $name = $this->_getKey($pasteid) . '/discussion/' . $parentid . '/' . $commentid;
-        $o    = self::$_bucket->object($name);
+        $o    = $this->_bucket->object($name);
         return $o->exists();
     }
 
@@ -252,7 +237,7 @@ class GoogleCloudStorage extends AbstractData
     {
         $path = 'config/' . $namespace;
         try {
-            foreach (self::$_bucket->objects(array('prefix' => $path)) as $object) {
+            foreach ($this->_bucket->objects(array('prefix' => $path)) as $object) {
                 $name = $object->name();
                 if (strlen($name) > strlen($path) && substr($name, strlen($path), 1) !== '/') {
                     continue;
@@ -300,12 +285,12 @@ class GoogleCloudStorage extends AbstractData
                     'metadata'     => $metadata,
                 ),
             );
-            if (!self::$_uniformacl) {
+            if (!$this->_uniformacl) {
                 $data['predefinedAcl'] = 'private';
             }
-            self::$_bucket->upload($value, $data);
+            $this->_bucket->upload($value, $data);
         } catch (Exception $e) {
-            error_log('failed to set key ' . $key . ' to ' . self::$_bucket->name() . ', ' .
+            error_log('failed to set key ' . $key . ' to ' . $this->_bucket->name() . ', ' .
                 trim(preg_replace('/\s\s+/', ' ', $e->getMessage())));
             return false;
         }
@@ -323,7 +308,7 @@ class GoogleCloudStorage extends AbstractData
             $key = 'config/' . $namespace . '/' . $key;
         }
         try {
-            $o = self::$_bucket->object($key);
+            $o = $this->_bucket->object($key);
             return $o->downloadAsString();
         } catch (NotFoundException $e) {
             return '';
@@ -338,12 +323,12 @@ class GoogleCloudStorage extends AbstractData
         $expired = array();
 
         $now    = time();
-        $prefix = self::$_prefix;
+        $prefix = $this->_prefix;
         if ($prefix != '') {
             $prefix .= '/';
         }
         try {
-            foreach (self::$_bucket->objects(array('prefix' => $prefix)) as $object) {
+            foreach ($this->_bucket->objects(array('prefix' => $prefix)) as $object) {
                 $metadata = $object->info()['metadata'];
                 if ($metadata != null && array_key_exists('expire_date', $metadata)) {
                     $expire_at = intval($metadata['expire_date']);
@@ -360,5 +345,29 @@ class GoogleCloudStorage extends AbstractData
             // no objects in the bucket yet
         }
         return $expired;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getAllPastes()
+    {
+        $pastes = array();
+        $prefix  = $this->_prefix;
+        if ($prefix != '') {
+            $prefix .= '/';
+        }
+
+        try {
+            foreach ($this->_bucket->objects(array('prefix' => $prefix)) as $object) {
+                $candidate = substr($object->name(), strlen($prefix));
+                if (strpos($candidate, "/") === false) {
+                    $pastes[] = $candidate;
+                }
+            }
+        } catch (NotFoundException $e) {
+            // no objects in the bucket yet
+        }
+        return $pastes;
     }
 }

--- a/lib/Data/GoogleCloudStorage.php
+++ b/lib/Data/GoogleCloudStorage.php
@@ -353,7 +353,7 @@ class GoogleCloudStorage extends AbstractData
     public function getAllPastes()
     {
         $pastes = array();
-        $prefix  = $this->_prefix;
+        $prefix = $this->_prefix;
         if ($prefix != '') {
             $prefix .= '/';
         }
@@ -361,7 +361,7 @@ class GoogleCloudStorage extends AbstractData
         try {
             foreach ($this->_bucket->objects(array('prefix' => $prefix)) as $object) {
                 $candidate = substr($object->name(), strlen($prefix));
-                if (strpos($candidate, "/") === false) {
+                if (strpos($candidate, '/') === false) {
                     $pastes[] = $candidate;
                 }
             }

--- a/lib/Data/S3Storage.php
+++ b/lib/Data/S3Storage.php
@@ -78,7 +78,7 @@ class S3Storage extends AbstractData
      *
      * @access public
      * @param array $options
-     * @return 
+     * @return
      */
     public function __construct(array $options)
     {
@@ -453,15 +453,15 @@ class S3Storage extends AbstractData
     public function getAllPastes()
     {
         $pastes = array();
-        $prefix  = $this->_prefix;
+        $prefix = $this->_prefix;
         if ($prefix != '') {
             $prefix .= '/';
         }
 
         try {
             foreach ($this->_listAllObjects($prefix) as $object) {
-                $candidate = substr($object["Key"], strlen($prefix));
-                if (strpos($candidate, "/") === false) {
+                $candidate = substr($object['Key'], strlen($prefix));
+                if (strpos($candidate, '/') === false) {
                     $pastes[] = $candidate;
                 }
             }

--- a/lib/Model.php
+++ b/lib/Model.php
@@ -81,10 +81,8 @@ class Model
     public function getStore()
     {
         if ($this->_store === null) {
-            $this->_store = forward_static_call(
-                'PrivateBin\\Data\\' . $this->_conf->getKey('class', 'model') . '::getInstance',
-                $this->_conf->getSection('model_options')
-            );
+            $class = 'PrivateBin\\Data\\' . $this->_conf->getKey('class', 'model');
+            $this->_store = new $class($this->_conf->getSection('model_options'));
         }
         return $this->_store;
     }

--- a/lib/Model.php
+++ b/lib/Model.php
@@ -81,7 +81,7 @@ class Model
     public function getStore()
     {
         if ($this->_store === null) {
-            $class = 'PrivateBin\\Data\\' . $this->_conf->getKey('class', 'model');
+            $class        = 'PrivateBin\\Data\\' . $this->_conf->getKey('class', 'model');
             $this->_store = new $class($this->_conf->getSection('model_options'));
         }
         return $this->_store;

--- a/tst/Bootstrap.php
+++ b/tst/Bootstrap.php
@@ -34,7 +34,7 @@ class StorageClientStub extends StorageClient
 {
     private $_config     = null;
     private $_connection = null;
-    private $_buckets    = array();
+    private static $_buckets    = array();
 
     public function __construct(array $config = array())
     {
@@ -44,11 +44,11 @@ class StorageClientStub extends StorageClient
 
     public function bucket($name, $userProject = false)
     {
-        if (!key_exists($name, $this->_buckets)) {
+        if (!key_exists($name, self::$_buckets)) {
             $b                     = new BucketStub($this->_connection, $name, array(), $this);
-            $this->_buckets[$name] = $b;
+            self::$_buckets[$name] = $b;
         }
-        return $this->_buckets[$name];
+        return self::$_buckets[$name];
     }
 
     /**
@@ -56,8 +56,8 @@ class StorageClientStub extends StorageClient
      */
     public function deleteBucket($name)
     {
-        if (key_exists($name, $this->_buckets)) {
-            unset($this->_buckets[$name]);
+        if (key_exists($name, self::$_buckets)) {
+            unset(self::$_buckets[$name]);
         } else {
             throw new NotFoundException();
         }
@@ -110,11 +110,11 @@ class StorageClientStub extends StorageClient
 
     public function createBucket($name, array $options = array())
     {
-        if (key_exists($name, $this->_buckets)) {
+        if (key_exists($name, self::$_buckets)) {
             throw new BadRequestException('already exists');
         }
         $b                     = new BucketStub($this->_connection, $name, array(), $this);
-        $this->_buckets[$name] = $b;
+        self::$_buckets[$name] = $b;
         return $b;
     }
 }

--- a/tst/Bootstrap.php
+++ b/tst/Bootstrap.php
@@ -32,9 +32,9 @@ Helper::updateSubresourceIntegrity();
  */
 class StorageClientStub extends StorageClient
 {
-    private $_config     = null;
-    private $_connection = null;
-    private static $_buckets    = array();
+    private $_config         = null;
+    private $_connection     = null;
+    private static $_buckets = array();
 
     public function __construct(array $config = array())
     {

--- a/tst/ConfigurationTestGenerator.php
+++ b/tst/ConfigurationTestGenerator.php
@@ -427,7 +427,7 @@ class ConfigurationCombinationsTest extends PHPUnit_Framework_TestCase
         /* Setup Routine */
         Helper::confBackup();
         $this->_path  = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'privatebin_data';
-        $this->_model = Filesystem::getInstance(array('dir' => $this->_path));
+        $this->_model = new Filesystem(array('dir' => $this->_path));
         $this->reset();
     }
 

--- a/tst/ControllerTest.php
+++ b/tst/ControllerTest.php
@@ -16,7 +16,7 @@ class ControllerTest extends PHPUnit_Framework_TestCase
     {
         /* Setup Routine */
         $this->_path  = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'privatebin_data';
-        $this->_data  = Filesystem::getInstance(array('dir' => $this->_path));
+        $this->_data  = new Filesystem(array('dir' => $this->_path));
         ServerSalt::setStore($this->_data);
         TrafficLimiter::setStore($this->_data);
         $this->reset();

--- a/tst/ControllerWithDbTest.php
+++ b/tst/ControllerWithDbTest.php
@@ -25,7 +25,7 @@ class ControllerWithDbTest extends ControllerTest
             mkdir($this->_path);
         }
         $this->_options['dsn'] = 'sqlite:' . $this->_path . DIRECTORY_SEPARATOR . 'tst.sq3';
-        $this->_data           = Database::getInstance($this->_options);
+        $this->_data           = new Database($this->_options);
         ServerSalt::setStore($this->_data);
         TrafficLimiter::setStore($this->_data);
         $this->reset();

--- a/tst/ControllerWithGcsTest.php
+++ b/tst/ControllerWithGcsTest.php
@@ -39,7 +39,7 @@ class ControllerWithGcsTest extends ControllerTest
             'bucket' => self::$_bucket->name(),
             'prefix' => 'pastes',
         );
-        $this->_data    = GoogleCloudStorage::getInstance($this->_options);
+        $this->_data    = new GoogleCloudStorage($this->_options);
         ServerSalt::setStore($this->_data);
         TrafficLimiter::setStore($this->_data);
         $this->reset();

--- a/tst/Data/DatabaseTest.php
+++ b/tst/Data/DatabaseTest.php
@@ -22,7 +22,7 @@ class DatabaseTest extends PHPUnit_Framework_TestCase
     {
         /* Setup Routine */
         $this->_path  = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'privatebin_data';
-        $this->_model = Database::getInstance($this->_options);
+        $this->_model = new Database($this->_options);
     }
 
     public function tearDown()
@@ -35,7 +35,7 @@ class DatabaseTest extends PHPUnit_Framework_TestCase
 
     public function testSaltMigration()
     {
-        ServerSalt::setStore(Filesystem::getInstance(array('dir' => 'data')));
+        ServerSalt::setStore(new Filesystem(array('dir' => 'data')));
         $salt = ServerSalt::get();
         $file = 'data' . DIRECTORY_SEPARATOR . 'salt.php';
         $this->assertFileExists($file, 'ServerSalt got initialized and stored on disk');
@@ -141,7 +141,7 @@ class DatabaseTest extends PHPUnit_Framework_TestCase
      */
     public function testGetIbmInstance()
     {
-        Database::getInstance(array(
+        new Database(array(
             'dsn' => 'ibm:', 'usr' => null, 'pwd' => null,
             'opt' => array(PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION),
         ));
@@ -152,7 +152,7 @@ class DatabaseTest extends PHPUnit_Framework_TestCase
      */
     public function testGetInformixInstance()
     {
-        Database::getInstance(array(
+        new Database(array(
             'dsn' => 'informix:', 'usr' => null, 'pwd' => null,
             'opt' => array(PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION),
         ));
@@ -163,7 +163,7 @@ class DatabaseTest extends PHPUnit_Framework_TestCase
      */
     public function testGetMssqlInstance()
     {
-        Database::getInstance(array(
+        new Database(array(
             'dsn' => 'mssql:', 'usr' => null, 'pwd' => null,
             'opt' => array(PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION),
         ));
@@ -174,7 +174,7 @@ class DatabaseTest extends PHPUnit_Framework_TestCase
      */
     public function testGetMysqlInstance()
     {
-        Database::getInstance(array(
+        new Database(array(
             'dsn' => 'mysql:', 'usr' => null, 'pwd' => null,
             'opt' => array(PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION),
         ));
@@ -185,7 +185,7 @@ class DatabaseTest extends PHPUnit_Framework_TestCase
      */
     public function testGetOciInstance()
     {
-        Database::getInstance(array(
+        new Database(array(
             'dsn' => 'oci:', 'usr' => null, 'pwd' => null,
             'opt' => array(PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION),
         ));
@@ -196,7 +196,7 @@ class DatabaseTest extends PHPUnit_Framework_TestCase
      */
     public function testGetPgsqlInstance()
     {
-        Database::getInstance(array(
+        new Database(array(
             'dsn' => 'pgsql:', 'usr' => null, 'pwd' => null,
             'opt' => array(PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION),
         ));
@@ -208,7 +208,7 @@ class DatabaseTest extends PHPUnit_Framework_TestCase
      */
     public function testGetFooInstance()
     {
-        Database::getInstance(array(
+        new Database(array(
             'dsn' => 'foo:', 'usr' => null, 'pwd' => null, 'opt' => null,
         ));
     }
@@ -221,7 +221,7 @@ class DatabaseTest extends PHPUnit_Framework_TestCase
     {
         $options = $this->_options;
         unset($options['dsn']);
-        Database::getInstance($options);
+        new Database($options);
     }
 
     /**
@@ -232,7 +232,7 @@ class DatabaseTest extends PHPUnit_Framework_TestCase
     {
         $options = $this->_options;
         unset($options['usr']);
-        Database::getInstance($options);
+        new Database($options);
     }
 
     /**
@@ -243,7 +243,7 @@ class DatabaseTest extends PHPUnit_Framework_TestCase
     {
         $options = $this->_options;
         unset($options['pwd']);
-        Database::getInstance($options);
+        new Database($options);
     }
 
     /**
@@ -254,7 +254,7 @@ class DatabaseTest extends PHPUnit_Framework_TestCase
     {
         $options = $this->_options;
         unset($options['opt']);
-        Database::getInstance($options);
+        new Database($options);
     }
 
     public function testOldAttachments()
@@ -266,7 +266,7 @@ class DatabaseTest extends PHPUnit_Framework_TestCase
         }
         $this->_options['dsn'] = 'sqlite:' . $path;
         $this->_options['tbl'] = 'bar_';
-        $model                 = Database::getInstance($this->_options);
+        $model                 = new Database($this->_options);
 
         $original               = $paste = Helper::getPasteWithAttachment(1, array('expire_date' => 1344803344));
         $meta                   = $paste['meta'];
@@ -311,7 +311,7 @@ class DatabaseTest extends PHPUnit_Framework_TestCase
         }
         $this->_options['dsn'] = 'sqlite:' . $path;
         $this->_options['tbl'] = 'baz_';
-        $model                 = Database::getInstance($this->_options);
+        $model                 = new Database($this->_options);
         $paste                 = Helper::getPaste(1, array('expire_date' => 1344803344));
         unset($paste['meta']['formatter'], $paste['meta']['opendiscussion'], $paste['meta']['salt']);
         $model->delete(Helper::getPasteId());
@@ -378,7 +378,7 @@ class DatabaseTest extends PHPUnit_Framework_TestCase
             'vizhash BLOB, ' .
             'postdate INT );'
         );
-        $this->assertInstanceOf('PrivateBin\\Data\\Database', Database::getInstance($this->_options));
+        $this->assertInstanceOf('PrivateBin\\Data\\Database', new Database($this->_options));
 
         // check if version number was upgraded in created configuration table
         $statement = $db->prepare('SELECT value FROM foo_config WHERE id LIKE ?');

--- a/tst/Data/FilesystemTest.php
+++ b/tst/Data/FilesystemTest.php
@@ -15,7 +15,7 @@ class FilesystemTest extends PHPUnit_Framework_TestCase
         /* Setup Routine */
         $this->_path        = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'privatebin_data';
         $this->_invalidPath = $this->_path . DIRECTORY_SEPARATOR . 'bar';
-        $this->_model       = Filesystem::getInstance(array('dir' => $this->_path));
+        $this->_model       = new Filesystem(array('dir' => $this->_path));
         if (!is_dir($this->_path)) {
             mkdir($this->_path);
         }

--- a/tst/Data/GoogleCloudStorageTest.php
+++ b/tst/Data/GoogleCloudStorageTest.php
@@ -26,7 +26,7 @@ class GoogleCloudStorageTest extends PHPUnit_Framework_TestCase
     public function setUp()
     {
         ini_set('error_log', stream_get_meta_data(tmpfile())['uri']);
-        $this->_model = GoogleCloudStorage::getInstance(array(
+        $this->_model = new GoogleCloudStorage(array(
             'bucket' => self::$_bucket->name(),
             'prefix' => 'pastes',
         ));

--- a/tst/JsonApiTest.php
+++ b/tst/JsonApiTest.php
@@ -18,7 +18,7 @@ class JsonApiTest extends PHPUnit_Framework_TestCase
         if (!is_dir($this->_path)) {
             mkdir($this->_path);
         }
-        $this->_model = Filesystem::getInstance(array('dir' => $this->_path));
+        $this->_model = new Filesystem(array('dir' => $this->_path));
         ServerSalt::setStore($this->_model);
 
         $_POST   = array();

--- a/tst/ModelTest.php
+++ b/tst/ModelTest.php
@@ -156,7 +156,7 @@ class ModelTest extends PHPUnit_Framework_TestCase
 
     public function testCommentDefaults()
     {
-        $class = 'PrivateBin\\Data\\' . $this->_conf->getKey('class', 'model');
+        $class   = 'PrivateBin\\Data\\' . $this->_conf->getKey('class', 'model');
         $comment = new Comment(
             $this->_conf,
             new $class(

--- a/tst/ModelTest.php
+++ b/tst/ModelTest.php
@@ -38,7 +38,7 @@ class ModelTest extends PHPUnit_Framework_TestCase
         );
         Helper::confBackup();
         Helper::createIniFile(CONF, $options);
-        ServerSalt::setStore(Database::getInstance($options['model_options']));
+        ServerSalt::setStore(new Database($options['model_options']));
         $this->_conf            = new Configuration;
         $this->_model           = new Model($this->_conf);
         $_SERVER['REMOTE_ADDR'] = '::1';
@@ -156,10 +156,10 @@ class ModelTest extends PHPUnit_Framework_TestCase
 
     public function testCommentDefaults()
     {
+        $class = 'PrivateBin\\Data\\' . $this->_conf->getKey('class', 'model');
         $comment = new Comment(
             $this->_conf,
-            forward_static_call(
-                'PrivateBin\\Data\\' . $this->_conf->getKey('class', 'model') . '::getInstance',
+            new $class(
                 $this->_conf->getSection('model_options')
             )
         );
@@ -445,7 +445,7 @@ class ModelTest extends PHPUnit_Framework_TestCase
     public function testPurge()
     {
         $conf  = new Configuration;
-        $store = Database::getInstance($conf->getSection('model_options'));
+        $store = new Database($conf->getSection('model_options'));
         $store->delete(Helper::getPasteId());
         $expired = Helper::getPaste(2, array('expire_date' => 1344803344));
         $paste   = Helper::getPaste(2, array('expire_date' => time() + 3600));

--- a/tst/Persistence/PurgeLimiterTest.php
+++ b/tst/Persistence/PurgeLimiterTest.php
@@ -15,7 +15,7 @@ class PurgeLimiterTest extends PHPUnit_Framework_TestCase
             mkdir($this->_path);
         }
         PurgeLimiter::setStore(
-            Filesystem::getInstance(array('dir' => $this->_path))
+            new Filesystem(array('dir' => $this->_path))
         );
     }
 

--- a/tst/Persistence/ServerSaltTest.php
+++ b/tst/Persistence/ServerSaltTest.php
@@ -21,7 +21,7 @@ class ServerSaltTest extends PHPUnit_Framework_TestCase
             mkdir($this->_path);
         }
         ServerSalt::setStore(
-            Filesystem::getInstance(array('dir' => $this->_path))
+            new Filesystem(array('dir' => $this->_path))
         );
 
         $this->_otherPath = $this->_path . DIRECTORY_SEPARATOR . 'foo';
@@ -44,17 +44,17 @@ class ServerSaltTest extends PHPUnit_Framework_TestCase
     {
         // generating new salt
         ServerSalt::setStore(
-            Filesystem::getInstance(array('dir' => $this->_path))
+            new Filesystem(array('dir' => $this->_path))
         );
         $salt = ServerSalt::get();
 
         // try setting a different path and resetting it
         ServerSalt::setStore(
-            Filesystem::getInstance(array('dir' => $this->_otherPath))
+            new Filesystem(array('dir' => $this->_otherPath))
         );
         $this->assertNotEquals($salt, ServerSalt::get());
         ServerSalt::setStore(
-            Filesystem::getInstance(array('dir' => $this->_path))
+            new Filesystem(array('dir' => $this->_path))
         );
         $this->assertEquals($salt, ServerSalt::get());
     }
@@ -63,7 +63,7 @@ class ServerSaltTest extends PHPUnit_Framework_TestCase
     {
         // try setting an invalid path
         chmod($this->_invalidPath, 0000);
-        $store = Filesystem::getInstance(array('dir' => $this->_invalidPath));
+        $store = new Filesystem(array('dir' => $this->_invalidPath));
         ServerSalt::setStore($store);
         $salt = ServerSalt::get();
         ServerSalt::setStore($store);
@@ -76,7 +76,7 @@ class ServerSaltTest extends PHPUnit_Framework_TestCase
         chmod($this->_invalidPath, 0700);
         file_put_contents($this->_invalidFile, '');
         chmod($this->_invalidFile, 0000);
-        $store = Filesystem::getInstance(array('dir' => $this->_invalidPath));
+        $store = new Filesystem(array('dir' => $this->_invalidPath));
         ServerSalt::setStore($store);
         $salt = ServerSalt::get();
         ServerSalt::setStore($store);
@@ -93,7 +93,7 @@ class ServerSaltTest extends PHPUnit_Framework_TestCase
         }
         file_put_contents($this->_invalidPath . DIRECTORY_SEPARATOR . '.htaccess', '');
         chmod($this->_invalidPath, 0500);
-        $store = Filesystem::getInstance(array('dir' => $this->_invalidPath));
+        $store = new Filesystem(array('dir' => $this->_invalidPath));
         ServerSalt::setStore($store);
         $salt = ServerSalt::get();
         ServerSalt::setStore($store);
@@ -105,9 +105,9 @@ class ServerSaltTest extends PHPUnit_Framework_TestCase
         // try creating an invalid path
         chmod($this->_invalidPath, 0000);
         ServerSalt::setStore(
-            Filesystem::getInstance(array('dir' => $this->_invalidPath . DIRECTORY_SEPARATOR . 'baz'))
+            new Filesystem(array('dir' => $this->_invalidPath . DIRECTORY_SEPARATOR . 'baz'))
         );
-        $store = Filesystem::getInstance(array('dir' => $this->_invalidPath));
+        $store = new Filesystem(array('dir' => $this->_invalidPath));
         ServerSalt::setStore($store);
         $salt = ServerSalt::get();
         ServerSalt::setStore($store);

--- a/tst/Persistence/TrafficLimiterTest.php
+++ b/tst/Persistence/TrafficLimiterTest.php
@@ -12,7 +12,7 @@ class TrafficLimiterTest extends PHPUnit_Framework_TestCase
     {
         /* Setup Routine */
         $this->_path = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'trafficlimit';
-        $store       = Filesystem::getInstance(array('dir' => $this->_path));
+        $store       = new Filesystem(array('dir' => $this->_path));
         ServerSalt::setStore($store);
         TrafficLimiter::setStore($store);
     }

--- a/tst/Vizhash16x16Test.php
+++ b/tst/Vizhash16x16Test.php
@@ -18,7 +18,7 @@ class Vizhash16x16Test extends PHPUnit_Framework_TestCase
             mkdir($this->_path);
         }
         $this->_file = $this->_path . DIRECTORY_SEPARATOR . 'vizhash.png';
-        ServerSalt::setStore(Filesystem::getInstance(array('dir' => $this->_path)));
+        ServerSalt::setStore(new Filesystem(array('dir' => $this->_path)));
     }
 
     public function tearDown()


### PR DESCRIPTION
This is a follow-up to https://github.com/PrivateBin/PrivateBin/discussions/1007
It basically adds bin/migrate.php which is a command line tool for copying or moving data between storage backends. Source and destination backends may be of different or same type. If they are of same type, their configuration must differ.
For this to work, I had to drop singleton behaviour from all storage backends and their unit tests. This also means all static properties and static member functions from AbstractData and derived classes are now instance members - with the exception of upgradePreV1Format().