### PR TITLE
Remove custom security button as GitHub added own

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -6,7 +6,4 @@ contact_links:
   - name: Problem with the container image
     url: https://github.com/PrivateBin/docker-nginx-fpm-alpine/issues/new
     about: Please report all problems that apply only(!) to the official (Docker) image “docker-nginx-fpm-alpine” here.
-  - name: Security issue
-    url: https://github.com/PrivateBin/PrivateBin/security/policy
-    about: Please report security vulnerabilities and other security issues here.
 


### PR DESCRIPTION
Apparently GitHub now adds a security policy button by default (this is new, is not it?)? Also they have a policy report form behind that button. So reports can apparently now be made online at GitHub? (IMHO that is fine, just need to be aware of that)
![grafik](https://github.com/PrivateBin/PrivateBin/assets/11966684/20997f36-039c-47c1-b4a7-eb5c4ed4454f)


As such, IMHO two buttons would be confusing, so let's remove our custom one here?

