### PR TITLE
Make QA template more strict and helpful

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/q-a.yml
+++ b/.github/DISCUSSION_TEMPLATE/q-a.yml
@@ -45,7 +45,7 @@ body:
     id: additional_info
     attributes:
       label: Additional information
-      description: E.g. if you have access to the server log files, copy them here. Or copy the browser console, if appropiate.
+      description: E.g. if you have access to the server log files, copy them here. Or copy the browser console content, if appropiate.
   - type: input
     id: server_address
     attributes:
@@ -66,7 +66,7 @@ body:
     id: privatebin_version
     attributes:
       label: PrivateBin version
-      description: The PrivateBin version, where you experience the issue. It is shown at the bottom left in the web interface e.g.
+      description: The PrivateBin version, where you experience the issue. It is e.g. shown at the bottom left in the web interface.
       placeholder: e.g. v1.5.2
   - type: input
     id: browser
@@ -84,8 +84,8 @@ body:
       label: Issue reproducibility
       description: Can you reproduce this issue on [https://privatebin.net](https://privatebin.net)?
       options:
-        - "No, I cannot reproduce it on https://privatebin.net""
-        - "Yes, reproducible on https://privatebin.net"
+        - "No, I cannot reproduce it on https://privatebin.net."
+        - "Yes, reproducible on https://privatebin.net."
       default: 0
     validations:
       required: true

--- a/.github/DISCUSSION_TEMPLATE/q-a.yml
+++ b/.github/DISCUSSION_TEMPLATE/q-a.yml
@@ -29,6 +29,8 @@ body:
         1.
         2.
         ...
+    validations:
+      required: true
   - type: textarea
     id: what_happens
     attributes:
@@ -43,35 +45,47 @@ body:
     id: additional_info
     attributes:
       label: Additional information
-      description: If you have access to the server log files, copy them here.
+      description: E.g. if you have access to the server log files, copy them here. Or copy the browser console, if appropiate.
   - type: input
     id: server_address
     attributes:
       label: Server address
+      description: The instance of PrivateBin, where you experience the issue.
+      placeholder: e.g. https://privatebin.net
   - type: input
     id: server_os
     attributes:
       label: Server OS
+      placeholder: e.g. Ubuntu
   - type: input
     id: webserver
     attributes:
       label: Webserver
-  - type: input
-    id: browser
-    attributes:
-      label: Browser
+      placeholder: e.g. Apache
   - type: input
     id: privatebin_version
     attributes:
       label: PrivateBin version
+      description: The PrivateBin version, where you experience the issue. It is shown at the bottom left in the web interface e.g.
+      placeholder: e.g. v1.5.2
+  - type: input
+    id: browser
+    attributes:
+      label: Browser and version
+      placeholder: e.g. Firefox v116.3.0 (desktop)
+  - type: input
+    id: client
+    attributes:
+      label: Local operating system and version
+      placeholder: e.g. Windows 10
   - type: dropdown
     id: reproduce_issue
     attributes:
       label: Issue reproducibility
       description: Can you reproduce this issue on [https://privatebin.net](https://privatebin.net)?
       options:
-        - "No"
-        - "Yes"
+        - "No, I cannot reproduce it on https://privatebin.net""
+        - "Yes, reproducible on https://privatebin.net"
       default: 0
     validations:
       required: true

--- a/.github/DISCUSSION_TEMPLATE/q-a.yml
+++ b/.github/DISCUSSION_TEMPLATE/q-a.yml
@@ -18,7 +18,7 @@ body:
       label: Did you use the FAQ section?
       description: Have you read [the FAQ](https://github.com/PrivateBin/PrivateBin/wiki/FAQ)?
       options:
-        - label: Yes, I have read the FAQ and I found no solution/answer there.
+        - label: Yes, I have read [the FAQ](https://github.com/PrivateBin/PrivateBin/wiki/FAQ) and I found no solution/answer there.
           required: true
   - type: textarea
     id: what_you_did


### PR DESCRIPTION
1. Require to fill out STRs.
2. Add more fields for client stuff, i.e. web browser and OS.
3. Add more placeholders and descriptions to guide users.
4. Adjust the reproducibility thing to be more clear. I.e. before the result was sth. like "Issue reproducibility: Yes" - this could be confused with "Is it always reproducible? Yes", and not "It is reproducible on our test instance."

<!-- This is a template for your Pull Request. This are just some suggestions for you. You do not have to use all of them. -->

<!-- If your PR fixes an issue, mention it here. You can also just copy the URL - GitHub will convert it for you.
If this PR fixes several issues, please prepend each issue url/number with the word "fix"/"fixes" or "close"/"closes" as this automatically closes the issues you mentioned when the PR is merged.
-->
