### PR TITLE
add basic right-to-left (RTL) support

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,6 +2,7 @@ bin/configuration-test-generator export-ignore
 bin/icon-test export-ignore
 doc/ export-ignore
 tst/ export-ignore
+i18n/en.json export-ignore
 img/browserstack.svg export-ignore
 js/.istanbul.yml export-ignore
 js/.nycrc.yml export-ignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # PrivateBin version history
 
+  * **1.6.1 (not yet released)**
+    * ADDED: Right-To-Left (RTL) support for Arabic & Hebrew (#1174)
   * **1.6.0 (2023-09-11)**
     * ADDED: Translations for Japanese & Arabic
     * ADDED: Configuration option to disable Email button (#1164)

--- a/css/bootstrap/privatebin.css
+++ b/css/bootstrap/privatebin.css
@@ -113,6 +113,7 @@ body.loading {
 #qrcodemodalClose {
 	float: right;
 }
+
 #qrcode-display {
 	width: 200px;
 	height: 200px;
@@ -204,4 +205,24 @@ li.L0, li.L1, li.L2, li.L3, li.L5, li.L6, li.L7, li.L8 {
 
 .modal .modal-content button {
 	margin: 0.5em 0;
+}
+
+/* right-to-left overrides */
+html[dir="rtl"] .checkbox label {
+	padding-left: inherit;
+	padding-right: 20px;
+}
+
+html[dir="rtl"] .checkbox input[type="checkbox"] {
+	margin-left: inherit;
+	margin-right: -20px;
+}
+
+html[dir="rtl"] #language {
+	margin-left: inherit;
+	margin-right: 8px;
+}
+
+html[dir="rtl"] #deletelink, html[dir="rtl"] #qrcodemodalClose {
+	float: left;
 }

--- a/css/privatebin.css
+++ b/css/privatebin.css
@@ -261,6 +261,7 @@ button img {
 
 #newbutton {
 	float: right;
+	margin-left: 0;
 	margin-right: 0;
 	margin-bottom: 5px;
 	display: inline;
@@ -487,4 +488,18 @@ img.vizhash {
 
 #cleartext h3 {
 	font-size: 1.2em;
+}
+
+/* right-to-left overrides */
+html[dir="rtl"] #aboutbox, html[dir="rtl"] #deletelink, html[dir="rtl"] #newbutton {
+	float: left;
+}
+
+html[dir="rtl"] button, html[dir="rtl"] .button, html[dir="rtl"] button img {
+	margin-left: 5px;
+	margin-right: inherit;
+}
+
+html[dir="rtl"] button img {
+	margin-left: 8px;
 }

--- a/i18n/ar.json
+++ b/i18n/ar.json
@@ -3,7 +3,6 @@
     "%s is a minimalist, open source online pastebin where the server has zero knowledge of pasted data. Data is encrypted/decrypted %sin the browser%s using 256 bits AES.": "%s عبارة عن أداة لصق على الإنترنت بسيطة ومفتوحة المصدر حيث لا يمتلك الخادم أي معرفة بالبيانات الملصقة. يتم تشفير / فك تشفير البيانات %sفي المتصفح%s باستخدام 256 بت AES.",
     "More information on the <a href=\"https://privatebin.info/\">project page</a>.": "مزيد من المعلومات على <a href=\"https://privatebin.info/\">صفحة المشروع</a>.",
     "Because ignorance is bliss": "لأن الجهل نعمة",
-    "en": "ar",
     "Paste does not exist, has expired or has been deleted.": "اللصق غير موجود أو انتهت صلاحيته أو تم حذفه.",
     "%s requires php %s or above to work. Sorry.": "%s يتطلب php %s أو أعلى للعمل. آسف.",
     "%s requires configuration section [%s] to be present in configuration file.": "%s يتطلب وجود قسم [%s] تضبيط في ملف تضبيط.",

--- a/i18n/bg.json
+++ b/i18n/bg.json
@@ -3,7 +3,6 @@
     "%s is a minimalist, open source online pastebin where the server has zero knowledge of pasted data. Data is encrypted/decrypted %sin the browser%s using 256 bits AES.": "%s е изчистен и изцяло достъпен като отворен код, онлайн \"paste\" услуга, където сървъра не знае подадената информация. Тя се шифрова/дешифрова %sвъв браузъра%s използвайки 256 битов AES алгоритъм.",
     "More information on the <a href=\"https://privatebin.info/\">project page</a>.": "Повече информация може да намерите на <a href=\"https://privatebin.info/\">страницата на проекта (Английски)</a>.",
     "Because ignorance is bliss": "Невежеството е блаженство",
-    "en": "bg",
     "Paste does not exist, has expired or has been deleted.": "Информацията не съществува, срокът и е изтекъл или е била изтрита.",
     "%s requires php %s or above to work. Sorry.": "%s има нужда от PHP %s или по-нова, за да работи. Съжалявам.",
     "%s requires configuration section [%s] to be present in configuration file.": "%s задължава отдела от настройките [%s] да съществува във файла със настройките.",

--- a/i18n/ca.json
+++ b/i18n/ca.json
@@ -3,7 +3,6 @@
     "%s is a minimalist, open source online pastebin where the server has zero knowledge of pasted data. Data is encrypted/decrypted %sin the browser%s using 256 bits AES.": "%s és un pastebin en línia de codi obert i minimalista on el servidor no té coneixement de les dades enganxades. Les dades estan encriptades/desxifrades %sen el navegador%s utilitzant AES de 256 bits.",
     "More information on the <a href=\"https://privatebin.info/\">project page</a>.": "Més informació a la <a href=\"https://privatebin.info/\">pàgina del projecte</a>.",
     "Because ignorance is bliss": "Perquè la ignorància és felicitat",
-    "en": "ca",
     "Paste does not exist, has expired or has been deleted.": "El paste no existeix, ha caducat o s'ha eliminat.",
     "%s requires php %s or above to work. Sorry.": "%s requereix php %s o superior per funcionar. Ho sento.",
     "%s requires configuration section [%s] to be present in configuration file.": "%s requereix que la secció de configuració [%s] sigui present al fitxer de configuració.",

--- a/i18n/co.json
+++ b/i18n/co.json
@@ -3,7 +3,6 @@
     "%s is a minimalist, open source online pastebin where the server has zero knowledge of pasted data. Data is encrypted/decrypted %sin the browser%s using 256 bits AES.": "%s hè un serviziu in linea di tipu « pastebin » (ghjestiunariu d’appiccicu di pezzi di testu è di codice di fonte) minimalistu è à fonte aperta induve u servitore ùn hà micca cunnuscenza di i dati mandati. I dati sò cifrati è dicifrati %sin u navigatore%s cù una cifratura AES di 256 bit.",
     "More information on the <a href=\"https://privatebin.info/\">project page</a>.": "Più d’infurmazione annant’à a <a href=\"https://privatebin.info/\">pagina di u prughjettu</a>.",
     "Because ignorance is bliss": "Perchè l’ignurenza hè una campa",
-    "en": "co",
     "Paste does not exist, has expired or has been deleted.": "L’appiccicu ùn esiste micca, hè scadutu o hè statu squassatu.",
     "%s requires php %s or above to work. Sorry.": "Per disgrazzia, %s richiede php %s o più recente per funziunà.",
     "%s requires configuration section [%s] to be present in configuration file.": "%s richiede a presenza di a sezzione di cunfigurazione [%s] in a schedariu di cunfigurazione.",

--- a/i18n/cs.json
+++ b/i18n/cs.json
@@ -3,7 +3,6 @@
     "%s is a minimalist, open source online pastebin where the server has zero knowledge of pasted data. Data is encrypted/decrypted %sin the browser%s using 256 bits AES.": "%s je minimalistický open source 'pastebin' server, který neanalyzuje vložená data. Data jsou šifrována %sv prohlížeči%s pomocí 256 bitů AES.",
     "More information on the <a href=\"https://privatebin.info/\">project page</a>.": "Více informací na <a href=\"https://privatebin.info/\">stránce projetu</a>.",
     "Because ignorance is bliss": "Protože nevědomost je sladká",
-    "en": "cs",
     "Paste does not exist, has expired or has been deleted.": "Vložený text neexistuje, expiroval nebo byl odstraněn.",
     "%s requires php %s or above to work. Sorry.": "%s vyžaduje php %s nebo vyšší. Lituji.",
     "%s requires configuration section [%s] to be present in configuration file.": "%s vyžaduje, aby byla v konfiguračním souboru přítomna sekce [%s].",

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -3,7 +3,6 @@
     "%s is a minimalist, open source online pastebin where the server has zero knowledge of pasted data. Data is encrypted/decrypted %sin the browser%s using 256 bits AES.": "%s ist ein minimalistischer, quelloffener \"Pastebin\"-artiger Dienst, bei dem der Server keinerlei Kenntnis der Inhalte hat. Die Daten werden %sim Browser%s mit 256 Bit AES ver- und entschlüsselt.",
     "More information on the <a href=\"https://privatebin.info/\">project page</a>.": "Weitere Informationen sind auf der <a href=\"https://privatebin.info/\">Projektseite</a> zu finden.",
     "Because ignorance is bliss": "Unwissenheit ist ein Segen",
-    "en": "de",
     "Paste does not exist, has expired or has been deleted.": "Diesen Text gibt es nicht, er ist abgelaufen oder wurde gelöscht.",
     "%s requires php %s or above to work. Sorry.": "%s benötigt PHP %s oder höher, um zu funktionieren. Sorry.",
     "%s requires configuration section [%s] to be present in configuration file.": "%s benötigt den Konfigurationsabschnitt [%s] in der Konfigurationsdatei um zu funktionieren.",

--- a/i18n/el.json
+++ b/i18n/el.json
@@ -3,7 +3,6 @@
     "%s is a minimalist, open source online pastebin where the server has zero knowledge of pasted data. Data is encrypted/decrypted %sin the browser%s using 256 bits AES.": "%s είναι ένα λιτό, ανοικτού λογισμικού διαδικτυακής υπηρεσίας επικόλλησης όπου ο διακομιστής έχει πλήρη άγνια του περιεχομένου που επικολλήθηκαν. Τα Δεδομένα κρυπτογραφούνται και αποκρυπτογραφούνται %sστον φιλομετρητή (browser)%s χρησιμοποιόντας 256 bits AES.",
     "More information on the <a href=\"https://privatebin.info/\">project page</a>.": "Περισσότερες πληροφορίες στον <a href=\"https://privatebin.info/\">ιστότοπο του εργαλείου</a>.",
     "Because ignorance is bliss": "Επειδή η άγνοια είναι ευτυχία",
-    "en": "el",
     "Paste does not exist, has expired or has been deleted.": "Η επικόλληση δεν υπάρχει, έληξε ή διαγράφηκε",
     "%s requires php %s or above to work. Sorry.": "%s απαιτεί php %s ή νεότερη για να λειτουργήσει. Συγγνώμη.",
     "%s requires configuration section [%s] to be present in configuration file.": "%s απαιτεί οι ρυθμίσεις [%s] να υπάρχουν στο αρχείο ρυθμίσεων.",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -3,7 +3,6 @@
     "%s is a minimalist, open source online pastebin where the server has zero knowledge of pasted data. Data is encrypted/decrypted %sin the browser%s using 256 bits AES.": "%s is a minimalist, open source online pastebin where the server has zero knowledge of pasted data. Data is encrypted/decrypted %sin the browser%s using 256 bits AES.",
     "More information on the <a href=\"https://privatebin.info/\">project page</a>.": "More information on the <a href=\"https://privatebin.info/\">project page</a>.",
     "Because ignorance is bliss": "Because ignorance is bliss",
-    "en": "en",
     "Paste does not exist, has expired or has been deleted.": "Paste does not exist, has expired or has been deleted.",
     "%s requires php %s or above to work. Sorry.": "%s requires php %s or above to work. Sorry.",
     "%s requires configuration section [%s] to be present in configuration file.": "%s requires configuration section [%s] to be present in configuration file.",

--- a/i18n/es.json
+++ b/i18n/es.json
@@ -3,7 +3,6 @@
     "%s is a minimalist, open source online pastebin where the server has zero knowledge of pasted data. Data is encrypted/decrypted %sin the browser%s using 256 bits AES.": "%s es un \"pastebin\" en línea minimalista de código abierto, donde el servidor no tiene ningún conocimiento de los datos guardados. Los datos son cifrados/descifrados %sen el navegador%s usando 256 bits AES.",
     "More information on the <a href=\"https://privatebin.info/\">project page</a>.": "Más información en la <a href=\"https://privatebin.info/\">página del proyecto</a>.",
     "Because ignorance is bliss": "Porque la ignorancia es felicidad",
-    "en": "es",
     "Paste does not exist, has expired or has been deleted.": "El \"paste\" no existe, ha caducado o ha sido eliminado.",
     "%s requires php %s or above to work. Sorry.": "%s requiere php %s o superior para funcionar. Lo siento.",
     "%s requires configuration section [%s] to be present in configuration file.": "%s requiere que la sección de configuración [%s] esté presente en el archivo de configuración.",

--- a/i18n/et.json
+++ b/i18n/et.json
@@ -3,7 +3,6 @@
     "%s is a minimalist, open source online pastebin where the server has zero knowledge of pasted data. Data is encrypted/decrypted %sin the browser%s using 256 bits AES.": "%s on minimalistlik, avatud lähtekoodiga online pastebin, kus serveril pole kleebitud andmete kohta teadmist. Andmed krüpteeritakse/dekrüpteeritakse %sbrauseris%s kasutades 256-bitist AES-i.",
     "More information on the <a href=\"https://privatebin.info/\">project page</a>.": "Lisateave <a href=\"https://privatebin.info/\">projekti lehel</a>.",
     "Because ignorance is bliss": "Kuna teadmatus on õndsus",
-    "en": "et",
     "Paste does not exist, has expired or has been deleted.": "Kleebet ei eksisteeri, on aegunud või on kustutatud.",
     "%s requires php %s or above to work. Sorry.": "%s vajab, et oleks php %s või kõrgem, et töötada. Vabandame.",
     "%s requires configuration section [%s] to be present in configuration file.": "%s vajab, et [%s] seadistamise jaotis oleks olemas konfiguratsioonifailis.",

--- a/i18n/fi.json
+++ b/i18n/fi.json
@@ -3,7 +3,6 @@
     "%s is a minimalist, open source online pastebin where the server has zero knowledge of pasted data. Data is encrypted/decrypted %sin the browser%s using 256 bits AES.": "%s on minimalistinen, avoimen lähdekoodin online pastebin jossa palvelimella ei ole tietoa syötetystä datasta. Data salataan/puretaan %sselaimessa%s käyttäen 256-bittistä AES:ää.",
     "More information on the <a href=\"https://privatebin.info/\">project page</a>.": "Lisää tietoa <a href=\"https://privatebin.info/\">projektisivulla</a>.",
     "Because ignorance is bliss": "Koska tieto lisää tuskaa",
-    "en": "fi",
     "Paste does not exist, has expired or has been deleted.": "Pastea ei ole olemassa, se on vanhentunut tai se on poistettu.",
     "%s requires php %s or above to work. Sorry.": "%s vaatii php:n %s-version tai uudemman toimiakseen. Anteeksi.",
     "%s requires configuration section [%s] to be present in configuration file.": "%s vaatii konfiguraatio-osion [%s] olevan läsnä konfiguraatiotiedostossa.",

--- a/i18n/fr.json
+++ b/i18n/fr.json
@@ -3,7 +3,6 @@
     "%s is a minimalist, open source online pastebin where the server has zero knowledge of pasted data. Data is encrypted/decrypted %sin the browser%s using 256 bits AES.": "%s est un 'pastebin' (ou gestionnaire d'extraits de texte et de code source) minimaliste et open source, dans lequel le serveur n'a aucune connaissance des données envoyées. Les données sont chiffrées/déchiffrées %sdans le navigateur%s par un chiffrement AES 256 bits.",
     "More information on the <a href=\"https://privatebin.info/\">project page</a>.": "Plus d'informations sur <a href=\"https://privatebin.info/\">la page du projet</a>.",
     "Because ignorance is bliss": "Vivons heureux, vivons cachés",
-    "en": "fr",
     "Paste does not exist, has expired or has been deleted.": "Le paste n'existe pas, a expiré, ou a été supprimé.",
     "%s requires php %s or above to work. Sorry.": "Désolé, %s nécessite php %s ou supérieur pour fonctionner.",
     "%s requires configuration section [%s] to be present in configuration file.": "%s a besoin de la section de configuration [%s] dans le fichier de configuration pour fonctionner.",

--- a/i18n/he.json
+++ b/i18n/he.json
@@ -3,7 +3,6 @@
     "%s is a minimalist, open source online pastebin where the server has zero knowledge of pasted data. Data is encrypted/decrypted %sin the browser%s using 256 bits AES.": "%s is a minimalist, open source online pastebin where the server has zero knowledge of pasted data. Data is encrypted/decrypted %sin the browser%s using 256 bits AES.",
     "More information on the <a href=\"https://privatebin.info/\">project page</a>.": "More information on the <a href=\"https://privatebin.info/\">project page</a>.",
     "Because ignorance is bliss": "כיוון שבורות היא ברכה",
-    "en": "he",
     "Paste does not exist, has expired or has been deleted.": "ההדבקה לא קיימת, פגה או נמחקה.",
     "%s requires php %s or above to work. Sorry.": "%s דורש PHP %s כדי לפעול.",
     "%s requires configuration section [%s] to be present in configuration file.": "%s דורש שסעיף ההגדרות [%s] יהיה קיים בקובץ ההגדרות.",

--- a/i18n/hi.json
+++ b/i18n/hi.json
@@ -3,7 +3,6 @@
     "%s is a minimalist, open source online pastebin where the server has zero knowledge of pasted data. Data is encrypted/decrypted %sin the browser%s using 256 bits AES.": "%s is a minimalist, open source online pastebin where the server has zero knowledge of pasted data. Data is encrypted/decrypted %sin the browser%s using 256 bits AES.",
     "More information on the <a href=\"https://privatebin.info/\">project page</a>.": "More information on the <a href=\"https://privatebin.info/\">project page</a>.",
     "Because ignorance is bliss": "Because ignorance is bliss",
-    "en": "hi",
     "Paste does not exist, has expired or has been deleted.": "Paste does not exist, has expired or has been deleted.",
     "%s requires php %s or above to work. Sorry.": "%s requires php %s or above to work. Sorry.",
     "%s requires configuration section [%s] to be present in configuration file.": "%s requires configuration section [%s] to be present in configuration file.",

--- a/i18n/hu.json
+++ b/i18n/hu.json
@@ -3,7 +3,6 @@
     "%s is a minimalist, open source online pastebin where the server has zero knowledge of pasted data. Data is encrypted/decrypted %sin the browser%s using 256 bits AES.": "A %s egy minimalista, nyílt forráskódú adattároló szoftver, ahol a szerver semmilyen információt nem tárol a feltett adatról. Azt ugyanis a %sböngésződ%s segítségével titkosítja és oldja fel 256 bit hosszú titkosítási kulcsú AES-t használva.",
     "More information on the <a href=\"https://privatebin.info/\">project page</a>.": "További információt a <a href=\"https://privatebin.info/\">projekt oldalán</a> találsz.",
     "Because ignorance is bliss": "A titok egyfajta hatalom.",
-    "en": "hu",
     "Paste does not exist, has expired or has been deleted.": "A bejegyzés nem létezik, lejárt vagy törölve lett.",
     "%s requires php %s or above to work. Sorry.": "Bocs, de a %s működéséhez %s vagy ezt meghaladó verziójú php-s környezet szükséges.",
     "%s requires configuration section [%s] to be present in configuration file.": "A %s megfelelő működéséhez a konfigurációs fájlban a [%s] résznek léteznie kell.",

--- a/i18n/id.json
+++ b/i18n/id.json
@@ -3,7 +3,6 @@
     "%s is a minimalist, open source online pastebin where the server has zero knowledge of pasted data. Data is encrypted/decrypted %sin the browser%s using 256 bits AES.": "%s adalah sebuah pastebin online sumber terbuka dan minimalis, dimana servernya tersebut tidak punya pengetahuan tentang data yang ditempelkan. Data tersebut di enkrip/dekrip %sdi dalam browser%s menggunakan metode enkrip AES 256 bit.",
     "More information on the <a href=\"https://privatebin.info/\">project page</a>.": "Infomasi lebih lanjut pada <a href=\"https://privatebin.info/\">halaman proyek</a>.",
     "Because ignorance is bliss": "Karena ketidaktahuan adalah kebahagiaan, gitu loh",
-    "en": "id",
     "Paste does not exist, has expired or has been deleted.": "Paste tidak ada, telah kedaluwarsa atau telah dihapus.",
     "%s requires php %s or above to work. Sorry.": "%s memerlukan php %s atau versi diatasnya untuk dapat dijalankan. Maaf.",
     "%s requires configuration section [%s] to be present in configuration file.": "%s membutuhkan bagian konfigurasi [%s] untuk ada di file konfigurasi.",

--- a/i18n/it.json
+++ b/i18n/it.json
@@ -3,7 +3,6 @@
     "%s is a minimalist, open source online pastebin where the server has zero knowledge of pasted data. Data is encrypted/decrypted %sin the browser%s using 256 bits AES.": "%s è un sistema di tipo \"Pastebin\" online, open source, minimalista. Il server non possiede alcuna conoscenza (\"Zero Knowledge\") del contenuto dei dati inviati. I dati sono cifrati/decifrati %snel Browser%s con algoritmo AES a 256 Bit.",
     "More information on the <a href=\"https://privatebin.info/\">project page</a>.": "Per ulteriori informazioni, vedi <a href=\"https://privatebin.info/\">Sito del progetto</a>.",
     "Because ignorance is bliss": "Perché l'ignoranza è una benedizione (Because ignorance is bliss)",
-    "en": "it",
     "Paste does not exist, has expired or has been deleted.": "Questo messaggio non esiste, è scaduto o è stato cancellato.",
     "%s requires php %s or above to work. Sorry.": "%s richiede php %s o superiore per funzionare. Ci spiace.",
     "%s requires configuration section [%s] to be present in configuration file.": "%s richiede la presenza della sezione [%s] nei file di configurazione.",

--- a/i18n/ja.json
+++ b/i18n/ja.json
@@ -3,7 +3,6 @@
     "%s is a minimalist, open source online pastebin where the server has zero knowledge of pasted data. Data is encrypted/decrypted %sin the browser%s using 256 bits AES.": "%s is a minimalist, open source online pastebin where the server has zero knowledge of pasted data. Data is encrypted/decrypted %sin the browser%s using 256 bits AES.",
     "More information on the <a href=\"https://privatebin.info/\">project page</a>.": "More information on the <a href=\"https://privatebin.info/\">project page</a>.",
     "Because ignorance is bliss": "Because ignorance is bliss",
-    "en": "ja",
     "Paste does not exist, has expired or has been deleted.": "Paste does not exist, has expired or has been deleted.",
     "%s requires php %s or above to work. Sorry.": "%s requires php %s or above to work. Sorry.",
     "%s requires configuration section [%s] to be present in configuration file.": "%s requires configuration section [%s] to be present in configuration file.",

--- a/i18n/jbo.json
+++ b/i18n/jbo.json
@@ -3,7 +3,6 @@
     "%s is a minimalist, open source online pastebin where the server has zero knowledge of pasted data. Data is encrypted/decrypted %sin the browser%s using 256 bits AES.": ".i la %s mupli lo sorcu lo'e se setca kibro .i ji'a zo'e se zancari gi'e fingubni .i lo samse'u na djuno lo datni selru'e cu .i ba'e %sle brauzero%s ku mipri le do datni ku fi la'oi AES poi bitni li 256",
     "More information on the <a href=\"https://privatebin.info/\">project page</a>.": "More information on the <a href=\"https://privatebin.info/\">project page</a>.",
     "Because ignorance is bliss": ".i ki'u le ka na djuno cu ka saxfri",
-    "en": "jbo",
     "Paste does not exist, has expired or has been deleted.": "Paste does not exist, has expired or has been deleted.",
     "%s requires php %s or above to work. Sorry.": "%s requires php %s or above to work. Sorry.",
     "%s requires configuration section [%s] to be present in configuration file.": "%s requires configuration section [%s] to be present in configuration file.",

--- a/i18n/ku.json
+++ b/i18n/ku.json
@@ -3,7 +3,6 @@
     "%s is a minimalist, open source online pastebin where the server has zero knowledge of pasted data. Data is encrypted/decrypted %sin the browser%s using 256 bits AES.": "%s is a minimalist, open source online pastebin where the server has zero knowledge of pasted data. Data is encrypted/decrypted %sin the browser%s using 256 bits AES.",
     "More information on the <a href=\"https://privatebin.info/\">project page</a>.": "More information on the <a href=\"https://privatebin.info/\">project page</a>.",
     "Because ignorance is bliss": "Because ignorance is bliss",
-    "en": "ku",
     "Paste does not exist, has expired or has been deleted.": "Paste does not exist, has expired or has been deleted.",
     "%s requires php %s or above to work. Sorry.": "%s requires php %s or above to work. Sorry.",
     "%s requires configuration section [%s] to be present in configuration file.": "%s requires configuration section [%s] to be present in configuration file.",

--- a/i18n/la.json
+++ b/i18n/la.json
@@ -3,7 +3,6 @@
     "%s is a minimalist, open source online pastebin where the server has zero knowledge of pasted data. Data is encrypted/decrypted %sin the browser%s using 256 bits AES.": "%s is a minimalist, open source online pastebin where the server has zero knowledge of pasted data. Data is encrypted/decrypted %sin the browser%s using 256 bits AES.",
     "More information on the <a href=\"https://privatebin.info/\">project page</a>.": "More information on the <a href=\"https://privatebin.info/\">project page</a>.",
     "Because ignorance is bliss": "Because ignorance is bliss",
-    "en": "la",
     "Paste does not exist, has expired or has been deleted.": "Paste does not exist, has expired or has been deleted.",
     "%s requires php %s or above to work. Sorry.": "%s requires php %s or above to work. Sorry.",
     "%s requires configuration section [%s] to be present in configuration file.": "%s requires configuration section [%s] to be present in configuration file.",

--- a/i18n/lt.json
+++ b/i18n/lt.json
@@ -3,7 +3,6 @@
     "%s is a minimalist, open source online pastebin where the server has zero knowledge of pasted data. Data is encrypted/decrypted %sin the browser%s using 256 bits AES.": "%s yra minimalistinis, atvirojo kodo internetinis įdėjimų dėklas, kurį naudojant, serveris nieko nenutuokia apie įdėtus duomenis. Duomenys yra šifruojami/iššifruojami %snaršyklėje%s naudojant 256 bitų AES.",
     "More information on the <a href=\"https://privatebin.info/\">project page</a>.": "Daugiau informacijos rasite <a href=\"https://privatebin.info/\">projekto puslapyje</a>.",
     "Because ignorance is bliss": "Nes nežinojimas yra palaima",
-    "en": "lt",
     "Paste does not exist, has expired or has been deleted.": "Įdėjimo nėra, jis nebegalioja arba buvo ištrintas.",
     "%s requires php %s or above to work. Sorry.": "%s savo darbui reikalauja php %s arba naujesnės versijos. Apgailestaujame.",
     "%s requires configuration section [%s] to be present in configuration file.": "%s reikalauja, kad konfigūracijos faile būtų [%s] konfigūracijos sekcija.",

--- a/i18n/nl.json
+++ b/i18n/nl.json
@@ -3,7 +3,6 @@
     "%s is a minimalist, open source online pastebin where the server has zero knowledge of pasted data. Data is encrypted/decrypted %sin the browser%s using 256 bits AES.": "%s is een minimalistische, open source online pastebin waarbij de server geen kennis heeft van de paste data zelf. Gegevens worden gecodeerd/gedecodeerd %s in de browser %s met behulp van 256-bits AES.",
     "More information on the <a href=\"https://privatebin.info/\">project page</a>.": "Meer informatie is te vinden op de <a href=\"https://privatebin.info/\">projectpagina</a>.",
     "Because ignorance is bliss": "Onwetendheid is een zegen",
-    "en": "nl",
     "Paste does not exist, has expired or has been deleted.": "Paste bestaat niet, is verlopen of verwijderd.",
     "%s requires php %s or above to work. Sorry.": "%s vereist PHP %s of hoger om te kunnen werken. Sorry",
     "%s requires configuration section [%s] to be present in configuration file.": "%s vereist dat de configuratiesectie [%s] aanwezig is in het configuratiebestand",

--- a/i18n/no.json
+++ b/i18n/no.json
@@ -3,7 +3,6 @@
     "%s is a minimalist, open source online pastebin where the server has zero knowledge of pasted data. Data is encrypted/decrypted %sin the browser%s using 256 bits AES.": "%s er en minimalistisk, åpen kildekode, elektronisk tilgjengelig pastebin hvor serveren ikke har kunnskap om dataene som limes inn. Dataene krypteres/dekrypteres %si nettleseren%s ved hjelp av 256 bits AES.",
     "More information on the <a href=\"https://privatebin.info/\">project page</a>.": "Mer informasjon om prosjektet på <a href=\"https://privatebin.info/\">prosjektsiden</a>.",
     "Because ignorance is bliss": "Fordi uvitenhet er lykke",
-    "en": "no",
     "Paste does not exist, has expired or has been deleted.": "Innlegget eksisterer ikke, er utløpt eller har blitt slettet.",
     "%s requires php %s or above to work. Sorry.": "Beklager, %s krever php %s eller nyere for å kjøre.",
     "%s requires configuration section [%s] to be present in configuration file.": "%s krever konfigurasjonsdel [%s] å være til stede i konfigurasjonsfilen .",

--- a/i18n/oc.json
+++ b/i18n/oc.json
@@ -3,7 +3,6 @@
     "%s is a minimalist, open source online pastebin where the server has zero knowledge of pasted data. Data is encrypted/decrypted %sin the browser%s using 256 bits AES.": "%s es un 'pastebin' (o gestionari d’extrachs de tèxte e còdi font) minimalista e open source, dins lo qual lo servidor a pas cap de coneissença de las donadas mandadas. Las donadas son chifradas/deschifradas %sdins lo navigator%s per un chiframent AES 256 bits.",
     "More information on the <a href=\"https://privatebin.info/\">project page</a>.": "Mai informacions sus <a href=\"https://privatebin.info/\">la pagina del projècte</a>.",
     "Because ignorance is bliss": "Perque lo bonaür es l’ignorància",
-    "en": "oc",
     "Paste does not exist, has expired or has been deleted.": "Lo tèxte existís pas, a expirat, o es estat suprimit.",
     "%s requires php %s or above to work. Sorry.": "O planhèm, %s necessita php %s o superior per foncionar.",
     "%s requires configuration section [%s] to be present in configuration file.": "%s fa besonh de la seccion de configuracion [%s] dins lo fichièr de configuracion per foncionar.",

--- a/i18n/pl.json
+++ b/i18n/pl.json
@@ -3,7 +3,6 @@
     "%s is a minimalist, open source online pastebin where the server has zero knowledge of pasted data. Data is encrypted/decrypted %sin the browser%s using 256 bits AES.": "%s jest minimalistycznym, otwartoźródłowym serwisem typu pastebin, w którym serwer nie ma jakichkolwiek informacji o tym, co jest wklejane. Dane są szyfrowane i deszyfrowane %sw przeglądarce%s z użyciem 256-bitowego klucza AES.",
     "More information on the <a href=\"https://privatebin.info/\">project page</a>.": "Więcej informacji na <a href=\"https://privatebin.info/\">stronie projektu</a>.",
     "Because ignorance is bliss": "Ponieważ ignorancja jest cnotą",
-    "en": "pl",
     "Paste does not exist, has expired or has been deleted.": "Wklejka nie istnieje, wygasła albo została usunięta.",
     "%s requires php %s or above to work. Sorry.": "%s wymaga PHP w wersji %s lub nowszej. Przykro mi.",
     "%s requires configuration section [%s] to be present in configuration file.": "%s wymaga obecności sekcji [%s] w pliku konfiguracyjnym.",

--- a/i18n/pt.json
+++ b/i18n/pt.json
@@ -3,7 +3,6 @@
     "%s is a minimalist, open source online pastebin where the server has zero knowledge of pasted data. Data is encrypted/decrypted %sin the browser%s using 256 bits AES.": "%s é um serviço minimalista e de código aberto do tipo \"pastebin\", em que o servidor tem zero conhecimento dos dados copiados. Os dados são cifrados e decifrados %sno navegador%s usando 256 bits AES.",
     "More information on the <a href=\"https://privatebin.info/\">project page</a>.": "Mais informações na <a href=\"https://privatebin.info/\">página do projeto</a>.",
     "Because ignorance is bliss": "Porque a ignorância é uma benção",
-    "en": "pt",
     "Paste does not exist, has expired or has been deleted.": "A cópia não existe, expirou ou já foi excluída.",
     "%s requires php %s or above to work. Sorry.": "%s requer php %s ou superior para funcionar. Desculpa.",
     "%s requires configuration section [%s] to be present in configuration file.": "%s requer que a seção de configuração [% s] esteja no arquivo de configuração.",

--- a/i18n/ru.json
+++ b/i18n/ru.json
@@ -3,7 +3,6 @@
     "%s is a minimalist, open source online pastebin where the server has zero knowledge of pasted data. Data is encrypted/decrypted %sin the browser%s using 256 bits AES.": "%s это минималистичный Open Source проект для создания заметок, где сервер не знает ничего о сохраняемых данных. Данные шифруются/расшифровываются %sв браузере%s с использованием 256 битного шифрования AES.",
     "More information on the <a href=\"https://privatebin.info/\">project page</a>.": "Подробнее можно узнать на <a href=\"https://privatebin.info/\">сайте проекта</a>.",
     "Because ignorance is bliss": "Потому что неведение - благо",
-    "en": "ru",
     "Paste does not exist, has expired or has been deleted.": "Запись не существует, просрочена или была удалена.",
     "%s requires php %s or above to work. Sorry.": "Для работы %s требуется php %s или выше. Извините.",
     "%s requires configuration section [%s] to be present in configuration file.": "%s необходимо наличие секции [%s] в конфигурационном файле.",

--- a/i18n/sk.json
+++ b/i18n/sk.json
@@ -3,7 +3,6 @@
     "%s is a minimalist, open source online pastebin where the server has zero knowledge of pasted data. Data is encrypted/decrypted %sin the browser%s using 256 bits AES.": "%s je minimalistický, open source online pastebin, kde server nemá žiadne znalosti o vložených údajoch. Údaje sú šifrované/dešifrované %sv prehliadači%s pomocou 256-bitového AES.",
     "More information on the <a href=\"https://privatebin.info/\">project page</a>.": "Viac informácií na <a href=\"https://privatebin.info/\">stránke projektu</a>.",
     "Because ignorance is bliss": "Pretože nevedomosť je sladká",
-    "en": "sk",
     "Paste does not exist, has expired or has been deleted.": "Vložený text neexistuje, jeho platnosť vypršala alebo bol vymazaný.",
     "%s requires php %s or above to work. Sorry.": "%s vyžaduje php %s alebo vyššie. Prepáčte.",
     "%s requires configuration section [%s] to be present in configuration file.": "%s vyžaduje, aby bola v konfiguračnom súbore prítomná sekcia [%s].",

--- a/i18n/sl.json
+++ b/i18n/sl.json
@@ -3,7 +3,6 @@
     "%s is a minimalist, open source online pastebin where the server has zero knowledge of pasted data. Data is encrypted/decrypted %sin the browser%s using 256 bits AES.": "%s je minimalističen, odprtokodni spletni 'pastebin', kjer server ne ve ničesar o prilepljenih podatkih. Podatki so zakodirani/odkodirani %sv brskalniku%s z uporabo 256 bitnega AES.",
     "More information on the <a href=\"https://privatebin.info/\">project page</a>.": "Več informacij na <a href=\"https://privatebin.info/\">spletni strani projekta.</a>.",
     "Because ignorance is bliss": "Ker kar ne veš ne boli.",
-    "en": "sl",
     "Paste does not exist, has expired or has been deleted.": "Prilepek ne obstaja, mu je potekla življenjska doba, ali pa je izbrisan.",
     "%s requires php %s or above to work. Sorry.": "Oprosti, %s za delovanje potrebuje vsaj php %s.",
     "%s requires configuration section [%s] to be present in configuration file.": "%s potrebuje sekcijo konfiguracij [%s] v konfiguracijski datoteki.",

--- a/i18n/sv.json
+++ b/i18n/sv.json
@@ -3,7 +3,6 @@
     "%s is a minimalist, open source online pastebin where the server has zero knowledge of pasted data. Data is encrypted/decrypted %sin the browser%s using 256 bits AES.": "%s is a minimalist, open source online pastebin where the server has zero knowledge of pasted data. Data is encrypted/decrypted %sin the browser%s using 256 bits AES.",
     "More information on the <a href=\"https://privatebin.info/\">project page</a>.": "More information on the <a href=\"https://privatebin.info/\">project page</a>.",
     "Because ignorance is bliss": "Because ignorance is bliss",
-    "en": "sv",
     "Paste does not exist, has expired or has been deleted.": "Paste does not exist, has expired or has been deleted.",
     "%s requires php %s or above to work. Sorry.": "%s requires php %s or above to work. Sorry.",
     "%s requires configuration section [%s] to be present in configuration file.": "%s requires configuration section [%s] to be present in configuration file.",

--- a/i18n/th.json
+++ b/i18n/th.json
@@ -3,7 +3,6 @@
     "%s is a minimalist, open source online pastebin where the server has zero knowledge of pasted data. Data is encrypted/decrypted %sin the browser%s using 256 bits AES.": "%s เป็น pastebin ออนไลน์แบบโอเพ่นซอร์สที่มีรูปแบบการใช้งานที่เรียบง่าย เซิร์ฟเวอร์ไม่สามารถรู้ได้ว่าข้อมูลโค้ดที่มาฝากนั้นเป็นข้อมูลอะไร โดยจะถูกเข้ารหัส/ถอดรหัสด้วยกระบวนการ AES จำนวน 256 บิต%sผ่านเบราว์เซอร์%s",
     "More information on the <a href=\"https://privatebin.info/\">project page</a>.": "ข้อมูลเพิ่มเติม ดูได้ที่<a href=\"https://privatebin.info/\">หน้าโครงการ</a>",
     "Because ignorance is bliss": "ไม่รู้ไม่ชี้ดีที่สุด",
-    "en": "th",
     "Paste does not exist, has expired or has been deleted.": "การฝากโค้ดไม่มีอยู่ อาจจะหมดอายุหรือถูกลบไปแล้ว",
     "%s requires php %s or above to work. Sorry.": "ขออภัย %s ต้องใช้ PHP %s ขึ้นไปจึงจะใช้งานได้",
     "%s requires configuration section [%s] to be present in configuration file.": "%s จำเป็นต้องตั้งค่าตัวแปร [%s] ในไฟล์กำหนดค่า",

--- a/i18n/tr.json
+++ b/i18n/tr.json
@@ -3,7 +3,6 @@
     "%s is a minimalist, open source online pastebin where the server has zero knowledge of pasted data. Data is encrypted/decrypted %sin the browser%s using 256 bits AES.": "%s sunucunun burada paylaştığınız veriyi görmediği, minimal, açık kaynak bir pastebindir. Veriler tarayıcıda 256 bit AES kullanılarak şifrelenir/çözülür.",
     "More information on the <a href=\"https://privatebin.info/\">project page</a>.": "Daha fazla bilgi için <a href=\"https://privatebin.info/\">proje sayfası</a>'na göz atabilirsiniz.",
     "Because ignorance is bliss": "Çünkü, cehalet mutluluktur",
-    "en": "tr",
     "Paste does not exist, has expired or has been deleted.": "Paste does not exist, has expired or has been deleted.",
     "%s requires php %s or above to work. Sorry.": "%s PHP %s veya daha üstünü gerektirir.",
     "%s requires configuration section [%s] to be present in configuration file.": "%s konfigürasyon bölümünün [%s] bulunmasını gerektir.",

--- a/i18n/uk.json
+++ b/i18n/uk.json
@@ -3,7 +3,6 @@
     "%s is a minimalist, open source online pastebin where the server has zero knowledge of pasted data. Data is encrypted/decrypted %sin the browser%s using 256 bits AES.": "%s це мінімалістичний Open Source проєкт для створення нотаток, де сервер не знає нічого про дані, що зберігаються. Дані шифруються/розшифровуються %sу переглядачі%s з використанням 256-бітного шифрувания AES.",
     "More information on the <a href=\"https://privatebin.info/\">project page</a>.": "Подробиці можна дізнатися на <a href=\"https://privatebin.info/\">сайті проєкту</a>.",
     "Because ignorance is bliss": "Бо незнання - благо",
-    "en": "uk",
     "Paste does not exist, has expired or has been deleted.": "Допис не існує, протермінований чи був видалений.",
     "%s requires php %s or above to work. Sorry.": "Для роботи %s потрібен php %s и вище. Вибачте.",
     "%s requires configuration section [%s] to be present in configuration file.": "%s потрібна секція [%s] в конфігураційному файлі.",

--- a/i18n/zh.json
+++ b/i18n/zh.json
@@ -3,7 +3,6 @@
     "%s is a minimalist, open source online pastebin where the server has zero knowledge of pasted data. Data is encrypted/decrypted %sin the browser%s using 256 bits AES.": "%s 是一个极简、开源、对粘贴内容毫不知情的在线粘贴板，数据%s在浏览器内%s进行 AES-256 加密和解密。",
     "More information on the <a href=\"https://privatebin.info/\">project page</a>.": "更多信息请查看<a href=\"https://privatebin.info/\">项目主页</a>。",
     "Because ignorance is bliss": "因为无知是福",
-    "en": "zh",
     "Paste does not exist, has expired or has been deleted.": "粘贴内容不存在、已过期或已被删除。",
     "%s requires php %s or above to work. Sorry.": "抱歉，%s 需要 PHP %s 及以上版本才能运行。",
     "%s requires configuration section [%s] to be present in configuration file.": "%s 需要设置配置文件中的 [%s] 部分。",

--- a/js/privatebin.js
+++ b/js/privatebin.js
@@ -791,6 +791,18 @@ jQuery.PrivateBin = (function($, RawDeflate) {
         };
 
         /**
+         * get currently loaded language
+         *
+         * @name   I18n.getLanguage
+         * @function
+         * @return {string}
+         */
+        me.getLanguage = function()
+        {
+            return language;
+        };
+
+        /**
          * per language functions to use to determine the plural form
          *
          * @see    {@link https://docs.translatehouse.org/projects/localization-guide/en/latest/l10n/pluralforms.html}
@@ -847,7 +859,10 @@ jQuery.PrivateBin = (function($, RawDeflate) {
 
             // auto-select language based on browser settings
             if (newLanguage.length === 0) {
-                newLanguage = (navigator.language || navigator.userLanguage || 'en').substring(0, 2);
+                newLanguage = (navigator.language || navigator.userLanguage || 'en');
+                if (newLanguage.indexOf('-') > 0) {
+                    newLanguage = newLanguage.split('-')[0];
+                }
             }
 
             // if language is already used skip update

--- a/js/test/I18n.js
+++ b/js/test/I18n.js
@@ -193,10 +193,11 @@ describe('I18n', function () {
                 // mock
                 clean = jsdom('', {cookie: ['lang=' + language]});
                 $.PrivateBin.I18n.reset(language, require('../../i18n/' + language + '.json'));
-                var result = $.PrivateBin.I18n.translate('en'),
-                    alias  = $.PrivateBin.I18n._('en');
+                var loadedLang = $.PrivateBin.I18n.getLanguage(),
+                    result = $.PrivateBin.I18n.translate('Never'),
+                    alias  = $.PrivateBin.I18n._('Never');
                 clean();
-                return language === result && language === alias;
+                return language === loadedLang && result === alias;
             }
         );
 
@@ -216,13 +217,12 @@ describe('I18n', function () {
 
                 $.PrivateBin.I18n.reset('en');
                 $.PrivateBin.I18n.loadTranslations();
-                var result = $.PrivateBin.I18n.translate('en'),
-                    alias  = $.PrivateBin.I18n._('en');
+                var result = $.PrivateBin.I18n.translate('Never'),
+                    alias  = $.PrivateBin.I18n._('Never');
 
                 clean();
-                return 'en' === result && 'en' === alias;
+                return 'Never' === result && 'Never' === alias;
             }
         );
     });
 });
-

--- a/lib/I18n.php
+++ b/lib/I18n.php
@@ -273,6 +273,18 @@ class I18n
     }
 
     /**
+     * determines if the current language is written right-to-left (RTL)
+     *
+     * @access public
+     * @static
+     * @return bool
+     */
+    public static function isRtl()
+    {
+        return in_array(self::$_language, array('ar', 'he'));
+    }
+
+    /**
      * set the default language
      *
      * @access public

--- a/tpl/bootstrap.php
+++ b/tpl/bootstrap.php
@@ -4,7 +4,7 @@ $isCpct = substr($template, 9, 8) === '-compact';
 $isDark = substr($template, 9, 5) === '-dark';
 $isPage = substr($template, -5) === '-page';
 ?><!DOCTYPE html>
-<html lang="<?php echo I18n::_('en'); ?>">
+<html lang="<?php echo I18n::getLanguage(); ?>"<?php echo I18n::isRtl() ? ' dir="rtl"' : ''; ?>>
 	<head>
 		<meta charset="utf-8" />
 		<meta http-equiv="Content-Security-Policy" content="<?php echo I18n::encode($CSPHEADER); ?>">
@@ -73,7 +73,7 @@ endif;
 ?>
 		<script type="text/javascript" data-cfasync="false" src="js/purify-3.0.4.js" integrity="sha512-N7H+3ylaOUeKuTX57cZoa42hqaG5w1rchG/IP9+BHd48W/vESgPDpb5QuDqzJE1dZhrGVCQgU8peIQGHmdGFhQ==" crossorigin="anonymous"></script>
 		<script type="text/javascript" data-cfasync="false" src="js/legacy.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-LYos+qXHIRqFf5ZPNphvtTB0cgzHUizu2wwcOwcwz/VIpRv9lpcBgPYz4uq6jx0INwCAj6Fbnl5HoKiLufS2jg==" crossorigin="anonymous"></script>
-		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-bvLSauH52p3a1alLFQ7YYbl95KUHaf4oVPsUeIqVEBry0c30By+chwu3o5cXUPWB/+OAz0TY00P+k+lquMsAcQ==" crossorigin="anonymous"></script>
+		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-ykPMZuZDmyGNik7G5dIeqE/+CJ79OKZ0XzPPVWUwAzp+k8PQoP66J8F8zYtI53dM4ITLojkNKrv4vTv6E3bzFQ==" crossorigin="anonymous"></script>
 		<!-- icon -->
 		<link rel="apple-touch-icon" href="<?php echo I18n::encode($BASEPATH); ?>img/apple-touch-icon.png" sizes="180x180" />
 		<link rel="icon" type="image/png" href="img/favicon-32x32.png" sizes="32x32" />

--- a/tpl/page.php
+++ b/tpl/page.php
@@ -1,7 +1,7 @@
 <?php
 use PrivateBin\I18n;
 ?><!DOCTYPE html>
-<html lang="<?php echo I18n::_('en'); ?>">
+<html lang="<?php echo I18n::getLanguage(); ?>"<?php echo I18n::isRtl() ? ' dir="rtl"' : ''; ?>>
 	<head>
 		<meta charset="utf-8" />
 		<meta http-equiv="Content-Security-Policy" content="<?php echo I18n::encode($CSPHEADER); ?>">
@@ -51,7 +51,7 @@ endif;
 ?>
 		<script type="text/javascript" data-cfasync="false" src="js/purify-3.0.4.js" integrity="sha512-N7H+3ylaOUeKuTX57cZoa42hqaG5w1rchG/IP9+BHd48W/vESgPDpb5QuDqzJE1dZhrGVCQgU8peIQGHmdGFhQ==" crossorigin="anonymous"></script>
 		<script type="text/javascript" data-cfasync="false" src="js/legacy.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-LYos+qXHIRqFf5ZPNphvtTB0cgzHUizu2wwcOwcwz/VIpRv9lpcBgPYz4uq6jx0INwCAj6Fbnl5HoKiLufS2jg==" crossorigin="anonymous"></script>
-		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-bvLSauH52p3a1alLFQ7YYbl95KUHaf4oVPsUeIqVEBry0c30By+chwu3o5cXUPWB/+OAz0TY00P+k+lquMsAcQ==" crossorigin="anonymous"></script>
+		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-ykPMZuZDmyGNik7G5dIeqE/+CJ79OKZ0XzPPVWUwAzp+k8PQoP66J8F8zYtI53dM4ITLojkNKrv4vTv6E3bzFQ==" crossorigin="anonymous"></script>
 		<!-- icon -->
 		<link rel="apple-touch-icon" href="img/apple-touch-icon.png?<?php echo rawurlencode($VERSION); ?>" sizes="180x180" />
 		<link rel="icon" type="image/png" href="img/favicon-32x32.png?<?php echo rawurlencode($VERSION); ?>" sizes="32x32" />

--- a/tpl/yourlsproxy.php
+++ b/tpl/yourlsproxy.php
@@ -1,7 +1,7 @@
 <?php
 use PrivateBin\I18n;
 ?><!DOCTYPE html>
-<html lang="<?php echo I18n::_('en'); ?>">
+<html lang="<?php echo I18n::getLanguage(); ?>"<?php echo I18n::isRtl() ? ' dir="rtl"' : ''; ?>>
 	<head>
 		<meta charset="utf-8" />
 		<meta http-equiv="Content-Security-Policy" content="<?php echo I18n::encode($CSPHEADER); ?>">

--- a/tst/I18nTest.php
+++ b/tst/I18nTest.php
@@ -34,7 +34,7 @@ class I18nTest extends TestCase
     {
         $_COOKIE['lang'] = 'de';
         I18n::loadTranslations();
-        $this->assertEquals($this->_translations['en'], I18n::_('en'), 'browser language de');
+        $this->assertEquals($_COOKIE['lang'], I18n::getLanguage(), 'browser language de');
         $this->assertEquals('0 Stunden', I18n::_('%d hours', 0), '0 hours in German');
         $this->assertEquals('1 Stunde',  I18n::_('%d hours', 1), '1 hour in German');
         $this->assertEquals('2 Stunden', I18n::_('%d hours', 2), '2 hours in German');
@@ -44,7 +44,7 @@ class I18nTest extends TestCase
     {
         $_SERVER['HTTP_ACCEPT_LANGUAGE'] = 'de-CH,de;q=0.8,en-GB;q=0.6,en-US;q=0.4,en;q=0.2,fr;q=0.0';
         I18n::loadTranslations();
-        $this->assertEquals($this->_translations['en'], I18n::_('en'), 'browser language de');
+        $this->assertEquals('de', I18n::getLanguage(), 'browser language de');
         $this->assertEquals('0 Stunden', I18n::_('%d hours', 0), '0 hours in German');
         $this->assertEquals('1 Stunde',  I18n::_('%d hours', 1), '1 hour in German');
         $this->assertEquals('2 Stunden', I18n::_('%d hours', 2), '2 hours in German');
@@ -54,7 +54,7 @@ class I18nTest extends TestCase
     {
         $_SERVER['HTTP_ACCEPT_LANGUAGE'] = 'fr-CH,fr;q=0.8,en-GB;q=0.6,en-US;q=0.4,en;q=0.2,de;q=0.0';
         I18n::loadTranslations();
-        $this->assertEquals('fr', I18n::_('en'), 'browser language fr');
+        $this->assertEquals('fr', I18n::getLanguage(), 'browser language fr');
         $this->assertEquals('0 heure',  I18n::_('%d hours', 0), '0 hours in French');
         $this->assertEquals('1 heure',  I18n::_('%d hours', 1), '1 hour in French');
         $this->assertEquals('2 heures', I18n::_('%d hours', 2), '2 hours in French');
@@ -64,7 +64,7 @@ class I18nTest extends TestCase
     {
         $_SERVER['HTTP_ACCEPT_LANGUAGE'] = 'no;q=0.8,en-GB;q=0.6,en-US;q=0.4,en;q=0.2';
         I18n::loadTranslations();
-        $this->assertEquals('no', I18n::_('en'), 'browser language no');
+        $this->assertEquals('no', I18n::getLanguage(), 'browser language no');
         $this->assertEquals('0 timer',  I18n::_('%d hours', 0), '0 hours in Norwegian');
         $this->assertEquals('1 time',  I18n::_('%d hours', 1), '1 hour in Norwegian');
         $this->assertEquals('2 timer', I18n::_('%d hours', 2), '2 hours in Norwegian');
@@ -74,7 +74,7 @@ class I18nTest extends TestCase
     {
         $_SERVER['HTTP_ACCEPT_LANGUAGE'] = 'oc;q=0.8,en-GB;q=0.6,en-US;q=0.4,en;q=0.2';
         I18n::loadTranslations();
-        $this->assertEquals('oc', I18n::_('en'), 'browser language oc');
+        $this->assertEquals('oc', I18n::getLanguage(), 'browser language oc');
         $this->assertEquals('0 ora',  I18n::_('%d hours', 0), '0 hours in Occitan');
         $this->assertEquals('1 ora',  I18n::_('%d hours', 1), '1 hour in Occitan');
         $this->assertEquals('2 oras', I18n::_('%d hours', 2), '2 hours in Occitan');
@@ -84,7 +84,7 @@ class I18nTest extends TestCase
     {
         $_SERVER['HTTP_ACCEPT_LANGUAGE'] = 'zh;q=0.8,en-GB;q=0.6,en-US;q=0.4,en;q=0.2';
         I18n::loadTranslations();
-        $this->assertEquals('zh', I18n::_('en'), 'browser language zh');
+        $this->assertEquals('zh', I18n::getLanguage(), 'browser language zh');
         $this->assertEquals('0 小时',  I18n::_('%d hours', 0), '0 hours in Chinese');
         $this->assertEquals('1 小时',  I18n::_('%d hours', 1), '1 hour in Chinese');
         $this->assertEquals('2 小时', I18n::_('%d hours', 2), '2 hours in Chinese');
@@ -94,7 +94,7 @@ class I18nTest extends TestCase
     {
         $_SERVER['HTTP_ACCEPT_LANGUAGE'] = 'pl;q=0.8,en-GB;q=0.6,en-US;q=0.4,en;q=0.2';
         I18n::loadTranslations();
-        $this->assertEquals('pl', I18n::_('en'), 'browser language pl');
+        $this->assertEquals('pl', I18n::getLanguage(), 'browser language pl');
         $this->assertEquals('1 godzina', I18n::_('%d hours', 1), '1 hour in Polish');
         $this->assertEquals('2 godzina', I18n::_('%d hours', 2), '2 hours in Polish');
         $this->assertEquals('12 godzinę', I18n::_('%d hours', 12), '12 hours in Polish');
@@ -109,7 +109,7 @@ class I18nTest extends TestCase
     {
         $_SERVER['HTTP_ACCEPT_LANGUAGE'] = 'ru;q=0.8,en-GB;q=0.6,en-US;q=0.4,en;q=0.2';
         I18n::loadTranslations();
-        $this->assertEquals('ru', I18n::_('en'), 'browser language ru');
+        $this->assertEquals('ru', I18n::getLanguage(), 'browser language ru');
         $this->assertEquals('1 минуту',  I18n::_('%d minutes', 1), '1 minute in Russian');
         $this->assertEquals('3 минуты',  I18n::_('%d minutes', 3), '3 minutes in Russian');
         $this->assertEquals('10 минут',  I18n::_('%d minutes', 10), '10 minutes in Russian');
@@ -120,7 +120,7 @@ class I18nTest extends TestCase
     {
         $_SERVER['HTTP_ACCEPT_LANGUAGE'] = 'sl;q=0.8,en-GB;q=0.6,en-US;q=0.4,en;q=0.2';
         I18n::loadTranslations();
-        $this->assertEquals('sl', I18n::_('en'), 'browser language sl');
+        $this->assertEquals('sl', I18n::getLanguage(), 'browser language sl');
         $this->assertEquals('0 ura',  I18n::_('%d hours', 0), '0 hours in Slowene');
         $this->assertEquals('1 uri',  I18n::_('%d hours', 1), '1 hour in Slowene');
         $this->assertEquals('2 ure', I18n::_('%d hours', 2), '2 hours in Slowene');
@@ -135,7 +135,7 @@ class I18nTest extends TestCase
     {
         $_SERVER['HTTP_ACCEPT_LANGUAGE'] = 'cs;q=0.8,en-GB;q=0.6,en-US;q=0.4,en;q=0.2';
         I18n::loadTranslations();
-        $this->assertEquals('cs', I18n::_('en'), 'browser language cs');
+        $this->assertEquals('cs', I18n::getLanguage(), 'browser language cs');
         $this->assertEquals('1 hodina', I18n::_('%d hours', 1), '1 hour in Czech');
         $this->assertEquals('2 hodiny', I18n::_('%d hours', 2), '2 hours in Czech');
         $this->assertEquals('5 minut',  I18n::_('%d minutes', 5), '5 minutes in Czech');
@@ -146,7 +146,7 @@ class I18nTest extends TestCase
     {
         $_SERVER['HTTP_ACCEPT_LANGUAGE'] = '*';
         I18n::loadTranslations();
-        $this->assertTrue(strlen(I18n::_('en')) >= 2, 'browser language any');
+        $this->assertTrue(strlen(I18n::getLanguage()) >= 2, 'browser language any');
     }
 
     public function testVariableInjection()


### PR DESCRIPTION
This PR fixes #1174

## Changes
* remove need for the language label translation, we already provide a function for the loaded translation in PHP, added the same in JS for unit testing purposes
* allow Lojban to be used as a browser language (handle "jbo", which is 3 letters instead of two, so search and split by dash instead)
* remove en.json from being packaged/released - it is not accessed by any of our code paths and only used by Crowdin when adding new translations
* adds direction right-to-left if Arabic or Hebrew are used
* adds some CSS overrides to adjust icon alignment
* bootstrap 3 doesn't yet support RTL for nav-bars, so those elements are currently not re-ordered, but on the page template the menus do get displayed in right-to-left order

Result (compare with before screenshots in #1174):

![bootstrap-rtl](https://github.com/PrivateBin/PrivateBin/assets/1017622/171522e3-2d3e-407a-acb4-5bc0c9afc945)

![page-rtl](https://github.com/PrivateBin/PrivateBin/assets/1017622/456543f2-f80b-4a37-b3fc-44bf84272019)
