### PR TITLE
add YOURLS API samples for extractUrl validation

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -131,3 +131,24 @@ exports.jscMimeTypes = function() {
 exports.jscFormats = function() {
     return jsc.elements(formats);
 };
+
+// provides random URLs
+exports.jscUrl = function(withFragment = true, withQuery = true) {
+    let url = {
+        schema: exports.jscSchemas(),
+        address: jsc.nearray(exports.jscA2zString()),
+    };
+    if (withFragment) {
+        url.fragment = jsc.string;
+    }
+    if(withQuery) {
+        url.query = jsc.array(exports.jscQueryString());
+    }
+    return jsc.record(url);
+};
+
+exports.urlToString = function (url) {
+    return url.schema + '://' + url.address.join('') + '/' + (url.query ? '?' +
+        encodeURI(url.query.join('').replace(/^&+|&+$/gm,'')) : '') +
+        (url.fragment ? '#' + encodeURI(url.fragment) : '');
+};

--- a/js/common.js
+++ b/js/common.js
@@ -113,8 +113,8 @@ exports.jscBase64String = function() {
 };
 
 // provides a random URL schema supported by the whatwg-url library
-exports.jscSchemas = function() {
-    return jsc.elements(schemas);
+exports.jscSchemas = function(withFtp = true) {
+    return jsc.elements(withFtp ? schemas : schemas.slice(1));
 };
 
 // provides a random supported language string

--- a/js/privatebin.js
+++ b/js/privatebin.js
@@ -2117,7 +2117,7 @@ jQuery.PrivateBin = (function($, RawDeflate) {
                 response = JSON.stringify(response);
             }
             if (typeof response === 'string' && response.length > 0) {
-                const shortUrlMatcher = /https?:\/\/[^\s]+/g;
+                const shortUrlMatcher = /https?:\/\/[^\s"<]+/g; // JSON API will have URL in quotes, XML in tags
                 const shortUrl = (response.match(shortUrlMatcher) || []).filter(function(urlRegExMatch) {
                     if (typeof URL.canParse === 'function') {
                         return URL.canParse(urlRegExMatch);
@@ -2129,7 +2129,7 @@ jQuery.PrivateBin = (function($, RawDeflate) {
                         return false;
                     }
                 }).sort(function(a, b) {
-                    return a.length - b.length;
+                    return a.length - b.length; // shortest first
                 })[0];
                 if (typeof shortUrl === 'string' && shortUrl.length > 0) {
                     // we disable the button to avoid calling shortener again

--- a/js/test/Helper.js
+++ b/js/test/Helper.js
@@ -96,36 +96,34 @@ describe('Helper', function () {
         jsc.property(
             'replaces URLs with anchors',
             'string',
-            jsc.elements(['http', 'https', 'ftp']),
-            jsc.nearray(common.jscA2zString()),
-            jsc.array(common.jscQueryString()),
+            common.jscUrl(),
             jsc.array(common.jscHashString()),
             'string',
-            function (prefix, schema, address, query, fragment, postfix) {
-                query    = query.join('');
-                fragment = fragment.join('');
+            function (prefix, url, fragment, postfix) {
                 prefix = prefix.replace(/\r|\f/g, '\n').replace(/\u0000/g, '').replace(/\u000b/g, '');
                 postfix  = ' ' + postfix.replace(/\r/g, '\n').replace(/\u0000/g, '');
-                let url  = schema + '://' + address.join('') + '/?' + query + '#' + fragment,
+                url.fragment = fragment.join('');
+                let urlString = common.urlToString(url),
                     clean = jsdom();
                 $('body').html('<div id="foo"></div>');
                 let e = $('#foo');
 
                 // special cases: When the query string and fragment imply the beginning of an HTML entity, eg. &#0 or &#x
                 if (
-                    query.slice(-1) === '&' &&
-                    (parseInt(fragment.substring(0, 1), 10) >= 0 || fragment.charAt(0) === 'x' )
-                )
-                {
-                    url = schema + '://' + address.join('') + '/?' + query.substring(0, query.length - 1);
+                    url.query[-1] === '&' &&
+                    (parseInt(url.fragment.charAt(0), 10) >= 0 || url.fragment.charAt(0) === 'x')
+                ) {
+                    url.query.pop();
+                    urlString = common.urlToString(url);
                     postfix = '';
                 }
-                e.text(prefix + url + postfix);
+                e.text(prefix + urlString + postfix);
                 $.PrivateBin.Helper.urls2links(e);
                 let result = e.html();
                 clean();
-                url = $('<div />').text(url).html();
-                return $('<div />').text(prefix).html() + '<a href="' + url + '" target="_blank" rel="nofollow noopener noreferrer">' + url + '</a>' + $('<div />').text(postfix).html() === result;
+                urlString = $('<div />').text(urlString).html();
+                const expected = $('<div />').text(prefix).html() + '<a href="' + urlString + '" target="_blank" rel="nofollow noopener noreferrer">' + urlString + '</a>' + $('<div />').text(postfix).html();
+                return $('<div />').text(prefix).html() + '<a href="' + urlString + '" target="_blank" rel="nofollow noopener noreferrer">' + urlString + '</a>' + $('<div />').text(postfix).html() === result;
             }
         );
         jsc.property(

--- a/js/test/Helper.js
+++ b/js/test/Helper.js
@@ -259,16 +259,16 @@ describe('Helper', function () {
         this.timeout(30000);
         jsc.property(
             'returns the URL without query & fragment',
-            jsc.elements(['http', 'https']),
-            jsc.nearray(common.jscA2zString()),
-            jsc.array(common.jscA2zString()),
-            jsc.array(common.jscQueryString()),
-            'string',
-            function (schema, address, path, query, fragment) {
+            common.jscSchemas(false),
+            common.jscUrl(),
+            function (schema, url) {
+                url.schema = schema;
+                const fullUrl = common.urlToString(url);
+                delete(url.query);
+                delete(url.fragment);
                 $.PrivateBin.Helper.reset();
-                var path = path.join('') + (path.length > 0 ? '/' : ''),
-                    expected = schema + '://' + address.join('') + '/' + path,
-                    clean = jsdom('', {url: expected + '?' + query.join('') + '#' + fragment}),
+                const expected = common.urlToString(url),
+                    clean = jsdom('', {url: fullUrl}),
                     result = $.PrivateBin.Helper.baseUri();
                 clean();
                 return expected === result;

--- a/js/test/Model.js
+++ b/js/test/Model.js
@@ -80,23 +80,22 @@ describe('Model', function () {
 
         jsc.property(
             'returns the query string without separator, if any',
-            jsc.nearray(common.jscA2zString()),
-            jsc.nearray(common.jscA2zString()),
+            common.jscUrl(),
             jsc.tuple(new Array(16).fill(common.jscHexString)),
             jsc.array(common.jscQueryString()),
             jsc.array(common.jscQueryString()),
-            'string',
-            function (schema, address, pasteId, queryStart, queryEnd, fragment) {
-                var pasteIdString    = pasteId.join(''),
-                    queryStartString = queryStart.join('') + (queryStart.length > 0 ? '&' : ''),
-                    queryEndString   = (queryEnd.length > 0 ? '&' : '') + queryEnd.join(''),
-                    queryString      = queryStartString + pasteIdString + queryEndString,
-                    clean            = jsdom('', {
-                        url: schema.join('') + '://' + address.join('') +
-                             '/?' + queryString + '#' + fragment
-                    });
-                    global.URL = require('jsdom-url').URL;
-                    var result = $.PrivateBin.Model.getPasteId();
+            function (url, pasteId, queryStart, queryEnd) {
+                if (queryStart.length > 0) {
+                    queryStart.push('&');
+                }
+                if (queryEnd.length > 0) {
+                    queryEnd.unshift('&');
+                }
+                url.query = queryStart.concat(pasteId, queryEnd);
+                const pasteIdString = pasteId.join(''),
+                    clean           = jsdom('', {url: common.urlToString(url)});
+                global.URL = require('jsdom-url').URL;
+                const result = $.PrivateBin.Model.getPasteId();
                 $.PrivateBin.Model.reset();
                 clean();
                 return pasteIdString === result;
@@ -104,14 +103,9 @@ describe('Model', function () {
         );
         jsc.property(
             'throws exception on empty query string',
-            jsc.nearray(common.jscA2zString()),
-            jsc.nearray(common.jscA2zString()),
-            'string',
-            function (schema, address, fragment) {
-                var clean = jsdom('', {
-                        url: schema.join('') + '://' + address.join('') +
-                             '/#' + fragment
-                    }),
+            common.jscUrl(true, false),
+            function (url) {
+                let clean = jsdom('', {url: common.urlToString(url)}),
                     result = false;
                 global.URL = require('jsdom-url').URL;
                 try {
@@ -135,35 +129,24 @@ describe('Model', function () {
 
         jsc.property(
             'returns the fragment of a v1 URL',
-            jsc.nearray(common.jscA2zString()),
-            jsc.nearray(common.jscA2zString()),
-            jsc.array(common.jscQueryString()),
-            'nestring',
-            function (schema, address, query, fragment) {
-                const fragmentString = common.btoa(fragment.padStart(32, '\u0000'));
-                let clean = jsdom('', {
-                        url: schema.join('') + '://' + address.join('') +
-                             '/?' + query.join('') + '#' + fragmentString
-                    }),
+            common.jscUrl(),
+            function (url) {
+                url.fragment = common.btoa(url.fragment.padStart(32, '\u0000'));
+                const clean = jsdom('', {url: common.urlToString(url)}),
                     result = $.PrivateBin.Model.getPasteKey();
                 $.PrivateBin.Model.reset();
                 clean();
-                return fragmentString === result;
+                return url.fragment === result;
             }
         );
         jsc.property(
             'returns the v1 fragment stripped of trailing query parts',
-            jsc.nearray(common.jscA2zString()),
-            jsc.nearray(common.jscA2zString()),
-            jsc.array(common.jscQueryString()),
-            'nestring',
+            common.jscUrl(),
             jsc.array(common.jscHashString()),
-            function (schema, address, query, fragment, trail) {
-                const fragmentString = common.btoa(fragment.padStart(32, '\u0000'));
-                let clean = jsdom('', {
-                        url: schema.join('') + '://' + address.join('') + '/?' +
-                             query.join('') + '#' + fragmentString + '&' + trail.join('')
-                    }),
+            function (url, trail) {
+                const fragmentString = common.btoa(url.fragment.padStart(32, '\u0000'));
+                url.fragment = fragmentString + '&' + trail.join('');
+                const clean = jsdom('', {url: common.urlToString(url)}),
                     result = $.PrivateBin.Model.getPasteKey();
                 $.PrivateBin.Model.reset();
                 clean();
@@ -172,18 +155,12 @@ describe('Model', function () {
         );
         jsc.property(
             'returns the fragment of a v2 URL',
-            jsc.nearray(common.jscA2zString()),
-            jsc.nearray(common.jscA2zString()),
-            jsc.array(common.jscQueryString()),
-            'nestring',
-            function (schema, address, query, fragment) {
+            common.jscUrl(),
+            function (url) {
                 // base58 strips leading NULL bytes, so the string is padded with these if not found
-                fragment = fragment.padStart(32, '\u0000');
-                let fragmentString = $.PrivateBin.CryptTool.base58encode(fragment),
-                    clean = jsdom('', {
-                        url: schema.join('') + '://' + address.join('') +
-                             '/?' + query.join('') + '#' + fragmentString
-                    }),
+                const fragment = url.fragment.padStart(32, '\u0000');
+                url.fragment = $.PrivateBin.CryptTool.base58encode(fragment);
+                const clean = jsdom('', {url: common.urlToString(url)}),
                     result = $.PrivateBin.Model.getPasteKey();
                 $.PrivateBin.Model.reset();
                 clean();
@@ -192,19 +169,13 @@ describe('Model', function () {
         );
         jsc.property(
             'returns the v2 fragment stripped of trailing query parts',
-            jsc.nearray(common.jscA2zString()),
-            jsc.nearray(common.jscA2zString()),
-            jsc.array(common.jscQueryString()),
-            'nestring',
+            common.jscUrl(),
             jsc.array(common.jscHashString()),
-            function (schema, address, query, fragment, trail) {
+            function (url, trail) {
                 // base58 strips leading NULL bytes, so the string is padded with these if not found
-                fragment = fragment.padStart(32, '\u0000');
-                let fragmentString = $.PrivateBin.CryptTool.base58encode(fragment),
-                    clean = jsdom('', {
-                        url: schema.join('') + '://' + address.join('') + '/?' +
-                             query.join('') + '#' + fragmentString + '&' + trail.join('')
-                    }),
+                const fragment = url.fragment.padStart(32, '\u0000');
+                url.fragment = $.PrivateBin.CryptTool.base58encode(fragment) + '&' + trail.join('');
+                const clean = jsdom('', {url: common.urlToString(url)}),
                     result = $.PrivateBin.Model.getPasteKey();
                 $.PrivateBin.Model.reset();
                 clean();
@@ -213,14 +184,9 @@ describe('Model', function () {
         );
         jsc.property(
             'throws exception on empty fragment of the URL',
-            jsc.nearray(common.jscA2zString()),
-            jsc.nearray(common.jscA2zString()),
-            jsc.array(common.jscQueryString()),
-            function (schema, address, query) {
-                var clean = jsdom('', {
-                        url: schema.join('') + '://' + address.join('') +
-                             '/?' + query.join('')
-                    }),
+            common.jscUrl(false, false),
+            function (url) {
+                let clean = jsdom('', {url: common.urlToString(url)}),
                     result = false;
                 try {
                     $.PrivateBin.Model.getPasteKey();

--- a/js/test/Model.js
+++ b/js/test/Model.js
@@ -80,7 +80,7 @@ describe('Model', function () {
 
         jsc.property(
             'returns the query string without separator, if any',
-            common.jscUrl(),
+            common.jscUrl(true, false),
             jsc.tuple(new Array(16).fill(common.jscHexString)),
             jsc.array(common.jscQueryString()),
             jsc.array(common.jscQueryString()),
@@ -184,7 +184,7 @@ describe('Model', function () {
         );
         jsc.property(
             'throws exception on empty fragment of the URL',
-            common.jscUrl(false, false),
+            common.jscUrl(false),
             function (url) {
                 let clean = jsdom('', {url: common.urlToString(url)}),
                     result = false;

--- a/js/test/PasteStatus.js
+++ b/js/test/PasteStatus.js
@@ -1,6 +1,23 @@
 'use strict';
 var common = require('../common');
 
+function urlStrings(schema, longUrl, shortUrl) {
+    longUrl.schema = schema;
+    shortUrl.schema = schema;
+    let longUrlString = common.urlToString(longUrl),
+        shortUrlString = common.urlToString(shortUrl);
+    // ensure the two random URLs actually are sorted as expected
+    if (longUrlString.length <= shortUrlString.length) {
+        if (longUrlString.length === shortUrlString.length) {
+            longUrl.address.unshift('a');
+            longUrlString = common.urlToString(longUrl);
+        } else {
+            [longUrlString, shortUrlString] = [shortUrlString, longUrlString];
+        }
+    }
+    return [longUrlString, shortUrlString];
+}
+
 describe('PasteStatus', function () {
     describe('createPasteNotification', function () {
         this.timeout(30000);
@@ -28,8 +45,8 @@ describe('PasteStatus', function () {
         this.timeout(30000);
 
         jsc.property(
-            'extracts and updates URLs found in given response',
-            jsc.elements(['http','https']),
+            'extracts and updates IDN URLs found in given response',
+            common.jscSchemas(false),
             'nestring',
             common.jscUrl(),
             function (schema, domain, url) {
@@ -56,6 +73,102 @@ describe('PasteStatus', function () {
                     result.startsWith(schema + '://xn--') ||
                     result.startsWith(schema + '://' + domain)
                 );
+            }
+        );
+
+        // YOURLS API samples from: https://yourls.org/readme.html#API;apireturn
+        jsc.property(
+            'extracts and updates URLs found in YOURLS API JSON response',
+            common.jscSchemas(false),
+            common.jscUrl(),
+            common.jscUrl(false),
+            function (schema, longUrl, shortUrl) {
+                const [longUrlString, shortUrlString] = urlStrings(schema, longUrl, shortUrl),
+                    yourlsResponse = {
+                        url: {
+                            keyword: longUrl.address.join(''),
+                            url: longUrlString,
+                            title: "example title",
+                            date: "2014-10-24 16:01:39",
+                            ip: "127.0.0.1"
+                        },
+                        status: "success",
+                        message: longUrlString + " added to database",
+                        title: "example title",
+                        shorturl: shortUrlString,
+                        statusCode: 200
+                    },
+                    clean = jsdom();
+
+                $('body').html('<div><div id="pastelink"></div></div>');
+                $.PrivateBin.PasteStatus.init();
+                $.PrivateBin.PasteStatus.createPasteNotification('', '');
+                $.PrivateBin.PasteStatus.extractUrl(JSON.stringify(yourlsResponse, undefined, 4));
+
+                const result = $('#pasteurl')[0].href;
+                clean();
+
+                return result === shortUrlString;
+            }
+        );
+        jsc.property(
+            'extracts and updates URLs found in YOURLS API XML response',
+            common.jscSchemas(false),
+            common.jscUrl(),
+            common.jscUrl(false),
+            function (schema, longUrl, shortUrl) {
+                const [longUrlString, shortUrlString] = urlStrings(schema, longUrl, shortUrl),
+                    yourlsResponse = '<result>\n' +
+                        '    <keyword>' + longUrl.address.join('') + '</keyword>\n' +
+                        '    <shorturl>' + shortUrlString + '</shorturl>\n' +
+                        '    <longurl>' + longUrlString + '</longurl>\n' +
+                        '    <message>success</message>\n' +
+                        '    <statusCode>200</statusCode>\n' +
+                        '</result>',
+                    clean = jsdom();
+
+                $('body').html('<div><div id="pastelink"></div></div>');
+                $.PrivateBin.PasteStatus.init();
+                $.PrivateBin.PasteStatus.createPasteNotification('', '');
+                $.PrivateBin.PasteStatus.extractUrl(yourlsResponse);
+
+                const result = $('#pasteurl')[0].href;
+                clean();
+
+                return result === shortUrlString;
+            }
+        );
+        jsc.property(
+            'extracts and updates URLs found in YOURLS proxy HTML response',
+            common.jscSchemas(false),
+            common.jscUrl(),
+            common.jscUrl(false),
+            function (schema, longUrl, shortUrl) {
+                const [longUrlString, shortUrlString] = urlStrings(schema, longUrl, shortUrl),
+                    yourlsResponse = '<!DOCTYPE html>\n' +
+                        '<html lang="en">\n' +
+                        '\t<head>\n' +
+                        '\t\t<meta charset="utf-8" />\n' +
+                        '\t\t<meta http-equiv="Content-Security-Policy" content="default-src \'none\'; base-uri \'self\'; form-action \'none\'; manifest-src \'self\'; connect-src * blob:; script-src \'self\' \'unsafe-eval\'; style-src \'self\'; font-src \'self\'; frame-ancestors \'none\'; img-src \'self\' data: blob:; media-src blob:; object-src blob:; sandbox allow-same-origin allow-scripts allow-forms allow-popups allow-modals allow-downloads">\n' +
+                        '\t\t<meta name="robots" content="noindex" />\n' +
+                        '\t\t<meta name="google" content="notranslate">\n' +
+                        '\t\t<title>PrivateBin</title>\n' +
+                        '\t</head>\n' +
+                        '\t<body>\n' +
+                        '\t\t<p>Your paste is <a id="pasteurl" href="' + shortUrlString + '">' + shortUrlString + '</a> <span id="copyhint">(Hit [Ctrl]+[c] to copy)</span></p>\n' +
+                        '\t</body>\n' +
+                        '</html>',
+                    clean = jsdom();
+
+                $('body').html('<div><div id="pastelink"></div></div>');
+                $.PrivateBin.PasteStatus.init();
+                $.PrivateBin.PasteStatus.createPasteNotification('', '');
+                $.PrivateBin.PasteStatus.extractUrl(yourlsResponse);
+
+                const result = $('#pasteurl')[0].href;
+                clean();
+
+                return result === shortUrlString;
             }
         );
     });

--- a/js/test/PasteStatus.js
+++ b/js/test/PasteStatus.js
@@ -27,13 +27,13 @@ describe('PasteStatus', function () {
             common.jscUrl(),
             common.jscUrl(false),
             function (url1, url2) {
-                const expected1 = common.urlToString(url1),
-                    expected2 = common.urlToString(url2),
+                const expected1 = common.urlToString(url1).replace(/&(gt|lt)$/, '&$1a'),
+                    expected2 = common.urlToString(url2).replace(/&(gt|lt)$/, '&$1a'),
                     clean = jsdom();
                 $('body').html('<div><div id="deletelink"></div><div id="pastelink"></div></div>');
                 $.PrivateBin.PasteStatus.init();
                 $.PrivateBin.PasteStatus.createPasteNotification(expected1, expected2);
-                var result1 = $('#pasteurl')[0].href,
+                const result1 = $('#pasteurl')[0].href,
                     result2 = $('#deletelink a')[0].href;
                 clean();
                 return result1 === expected1 && result2 === expected2;
@@ -50,7 +50,7 @@ describe('PasteStatus', function () {
             'nestring',
             common.jscUrl(),
             function (schema, domain, url) {
-                domain = domain.replace(/\P{Letter}|[\u00AA-\u00BA]/gu,'').toLowerCase();
+                domain = domain.replace(/\P{Letter}|[\u00AA-\u00BA]/gu, '').toLowerCase();
                 if (domain.length === 0) {
                     domain = 'a';
                 }

--- a/js/test/PasteStatus.js
+++ b/js/test/PasteStatus.js
@@ -7,21 +7,11 @@ describe('PasteStatus', function () {
 
         jsc.property(
             'creates a notification after a successfull paste upload',
-            common.jscSchemas(),
-            jsc.nearray(common.jscA2zString()),
-            jsc.array(common.jscQueryString()),
-            'string',
-            common.jscSchemas(),
-            jsc.nearray(common.jscA2zString()),
-            jsc.array(common.jscQueryString()),
-            function (
-                schema1, address1, query1, fragment1,
-                schema2, address2, query2
-            ) {
-                var expected1 = schema1 + '://' + address1.join('') + '/?' +
-                    encodeURI(query1.join('').replace(/^&+|&+$/gm,'') + '#' + fragment1),
-                    expected2 = schema2 + '://' + address2.join('') + '/?' +
-                    encodeURI(query2.join('').replace(/^&+|&+$/gm,'')),
+            common.jscUrl(),
+            common.jscUrl(false),
+            function (url1, url2) {
+                const expected1 = common.urlToString(url1),
+                    expected2 = common.urlToString(url2),
                     clean = jsdom();
                 $('body').html('<div><div id="deletelink"></div><div id="pastelink"></div></div>');
                 $.PrivateBin.PasteStatus.init();
@@ -41,25 +31,23 @@ describe('PasteStatus', function () {
             'extracts and updates URLs found in given response',
             jsc.elements(['http','https']),
             'nestring',
-            jsc.nearray(common.jscA2zString()),
-            jsc.array(common.jscQueryString()),
-            jsc.array(common.jscAlnumString()),
-            'string',
-            function (schema, domain, tld, query, shortid, fragment) {
+            common.jscUrl(),
+            function (schema, domain, url) {
                 domain = domain.replace(/\P{Letter}|[\u00AA-\u00BA]/gu,'').toLowerCase();
                 if (domain.length === 0) {
                     domain = 'a';
                 }
-                const expected = '.' + tld.join('') + '/' + (query.length > 0 ?
-                    ('?' + encodeURI(query.join('').replace(/^&+|&+$/gm,'')) +
-                    shortid.join('')) : '') + (fragment.length > 0 ?
-                    ('#' + encodeURI(fragment)) : ''),
+                url.schema = schema;
+                url.address.unshift('.');
+                url.address = domain.split('').concat(url.address);
+                const urlString = common.urlToString(url),
+                    expected = urlString.substring((schema + '://' + domain).length),
                     clean = jsdom();
 
                 $('body').html('<div><div id="pastelink"></div></div>');
                 $.PrivateBin.PasteStatus.init();
                 $.PrivateBin.PasteStatus.createPasteNotification('', '');
-                $.PrivateBin.PasteStatus.extractUrl(schema + '://' + domain + expected);
+                $.PrivateBin.PasteStatus.extractUrl(urlString);
 
                 const result = $('#pasteurl')[0].href;
                 clean();
@@ -79,18 +67,9 @@ describe('PasteStatus', function () {
             'shows burn after reading message or remaining time v1',
             'bool',
             'nat',
-            jsc.nearray(common.jscA2zString()),
-            jsc.nearray(common.jscA2zString()),
-            jsc.nearray(common.jscQueryString()),
-            'string',
-            function (
-                burnafterreading, remainingTime,
-                schema, address, query, fragment
-            ) {
-                var clean = jsdom('', {
-                        url: schema.join('') + '://' + address.join('') +
-                             '/?' + query.join('') + '#' + fragment
-                    }),
+            common.jscUrl(),
+            function (burnafterreading, remainingTime, url) {
+                let clean = jsdom('', {url: common.urlToString(url)}),
                     result;
                 $('body').html('<div id="remainingtime" class="hidden"></div>');
                 $.PrivateBin.PasteStatus.init();
@@ -117,18 +96,9 @@ describe('PasteStatus', function () {
             'shows burn after reading message or remaining time v2',
             'bool',
             'nat',
-            jsc.nearray(common.jscA2zString()),
-            jsc.nearray(common.jscA2zString()),
-            jsc.nearray(common.jscQueryString()),
-            'string',
-            function (
-                burnafterreading, remainingTime,
-                schema, address, query, fragment
-            ) {
-                var clean = jsdom('', {
-                        url: schema.join('') + '://' + address.join('') +
-                             '/?' + query.join('') + '#' + fragment
-                    }),
+            common.jscUrl(),
+            function (burnafterreading, remainingTime, url) {
+                let clean = jsdom('', {url: common.urlToString(url)}),
                     result;
                 $('body').html('<div id="remainingtime" class="hidden"></div>');
                 $.PrivateBin.PasteStatus.init();

--- a/js/test/UiHelper.js
+++ b/js/test/UiHelper.js
@@ -13,10 +13,9 @@ describe('UiHelper', function () {
 
         jsc.property(
             'redirects to home, when the state is null',
-            common.jscSchemas(),
-            jsc.nearray(common.jscA2zString()),
-            function (schema, address) {
-                var expected = schema + '://' + address.join('') + '/',
+            common.jscUrl(false, false),
+            function (url) {
+                const expected = common.urlToString(url),
                     clean = jsdom('', {url: expected});
 
                 // make window.location.href writable
@@ -34,13 +33,11 @@ describe('UiHelper', function () {
 
         jsc.property(
             'does not redirect to home, when a new paste is created',
-            common.jscSchemas(),
-            jsc.nearray(common.jscA2zString()),
-            jsc.array(common.jscQueryString()),
+            common.jscUrl(false),
             jsc.nearray(common.jscBase64String()),
-            function (schema, address, query, fragment) {
-                var expected = schema + '://' + address.join('') + '/?' +
-                               query.join('') + '#' + fragment.join(''),
+            function (url, fragment) {
+                url.fragment = fragment.join('');
+                const expected = common.urlToString(url),
                     clean = jsdom('', {url: expected});
 
                 // make window.location.href writable
@@ -67,15 +64,12 @@ describe('UiHelper', function () {
 
         jsc.property(
             'redirects to home',
-            common.jscSchemas(),
-            jsc.nearray(common.jscA2zString()),
-            jsc.array(common.jscQueryString()),
-            jsc.nearray(common.jscBase64String()),
-            function (schema, address, query, fragment) {
-                var expected = schema + '://' + address.join('') + '/',
-                    clean = jsdom('', {
-                        url: expected + '?' + query.join('') + '#' + fragment.join('')
-                    });
+            common.jscUrl(),
+            function (url) {
+                const clean = jsdom('', {url: common.urlToString(url)});
+                delete(url.query);
+                delete(url.fragment);
+                const expected = common.urlToString(url);
 
                 // make window.location.href writable
                 Object.defineProperty(window.location, 'href', {

--- a/tpl/bootstrap.php
+++ b/tpl/bootstrap.php
@@ -73,7 +73,7 @@ endif;
 ?>
 		<script type="text/javascript" data-cfasync="false" src="js/purify-3.0.6.js" integrity="sha512-N3y6/HOk3pbsw3lFh4O8CKKEVwu1B2CF8kinhjURf8Yqa5OfSUt+/arozxFW+TUPOPw3TsDCRT/0u7BGRTEVUw==" crossorigin="anonymous"></script>
 		<script type="text/javascript" data-cfasync="false" src="js/legacy.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-LYos+qXHIRqFf5ZPNphvtTB0cgzHUizu2wwcOwcwz/VIpRv9lpcBgPYz4uq6jx0INwCAj6Fbnl5HoKiLufS2jg==" crossorigin="anonymous"></script>
-		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-m/JO/NGsP+FEHPACdYe60BFkURk+NVCBaMsIUOUC5J1EnVE2XgVKF6Z+YSDd+9M4ISu0SivYxCZBEl8qW8u1Jg==" crossorigin="anonymous"></script>
+		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-pR0TsQjCcheBGUbJyi6WxjhuX0AvGFg/R/NTMBZd1Sz22lDydBVIRy2y2ik8qTr9P/XRKj3QTkLrZC3ZF1NMyA==" crossorigin="anonymous"></script>
 		<!-- icon -->
 		<link rel="apple-touch-icon" href="<?php echo I18n::encode($BASEPATH); ?>img/apple-touch-icon.png" sizes="180x180" />
 		<link rel="icon" type="image/png" href="img/favicon-32x32.png" sizes="32x32" />

--- a/tpl/page.php
+++ b/tpl/page.php
@@ -51,7 +51,7 @@ endif;
 ?>
 		<script type="text/javascript" data-cfasync="false" src="js/purify-3.0.6.js" integrity="sha512-N3y6/HOk3pbsw3lFh4O8CKKEVwu1B2CF8kinhjURf8Yqa5OfSUt+/arozxFW+TUPOPw3TsDCRT/0u7BGRTEVUw==" crossorigin="anonymous"></script>
 		<script type="text/javascript" data-cfasync="false" src="js/legacy.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-LYos+qXHIRqFf5ZPNphvtTB0cgzHUizu2wwcOwcwz/VIpRv9lpcBgPYz4uq6jx0INwCAj6Fbnl5HoKiLufS2jg==" crossorigin="anonymous"></script>
-		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-m/JO/NGsP+FEHPACdYe60BFkURk+NVCBaMsIUOUC5J1EnVE2XgVKF6Z+YSDd+9M4ISu0SivYxCZBEl8qW8u1Jg==" crossorigin="anonymous"></script>
+		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-pR0TsQjCcheBGUbJyi6WxjhuX0AvGFg/R/NTMBZd1Sz22lDydBVIRy2y2ik8qTr9P/XRKj3QTkLrZC3ZF1NMyA==" crossorigin="anonymous"></script>
 		<!-- icon -->
 		<link rel="apple-touch-icon" href="img/apple-touch-icon.png?<?php echo rawurlencode($VERSION); ?>" sizes="180x180" />
 		<link rel="icon" type="image/png" href="img/favicon-32x32.png?<?php echo rawurlencode($VERSION); ?>" sizes="32x32" />


### PR DESCRIPTION
This PR follows up on the discussion in https://github.com/PrivateBin/PrivateBin/pull/1227#pullrequestreview-1805108910

## Changes
* fixes extractUrl regex pattern when used against JSON, XML or HTML
* adds JSON & XML samples found in YOURLS doc and HTML from our yourlsproxy template
* refactored the tests to simplify URL generation

This confirms that I misunderstood the sort, it will find the shortest URL in the string. The sort is necessary to find the right URL in the JSON & XML responses that contain both the long and short one and not in the same order.

If anyone could provide more samples API messages from other shorteners, please let us know. Now would be a good time to add them to the tests.