### PR TITLE
Also add FAQ section/tick box requirement for bug template

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/q-a.yml
+++ b/.github/DISCUSSION_TEMPLATE/q-a.yml
@@ -1,4 +1,3 @@
-title: ""
 labels: ["question/support"]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -10,6 +10,9 @@ assignees: ''
 <!-- Please make sure to **only** use this template when it is about bugs in the PrivateBin PHP project.
 Otherwise, for help and support issues e.g. for deployment issues, please go back and chose the appropiate category. -->
 
+**Did you use the FAQ section?**
+- [ ] Yes, I have read [the FAQ](https://github.com/PrivateBin/PrivateBin/wiki/FAQ) and I found no solution/answer there.
+
 <!-- Describe the bug: A clear and concise description of what the bug is. -->
 
 ## Steps to reproduce


### PR DESCRIPTION
It's apparently not enough to have in the Q/A, best is we have it here to.

The next step would be converting that into the same form like the QA template. After all, it may mostly just be copy paste as it is nearly identical but well…