### PR TITLE
detect and report on damaged pastes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # PrivateBin version history
 
+## 1.6.3 (not yet released)
+* ADDED: Detect and report on damaged pastes (#1218)
+
 ## 1.6.2 (2023-12-15)
 * FIXED: English not selectable when `languageselection` enabled (#1208)
 * FIXED: SRI mismatch due to cached file having changed (#1207)

--- a/bin/administration
+++ b/bin/administration
@@ -14,6 +14,7 @@
 
 namespace PrivateBin;
 
+use Exception;
 use PrivateBin\Configuration;
 use PrivateBin\Data\AbstractData;
 use PrivateBin\Model\Paste;
@@ -195,6 +196,7 @@ EOT, PHP_EOL;
     {
         $counters = array(
             'burn'          => 0,
+            'damaged'       => 0,
             'discussion'    => 0,
             'expired'       => 0,
             'md'            => 0,
@@ -217,7 +219,12 @@ EOT, PHP_EOL;
 
         echo "Total:\t\t\t{$counters['total']}", PHP_EOL;
         foreach ($ids as $pasteid) {
-            $paste = $this->_store->read($pasteid);
+            try {
+                $paste = $this->_store->read($pasteid);
+            } catch (Exception $e) {
+                echo "Error reading paste {$pasteid}: ", $e->getMessage(), PHP_EOL;
+                ++$counters['damaged'];
+            }
             ++$counters['progress'];
 
             if (
@@ -271,6 +278,9 @@ Plain Text:\t\t{$counters['plain']}
 Source Code:\t\t{$counters['syntax']}
 Markdown:\t\t{$counters['md']}
 EOT, PHP_EOL;
+        if ($counters['damaged'] > 0) {
+            echo "Damaged:\t\t{$counters['damaged']}", PHP_EOL;
+        }
         if ($counters['unknown'] > 0) {
             echo "Unknown format:\t\t{$counters['unknown']}", PHP_EOL;
         }
@@ -305,7 +315,12 @@ EOT, PHP_EOL;
         }
 
         if ($this->_option('p', 'purge') !== null) {
-            $this->_store->purge(PHP_INT_MAX);
+            try {
+                $this->_store->purge(PHP_INT_MAX);
+            } catch (Exception $e) {
+                echo 'Error purging pastes: ', $e->getMessage(), PHP_EOL,
+                    'Run the statistics to find damaged paste IDs and either delete them or restore them from backup.', PHP_EOL;
+            }
             exit('purging of expired pastes concluded' . PHP_EOL);
         }
 

--- a/lib/Controller.php
+++ b/lib/Controller.php
@@ -111,10 +111,12 @@ class Controller
     public function __construct()
     {
         if (version_compare(PHP_VERSION, self::MIN_PHP_VERSION) < 0) {
-            throw new Exception(I18n::_('%s requires php %s or above to work. Sorry.', I18n::_('PrivateBin'), self::MIN_PHP_VERSION), 1);
+            error_log(I18n::_('%s requires php %s or above to work. Sorry.', I18n::_('PrivateBin'), self::MIN_PHP_VERSION));
+            return;
         }
         if (strlen(PATH) < 0 && substr(PATH, -1) !== DIRECTORY_SEPARATOR) {
-            throw new Exception(I18n::_('%s requires the PATH to end in a "%s". Please update the PATH in your index.php.', I18n::_('PrivateBin'), DIRECTORY_SEPARATOR), 5);
+            error_log(I18n::_('%s requires the PATH to end in a "%s". Please update the PATH in your index.php.', I18n::_('PrivateBin'), DIRECTORY_SEPARATOR));
+            return;
         }
 
         // load config from ini file, initialize required classes
@@ -250,7 +252,14 @@ class Controller
         }
         // The user posts a standard paste.
         else {
-            $this->_model->purge();
+            try {
+                $this->_model->purge();
+            } catch (Exception $e) {
+                error_log('Error purging pastes: ' . $e->getMessage() . PHP_EOL .
+                    'Use the administration scripts statistics to find ' .
+                    'damaged paste IDs and either delete them or restore them ' .
+                    'from backup.');
+            }
             $paste = $this->_model->getPaste();
             try {
                 $paste->setData($data);


### PR DESCRIPTION
May occur during statistics or purge, when existing pastes get parsed, addresses #1214

## Changes
* Catch exceptions in statistics and around purging, report these as errors
* Failure during purge should not prevent paste creation (unless the data folder is corrupt or otherwise not writable anymore)
* Statistics will report each damaged paste ID and also include a count if any were found
* Turn some basic exceptions into error_log messages - no point in getting a stack trace for them and exceptions will end up being reported in the same place. No point in throwing exceptions that no one will ever catch, either.
