### PR TITLE
move postCreateCommands to a separate file

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -40,11 +40,7 @@
     "forwardPorts": [
         8080
     ],
-    "postCreateCommand": [
-        "composer install --no-dev --optimize-autoloader",
-        "sudo chmod a+x \"$(pwd)\" && sudo rm -rf /var/www/html && sudo ln -s \"$(pwd)\" /var/www/html",
-        "npm install --global nyc"
-    ],
+    "postCreateCommand": ".devcontainer/postCreateCommand.sh",
     // alternatiuve: apache2ctl start (but requires root)
     "postAttachCommand": "php -S 0.0.0.0:8080"
 }

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 composer install --no-dev --optimize-autoloader
 sudo chmod a+x "$(pwd)" && sudo rm -rf /var/www/html && sudo ln -s "$(pwd)" /var/www/html

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+composer install --no-dev --optimize-autoloader
+sudo chmod a+x "$(pwd)" && sudo rm -rf /var/www/html && sudo ln -s "$(pwd)" /var/www/html
+npm install --global nyc


### PR DESCRIPTION
This PR fixes #1209 

## Changes
* Move entries in `.devcontainer/devcontainer.json#postCreateCommand` to their own file (`.devcontainer/postCreateCommand.sh`)

## ToDo

N/A