### PR TITLE
Fix error message about QA template

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/q-a.yml
+++ b/.github/DISCUSSION_TEMPLATE/q-a.yml
@@ -1,4 +1,3 @@
-title: ""
 labels: ["question/support"]
 body:
   - type: markdown


### PR DESCRIPTION
GitHub complains:
> title must be of type String and cannot be empty. [Learn more about this error.](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/common-validation-errors-when-creating-issue-forms#key-must-be-a-string)

Well then… as we don't want to provide a default title (see https://github.com/PrivateBin/PrivateBin/pull/1155) let's remove it.

The linked doc says:
> The error can be fixed by correcting the value to be a non-empty string. If the field is not required, you should delete the key-value pair.

So that should be valid.

