### PR TITLE
fix PHP 8.2 ${var} string interpolation deprecation

### DIFF
--- a/bin/administration
+++ b/bin/administration
@@ -215,7 +215,7 @@ EOT, PHP_EOL;
             $counters['total'] < 1000 ? 4 : 10
         );
 
-        echo "Total:\t\t\t${counters['total']}", PHP_EOL;
+        echo "Total:\t\t\t{$counters['total']}", PHP_EOL;
         foreach ($ids as $pasteid) {
             $paste = $this->_store->read($pasteid);
             ++$counters['progress'];
@@ -264,15 +264,15 @@ EOT, PHP_EOL;
         }
 
         echo PHP_EOL, <<<EOT
-Expired:\t\t${counters['expired']}
-Burn after reading:\t${counters['burn']}
-Discussions:\t\t${counters['discussion']}
-Plain Text:\t\t${counters['plain']}
-Source Code:\t\t${counters['syntax']}
-Markdown:\t\t${counters['md']}
+Expired:\t\t{$counters['expired']}
+Burn after reading:\t{$counters['burn']}
+Discussions:\t\t{$counters['discussion']}
+Plain Text:\t\t{$counters['plain']}
+Source Code:\t\t{$counters['syntax']}
+Markdown:\t\t{$counters['md']}
 EOT, PHP_EOL;
         if ($counters['unknown'] > 0) {
-            echo "Unknown format:\t\t${counters['unknown']}", PHP_EOL;
+            echo "Unknown format:\t\t{$counters['unknown']}", PHP_EOL;
         }
     }
 


### PR DESCRIPTION
This PR fixes #1092, see also https://php.watch/versions/8.2/$%7Bvar%7D-string-interpolation-deprecated