### PR TITLE
Feature: Allow AWS SDK to use default credential provider chain for S3Storage

### DIFF
--- a/cfg/conf.sample.php
+++ b/cfg/conf.sample.php
@@ -230,6 +230,19 @@ dir = PATH "data"
 ;accesskey = "access key id"
 ;secretkey = "secret access key"
 
+;[model]
+; example of S3 configuration for AWS using its SDK default credential provider chain
+; if relying on environment variables, the AWS SDK will look for the following:
+; - AWS_ACCESS_KEY_ID
+; - AWS_SECRET_ACCESS_KEY
+; - AWS_SESSION_TOKEN (if needed)
+; for more details, see https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/guide_credentials.html#default-credential-chain 
+;class = S3Storage
+;[model_options]
+;region = "eu-central-1"
+;version = "latest"
+;bucket = "my-bucket"
+
 [yourls]
 ; When using YOURLS as a "urlshortener" config item:
 ; - By default, "urlshortener" will point to the YOURLS API URL, with or without

--- a/lib/Data/S3Storage.php
+++ b/lib/Data/S3Storage.php
@@ -83,11 +83,12 @@ class S3Storage extends AbstractData
     public function __construct(array $options)
     {
         if (is_array($options)) {
-            // AWS SDK will try to load credentials from environment if credentials are not passed via configuration 
+            // AWS SDK will try to load credentials from environment if credentials are not passed via configuration
             // ref: https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/guide_credentials.html#default-credential-chain
             if (isset($options['accesskey']) && isset($options['secretkey'])) {
                 $this->_options['credentials'] = array();
-                $this->_options['credentials']['key'] = $options['accesskey'];
+
+                $this->_options['credentials']['key']    = $options['accesskey'];
                 $this->_options['credentials']['secret'] = $options['secretkey'];
             }
             if (array_key_exists('region', $options)) {

--- a/lib/Data/S3Storage.php
+++ b/lib/Data/S3Storage.php
@@ -82,31 +82,32 @@ class S3Storage extends AbstractData
      */
     public function __construct(array $options)
     {
-        $this->_options['credentials'] = array();
-
-        if (is_array($options) && array_key_exists('region', $options)) {
-            $this->_options['region'] = $options['region'];
-        }
-        if (is_array($options) && array_key_exists('version', $options)) {
-            $this->_options['version'] = $options['version'];
-        }
-        if (is_array($options) && array_key_exists('endpoint', $options)) {
-            $this->_options['endpoint'] = $options['endpoint'];
-        }
-        if (is_array($options) && array_key_exists('accesskey', $options)) {
-            $this->_options['credentials']['key'] = $options['accesskey'];
-        }
-        if (is_array($options) && array_key_exists('secretkey', $options)) {
-            $this->_options['credentials']['secret'] = $options['secretkey'];
-        }
-        if (is_array($options) && array_key_exists('use_path_style_endpoint', $options)) {
-            $this->_options['use_path_style_endpoint'] = filter_var($options['use_path_style_endpoint'], FILTER_VALIDATE_BOOLEAN);
-        }
-        if (is_array($options) && array_key_exists('bucket', $options)) {
-            $this->_bucket = $options['bucket'];
-        }
-        if (is_array($options) && array_key_exists('prefix', $options)) {
-            $this->_prefix = $options['prefix'];
+        if (is_array($options)) {
+            // AWS SDK will try to load credentials from environment if credentials are not passed via configuration 
+            // ref: https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/guide_credentials.html#default-credential-chain
+            if (isset($options['accesskey']) && isset($options['secretkey'])) {
+                $this->_options['credentials'] = array();
+                $this->_options['credentials']['key'] = $options['accesskey'];
+                $this->_options['credentials']['secret'] = $options['secretkey'];
+            }
+            if (array_key_exists('region', $options)) {
+                $this->_options['region'] = $options['region'];
+            }
+            if (array_key_exists('version', $options)) {
+                $this->_options['version'] = $options['version'];
+            }
+            if (array_key_exists('endpoint', $options)) {
+                $this->_options['endpoint'] = $options['endpoint'];
+            }
+            if (array_key_exists('use_path_style_endpoint', $options)) {
+                $this->_options['use_path_style_endpoint'] = filter_var($options['use_path_style_endpoint'], FILTER_VALIDATE_BOOLEAN);
+            }
+            if (array_key_exists('bucket', $options)) {
+                $this->_bucket = $options['bucket'];
+            }
+            if (array_key_exists('prefix', $options)) {
+                $this->_prefix = $options['prefix'];
+            }
         }
 
         $this->_client = new S3Client($this->_options);


### PR DESCRIPTION
<!-- This is a template for your Pull Request. This are just some suggestions for you. You do not have to use all of them. -->

<!-- If your PR fixes an issue, mention it here. You can also just copy the URL - GitHub will convert it for you.
If this PR fixes several issues, please prepend each issue url/number with the word "fix"/"fixes" or "close"/"closes" as this automatically closes the issues you mentioned when the PR is merged.
-->
This PR implements #1069

## Changes
<!-- List all the changes you have done -->
* S3Storage: Use credentials array only if values are passed via config
  * Instead of checking if array key exists, also checks if it's not `null` (using `isset`)
  * If both values are not passed (`accesskey` and `secretkey`) don't set the `credentials` array at all
  * If `credentials` array is not set, the AWS SDK will default to the default credentials provider chain, which will look for credentials in a few places automatically, including environment variables or instance roles, see [documentation](https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/guide_credentials.html#default-credential-chain)
