### PR TITLE
ensure English is always added to available languages, fixes #1208

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # PrivateBin version history
 
+## 1.6.2 (not yet released)
+* FIXED: English not selectable when languageselection enabled (#1208)
+
 ## 1.6.1 (2023-12-04)
 * ADDED: Right-To-Left (RTL) support for Arabic & Hebrew (#1174)
 * CHANGED: Upgrading libraries to: DOMpurify 3.0.6

--- a/lib/Data/Filesystem.php
+++ b/lib/Data/Filesystem.php
@@ -13,6 +13,7 @@
 namespace PrivateBin\Data;
 
 use Exception;
+use GlobIterator;
 use PrivateBin\Json;
 
 /**
@@ -394,7 +395,7 @@ class Filesystem extends AbstractData
     public function getAllPastes()
     {
         $pastes = array();
-        foreach (new \GlobIterator($this->_path . self::PASTE_FILE_PATTERN) as $file) {
+        foreach (new GlobIterator($this->_path . self::PASTE_FILE_PATTERN) as $file) {
             if ($file->isFile()) {
                 $pastes[] = $file->getBasename('.php');
             }

--- a/lib/I18n.php
+++ b/lib/I18n.php
@@ -12,6 +12,9 @@
 
 namespace PrivateBin;
 
+use AppendIterator;
+use GlobIterator;
+
 /**
  * I18n
  *
@@ -193,10 +196,14 @@ class I18n
     public static function getAvailableLanguages()
     {
         if (count(self::$_availableLanguages) == 0) {
-            $i18n = dir(self::_getPath());
-            while (false !== ($file = $i18n->read())) {
-                if (preg_match('/^([a-z]{2,3}).json$/', $file, $match) === 1) {
-                    self::$_availableLanguages[] = $match[1];
+            self::$_availableLanguages[] = 'en'; // en.json is not part of the release archive
+            $languageIterator = new AppendIterator();
+            $languageIterator->append(new GlobIterator(self::_getPath('??.json')));
+            $languageIterator->append(new GlobIterator(self::_getPath('???.json'))); // for jbo
+            foreach ($languageIterator as $file) {
+                $language = $file->getBasename('.json');
+                if ($language != 'en') {
+                    self::$_availableLanguages[] = $language;
                 }
             }
         }

--- a/lib/I18n.php
+++ b/lib/I18n.php
@@ -197,7 +197,7 @@ class I18n
     {
         if (count(self::$_availableLanguages) == 0) {
             self::$_availableLanguages[] = 'en'; // en.json is not part of the release archive
-            $languageIterator = new AppendIterator();
+            $languageIterator            = new AppendIterator();
             $languageIterator->append(new GlobIterator(self::_getPath('??.json')));
             $languageIterator->append(new GlobIterator(self::_getPath('???.json'))); // for jbo
             foreach ($languageIterator as $file) {


### PR DESCRIPTION
This PR fixes #1208

## Changes
* always add en to available languages
* use globs to fetch only the language files (2 and 3 letter .json files under i18n folder)
* don't add en twice

bug got introduced in 3668f1e3f4808d7232606349035c6a43c5a84c23 and started affecting release 1.6.1 after 896a49c8cf96ae9351796bd84050d2a0b249ddb3

