### PR TITLE
Secure password with compatibility for burn after reading

### DIFF
--- a/js/privatebin.js
+++ b/js/privatebin.js
@@ -4862,7 +4862,8 @@ jQuery.PrivateBin = (function($, RawDeflate) {
 
             const pw = TopNav.getPassword()
 
-            if(pw && pw.length) {
+            // only execute when it is a single time view
+            if(pw && pw.length && TopNav.getBurnAfterReading()) {
 
                 const sm =  CryptTool.getSymmetricKey();
 
@@ -5032,9 +5033,12 @@ jQuery.PrivateBin = (function($, RawDeflate) {
 
             // prepare server interaction
             ServerInteraction.prepare();
-            // This is not needed when encrypting browser side
-            // ServerInteraction.setCryptParameters(TopNav.getPassword());
-            ServerInteraction.setCryptParameters('');
+            if(!TopNav.getBurnAfterReading()) {
+                ServerInteraction.setCryptParameters(TopNav.getPassword());
+            } else {
+                // not needed in this scenario
+                ServerInteraction.setCryptParameters('');
+            }
 
             // set success/fail functions
             ServerInteraction.setSuccess(showCreatedPaste);


### PR DESCRIPTION
# Reasoning

As suggested in #1055 and discussed roughly with @elrido . This is our implementation of this. We were using this actually quite a long time and just forgot about submitting it back. So here we go. Please note that I wont have too much time the next weeks, so if there is anything missing to get this merged, please feel free to fork our work and make the needed changes, otherwise it might delay very long.

A short explanation:

The Link is encrypted in the browser, instead of encrypting the paste with the password, but only if burn after reading is checked. The server side encryption with the password is disable to prevent needing to enter it twice. Normal encrypted pastes remain with the same functionality.

# References 

Fixes #245 
