### PR TITLE
Create .gitleaks.toml

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -15,6 +15,7 @@ js/test/ export-ignore
 .gitattributes export-ignore
 .github export-ignore
 .gitignore export-ignore
+.gitleaks.toml export-ignore
 .jshintrc export-ignore
 .nsprc export-ignore
 .php_cs export-ignore

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,4 @@
+[allowlist]
+    description = "ignore base58 vocabulary & unit test cipher text - yes, it is a secret and a little easter egg"
+    regexTarget = "line"
+    regexes = ['''base58''', '''ME5JF''']


### PR DESCRIPTION
ignore base58 vocabulary & unit test cipher text, it seems to be the tool used by the shift left scan.