### PR TITLE
QA template: remove prefilled title

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/q-a.yml
+++ b/.github/DISCUSSION_TEMPLATE/q-a.yml
@@ -1,4 +1,4 @@
-title: "[Question and support] "
+title: ""
 labels: ["question/support"]
 body:
   - type: markdown


### PR DESCRIPTION
Let's remove that.

1. With label and A&A category we have more than enough options for filtering such requests.
2. Actually, as you can see in https://github.com/orgs/PrivateBin/discussions/1152, as it is a required field, but already filled out… we want them to write proper titles. A prefilled field can just be submitted, and empty field cannot (as it is required).
