### PR TITLE
enable unit testing on PHP 8.3 &  8.4 nightly

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['7.3', '7.4', '8.0', '8.1', '8.2']
+        php-versions: ['7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
     name: PHP ${{ matrix.php-versions }} unit tests on ${{ matrix.operating-system }}
     env:
       extensions: gd, sqlite3

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ tst/.phpunit.result.cache
 .settings
 .buildpath
 .project
+.phpdoc
 .externalToolBuilders
 .c9
 /.idea/


### PR DESCRIPTION
It doesn't seem like we hit any new warnings or deprecations. 8.4 is obviously provisional as it's a development branch. 8.3 got released last week. Seems we are ready for it.

The only feature that looked interesting to me was the new [json_validate](https://www.php.net/manual/en/function.json-validate.php) function - I checked our use of json_decode, but in all cases we also consume the result, so we would not benefit of validating it first, as we then would be processing it twice. It is a good fit when you are just an API that stores / passes on a valid JSON without parsing it.