### PR TITLE
prevent regression around presence or absence of en.json

### DIFF
--- a/lib/I18n.php
+++ b/lib/I18n.php
@@ -315,10 +315,10 @@ class I18n
      */
     protected static function _getPath($file = '')
     {
-        if (strlen(self::$_path) == 0) {
+        if (empty(self::$_path)) {
             self::$_path = PUBLIC_PATH . DIRECTORY_SEPARATOR . 'i18n';
         }
-        return self::$_path . (strlen($file) ? DIRECTORY_SEPARATOR . $file : '');
+        return self::$_path . (empty($file) ? '' : DIRECTORY_SEPARATOR . $file);
     }
 
     /**


### PR DESCRIPTION
It gets excluded in the release archive, it's absence should not make any difference.

As per discussion in https://github.com/PrivateBin/PrivateBin/pull/1213/files/684924e9e57af8797edcc0bb48ebe3732d1a61c8#r1427426364

This PR closes #1208
