### PR TITLE
Ask for confirmation, before loading burn after reading pastes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,13 @@
 
 ## 1.6.3 (not yet released)
 * ADDED: Detect and report on damaged pastes (#1218)
+* CHANGED: Ask for confirmation, before loading burn after reading pastes #1237
+* CHANGED: Focus on password input in modal dialog
 * CHANGED: Upgrading libraries to: zlib 1.3
 * FIXED: Support more types of valid URLs for shorteners, incl. IDN ones (#1224)
+* FIXED: Email timezone buttons overlapping in some languages #1039
+* FIXED: Changing language mangles URL #1191
+* FIXED: Needless reload when visiting default URL
 
 ## 1.6.2 (2023-12-15)
 * FIXED: English not selectable when `languageselection` enabled (#1208)

--- a/i18n/ar.json
+++ b/i18n/ar.json
@@ -214,5 +214,7 @@
     "Your IP is not authorized to create pastes.": "عنوان IP الخاص بك غير مصرح له بإنشاء لصُق.",
     "Trying to shorten a URL that isn't pointing at our instance.": "محاولة تقصير عنوان URL لا يشير إلى خادمنا.",
     "Error calling YOURLS. Probably a configuration issue, like wrong or missing \"apiurl\" or \"signature\".": "خطأ في الاتصال بـ YOURLS. ربما تكون هناك مشكلة في التضبيط، مثل \"apiurl\" أو \"التوقيع\" الخاطئ أو المفقود.",
-    "Error parsing YOURLS response.": "خطأ في تحليل استجابة YOURLS."
+    "Error parsing YOURLS response.": "خطأ في تحليل استجابة YOURLS.",
+    "Burn after reading pastes can only be displayed once upon loading it. Do you want to open it now?": "Burn after reading pastes can only be displayed once upon loading it. Do you want to open it now?",
+    "Yes, load it": "Yes, load it"
 }

--- a/i18n/bg.json
+++ b/i18n/bg.json
@@ -214,5 +214,7 @@
     "Your IP is not authorized to create pastes.": "Your IP is not authorized to create pastes.",
     "Trying to shorten a URL that isn't pointing at our instance.": "Trying to shorten a URL that isn't pointing at our instance.",
     "Error calling YOURLS. Probably a configuration issue, like wrong or missing \"apiurl\" or \"signature\".": "Error calling YOURLS. Probably a configuration issue, like wrong or missing \"apiurl\" or \"signature\".",
-    "Error parsing YOURLS response.": "Error parsing YOURLS response."
+    "Error parsing YOURLS response.": "Error parsing YOURLS response.",
+    "Burn after reading pastes can only be displayed once upon loading it. Do you want to open it now?": "Burn after reading pastes can only be displayed once upon loading it. Do you want to open it now?",
+    "Yes, load it": "Yes, load it"
 }

--- a/i18n/ca.json
+++ b/i18n/ca.json
@@ -214,5 +214,7 @@
     "Your IP is not authorized to create pastes.": "Your IP is not authorized to create pastes.",
     "Trying to shorten a URL that isn't pointing at our instance.": "Trying to shorten a URL that isn't pointing at our instance.",
     "Error calling YOURLS. Probably a configuration issue, like wrong or missing \"apiurl\" or \"signature\".": "Error calling YOURLS. Probably a configuration issue, like wrong or missing \"apiurl\" or \"signature\".",
-    "Error parsing YOURLS response.": "Error parsing YOURLS response."
+    "Error parsing YOURLS response.": "Error parsing YOURLS response.",
+    "Burn after reading pastes can only be displayed once upon loading it. Do you want to open it now?": "Burn after reading pastes can only be displayed once upon loading it. Do you want to open it now?",
+    "Yes, load it": "Yes, load it"
 }

--- a/i18n/co.json
+++ b/i18n/co.json
@@ -214,5 +214,7 @@
     "Your IP is not authorized to create pastes.": "U vostru indirizzu IP ùn hè micca auturizatu à creà l’appiccichi.",
     "Trying to shorten a URL that isn't pointing at our instance.": "Pruvate d’ammuzzà un indirizzu web chì ùn punta micca versu a vostra instanza.",
     "Error calling YOURLS. Probably a configuration issue, like wrong or missing \"apiurl\" or \"signature\".": "Sbagliu à a chjama di YOURLS. Seria forse una cunfigurazione gattiva, tale una \"apiurl\" o \"signature\" falsa o assente.",
-    "Error parsing YOURLS response.": "Sbagliu durante l’analisa di a risposta di YOURLS."
+    "Error parsing YOURLS response.": "Sbagliu durante l’analisa di a risposta di YOURLS.",
+    "Burn after reading pastes can only be displayed once upon loading it. Do you want to open it now?": "Burn after reading pastes can only be displayed once upon loading it. Do you want to open it now?",
+    "Yes, load it": "Yes, load it"
 }

--- a/i18n/cs.json
+++ b/i18n/cs.json
@@ -214,5 +214,7 @@
     "Your IP is not authorized to create pastes.": "Vaše IP adresa nemá oprávnění k vytvoření vložení.",
     "Trying to shorten a URL that isn't pointing at our instance.": "Trying to shorten a URL that isn't pointing at our instance.",
     "Error calling YOURLS. Probably a configuration issue, like wrong or missing \"apiurl\" or \"signature\".": "Error calling YOURLS. Probably a configuration issue, like wrong or missing \"apiurl\" or \"signature\".",
-    "Error parsing YOURLS response.": "Error parsing YOURLS response."
+    "Error parsing YOURLS response.": "Error parsing YOURLS response.",
+    "Burn after reading pastes can only be displayed once upon loading it. Do you want to open it now?": "Burn after reading pastes can only be displayed once upon loading it. Do you want to open it now?",
+    "Yes, load it": "Yes, load it"
 }

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -214,5 +214,7 @@
     "Your IP is not authorized to create pastes.": "Deine IP ist nicht berechtigt, Texte zu erstellen.",
     "Trying to shorten a URL that isn't pointing at our instance.": "Versuch eine URL zu verkürzen, die nicht auf unsere Instanz zeigt.",
     "Error calling YOURLS. Probably a configuration issue, like wrong or missing \"apiurl\" or \"signature\".": "Fehler beim Aufruf von YOURLS. Wahrscheinlich ein Konfigurationsproblem, wie eine falsche oder fehlende \"apiurl\" oder \"signature\".",
-    "Error parsing YOURLS response.": "Fehler beim Verarbeiten der YOURLS-Antwort."
+    "Error parsing YOURLS response.": "Fehler beim Verarbeiten der YOURLS-Antwort.",
+    "Burn after reading pastes can only be displayed once upon loading it. Do you want to open it now?": "Burn after reading pastes can only be displayed once upon loading it. Do you want to open it now?",
+    "Yes, load it": "Yes, load it"
 }

--- a/i18n/el.json
+++ b/i18n/el.json
@@ -214,5 +214,7 @@
     "Your IP is not authorized to create pastes.": "Η IP σας δεν επιτρέπεται να δημιουργεί επικολλήσεις.",
     "Trying to shorten a URL that isn't pointing at our instance.": "Trying to shorten a URL that isn't pointing at our instance.",
     "Error calling YOURLS. Probably a configuration issue, like wrong or missing \"apiurl\" or \"signature\".": "Error calling YOURLS. Probably a configuration issue, like wrong or missing \"apiurl\" or \"signature\".",
-    "Error parsing YOURLS response.": "Error parsing YOURLS response."
+    "Error parsing YOURLS response.": "Error parsing YOURLS response.",
+    "Burn after reading pastes can only be displayed once upon loading it. Do you want to open it now?": "Burn after reading pastes can only be displayed once upon loading it. Do you want to open it now?",
+    "Yes, load it": "Yes, load it"
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -214,5 +214,7 @@
     "Your IP is not authorized to create pastes.": "Your IP is not authorized to create pastes.",
     "Trying to shorten a URL that isn't pointing at our instance.": "Trying to shorten a URL that isn't pointing at our instance.",
     "Error calling YOURLS. Probably a configuration issue, like wrong or missing \"apiurl\" or \"signature\".": "Error calling YOURLS. Probably a configuration issue, like wrong or missing \"apiurl\" or \"signature\".",
-    "Error parsing YOURLS response.": "Error parsing YOURLS response."
+    "Error parsing YOURLS response.": "Error parsing YOURLS response.",
+    "Burn after reading pastes can only be displayed once upon loading it. Do you want to open it now?": "Burn after reading pastes can only be displayed once upon loading it. Do you want to open it now?",
+    "Yes, load it": "Yes, load it"
 }

--- a/i18n/es.json
+++ b/i18n/es.json
@@ -214,5 +214,7 @@
     "Your IP is not authorized to create pastes.": "Tu IP no está autorizada para crear contenido.",
     "Trying to shorten a URL that isn't pointing at our instance.": "Intentando acortar una URL que no apunta a nuestra instancia.",
     "Error calling YOURLS. Probably a configuration issue, like wrong or missing \"apiurl\" or \"signature\".": "Error calling YOURLS. Probably a configuration issue, like wrong or missing \"apiurl\" or \"signature\".",
-    "Error parsing YOURLS response.": "Error parsing YOURLS response."
+    "Error parsing YOURLS response.": "Error parsing YOURLS response.",
+    "Burn after reading pastes can only be displayed once upon loading it. Do you want to open it now?": "Burn after reading pastes can only be displayed once upon loading it. Do you want to open it now?",
+    "Yes, load it": "Yes, load it"
 }

--- a/i18n/et.json
+++ b/i18n/et.json
@@ -214,5 +214,7 @@
     "Your IP is not authorized to create pastes.": "Your IP is not authorized to create pastes.",
     "Trying to shorten a URL that isn't pointing at our instance.": "Trying to shorten a URL that isn't pointing at our instance.",
     "Error calling YOURLS. Probably a configuration issue, like wrong or missing \"apiurl\" or \"signature\".": "Error calling YOURLS. Probably a configuration issue, like wrong or missing \"apiurl\" or \"signature\".",
-    "Error parsing YOURLS response.": "Error parsing YOURLS response."
+    "Error parsing YOURLS response.": "Error parsing YOURLS response.",
+    "Burn after reading pastes can only be displayed once upon loading it. Do you want to open it now?": "Burn after reading pastes can only be displayed once upon loading it. Do you want to open it now?",
+    "Yes, load it": "Yes, load it"
 }

--- a/i18n/fi.json
+++ b/i18n/fi.json
@@ -214,5 +214,7 @@
     "Your IP is not authorized to create pastes.": "IP:llesi ei ole annettu oikeutta luoda pasteja.",
     "Trying to shorten a URL that isn't pointing at our instance.": "Yritetään lyhentää URL-osoite, joka ei osoita meidän instanssiiin.",
     "Error calling YOURLS. Probably a configuration issue, like wrong or missing \"apiurl\" or \"signature\".": "Virhe kutsuttaessa YOURLS. Luultavasti asetusongelma kuten väärä tai puuttuuva \"apiurl\" tai \"signature\".",
-    "Error parsing YOURLS response.": "Virhe jäsennettäessä YOURLS-vastausta."
+    "Error parsing YOURLS response.": "Virhe jäsennettäessä YOURLS-vastausta.",
+    "Burn after reading pastes can only be displayed once upon loading it. Do you want to open it now?": "Burn after reading pastes can only be displayed once upon loading it. Do you want to open it now?",
+    "Yes, load it": "Yes, load it"
 }

--- a/i18n/fr.json
+++ b/i18n/fr.json
@@ -214,5 +214,7 @@
     "Your IP is not authorized to create pastes.": "Votre adresse IP n'est pas autorisée à créer des pastes.",
     "Trying to shorten a URL that isn't pointing at our instance.": "Trying to shorten a URL that isn't pointing at our instance.",
     "Error calling YOURLS. Probably a configuration issue, like wrong or missing \"apiurl\" or \"signature\".": "Error calling YOURLS. Probably a configuration issue, like wrong or missing \"apiurl\" or \"signature\".",
-    "Error parsing YOURLS response.": "Error parsing YOURLS response."
+    "Error parsing YOURLS response.": "Error parsing YOURLS response.",
+    "Burn after reading pastes can only be displayed once upon loading it. Do you want to open it now?": "Burn after reading pastes can only be displayed once upon loading it. Do you want to open it now?",
+    "Yes, load it": "Yes, load it"
 }

--- a/i18n/he.json
+++ b/i18n/he.json
@@ -214,5 +214,7 @@
     "Your IP is not authorized to create pastes.": "Your IP is not authorized to create pastes.",
     "Trying to shorten a URL that isn't pointing at our instance.": "Trying to shorten a URL that isn't pointing at our instance.",
     "Error calling YOURLS. Probably a configuration issue, like wrong or missing \"apiurl\" or \"signature\".": "Error calling YOURLS. Probably a configuration issue, like wrong or missing \"apiurl\" or \"signature\".",
-    "Error parsing YOURLS response.": "Error parsing YOURLS response."
+    "Error parsing YOURLS response.": "Error parsing YOURLS response.",
+    "Burn after reading pastes can only be displayed once upon loading it. Do you want to open it now?": "Burn after reading pastes can only be displayed once upon loading it. Do you want to open it now?",
+    "Yes, load it": "Yes, load it"
 }

--- a/i18n/hi.json
+++ b/i18n/hi.json
@@ -214,5 +214,7 @@
     "Your IP is not authorized to create pastes.": "Your IP is not authorized to create pastes.",
     "Trying to shorten a URL that isn't pointing at our instance.": "Trying to shorten a URL that isn't pointing at our instance.",
     "Error calling YOURLS. Probably a configuration issue, like wrong or missing \"apiurl\" or \"signature\".": "Error calling YOURLS. Probably a configuration issue, like wrong or missing \"apiurl\" or \"signature\".",
-    "Error parsing YOURLS response.": "Error parsing YOURLS response."
+    "Error parsing YOURLS response.": "Error parsing YOURLS response.",
+    "Burn after reading pastes can only be displayed once upon loading it. Do you want to open it now?": "Burn after reading pastes can only be displayed once upon loading it. Do you want to open it now?",
+    "Yes, load it": "Yes, load it"
 }

--- a/i18n/hu.json
+++ b/i18n/hu.json
@@ -214,5 +214,7 @@
     "Your IP is not authorized to create pastes.": "Your IP is not authorized to create pastes.",
     "Trying to shorten a URL that isn't pointing at our instance.": "Trying to shorten a URL that isn't pointing at our instance.",
     "Error calling YOURLS. Probably a configuration issue, like wrong or missing \"apiurl\" or \"signature\".": "Error calling YOURLS. Probably a configuration issue, like wrong or missing \"apiurl\" or \"signature\".",
-    "Error parsing YOURLS response.": "Error parsing YOURLS response."
+    "Error parsing YOURLS response.": "Error parsing YOURLS response.",
+    "Burn after reading pastes can only be displayed once upon loading it. Do you want to open it now?": "Burn after reading pastes can only be displayed once upon loading it. Do you want to open it now?",
+    "Yes, load it": "Yes, load it"
 }

--- a/i18n/id.json
+++ b/i18n/id.json
@@ -214,5 +214,7 @@
     "Your IP is not authorized to create pastes.": "Your IP is not authorized to create pastes.",
     "Trying to shorten a URL that isn't pointing at our instance.": "Trying to shorten a URL that isn't pointing at our instance.",
     "Error calling YOURLS. Probably a configuration issue, like wrong or missing \"apiurl\" or \"signature\".": "Error calling YOURLS. Probably a configuration issue, like wrong or missing \"apiurl\" or \"signature\".",
-    "Error parsing YOURLS response.": "Error parsing YOURLS response."
+    "Error parsing YOURLS response.": "Error parsing YOURLS response.",
+    "Burn after reading pastes can only be displayed once upon loading it. Do you want to open it now?": "Burn after reading pastes can only be displayed once upon loading it. Do you want to open it now?",
+    "Yes, load it": "Yes, load it"
 }

--- a/i18n/it.json
+++ b/i18n/it.json
@@ -214,5 +214,7 @@
     "Your IP is not authorized to create pastes.": "Il tuo IP non è autorizzato a creare dei messaggi.",
     "Trying to shorten a URL that isn't pointing at our instance.": "Tantativo in corso di accorciare un URL che non punta alla nostra istanza.",
     "Error calling YOURLS. Probably a configuration issue, like wrong or missing \"apiurl\" or \"signature\".": "Errore nella chiamata a YOURLS. Probabilmente un problema di configurazione, come un \"apiurl\" o una \"signature\" sbagliati o mancanti.",
-    "Error parsing YOURLS response.": "Errore nell'analizzare la risposta YOURLS."
+    "Error parsing YOURLS response.": "Errore nell'analizzare la risposta YOURLS.",
+    "Burn after reading pastes can only be displayed once upon loading it. Do you want to open it now?": "Burn after reading pastes can only be displayed once upon loading it. Do you want to open it now?",
+    "Yes, load it": "Yes, load it"
 }

--- a/i18n/ja.json
+++ b/i18n/ja.json
@@ -214,5 +214,7 @@
     "Your IP is not authorized to create pastes.": "あなたのIPアドレスにはペーストを作成する権限がありません。",
     "Trying to shorten a URL that isn't pointing at our instance.": "このインスタンスを指していないURLを短縮しようとしています。",
     "Error calling YOURLS. Probably a configuration issue, like wrong or missing \"apiurl\" or \"signature\".": "YOURLSの呼び出し中にエラーが発生しました。\"apiurl\"または\"signature\"等の設定に問題がある可能性があります。",
-    "Error parsing YOURLS response.": "YOURLSレスポンスの解析中にエラーが発生しました。"
+    "Error parsing YOURLS response.": "YOURLSレスポンスの解析中にエラーが発生しました。",
+    "Burn after reading pastes can only be displayed once upon loading it. Do you want to open it now?": "Burn after reading pastes can only be displayed once upon loading it. Do you want to open it now?",
+    "Yes, load it": "Yes, load it"
 }

--- a/i18n/jbo.json
+++ b/i18n/jbo.json
@@ -214,5 +214,7 @@
     "Your IP is not authorized to create pastes.": "Your IP is not authorized to create pastes.",
     "Trying to shorten a URL that isn't pointing at our instance.": "Trying to shorten a URL that isn't pointing at our instance.",
     "Error calling YOURLS. Probably a configuration issue, like wrong or missing \"apiurl\" or \"signature\".": "Error calling YOURLS. Probably a configuration issue, like wrong or missing \"apiurl\" or \"signature\".",
-    "Error parsing YOURLS response.": "Error parsing YOURLS response."
+    "Error parsing YOURLS response.": "Error parsing YOURLS response.",
+    "Burn after reading pastes can only be displayed once upon loading it. Do you want to open it now?": "Burn after reading pastes can only be displayed once upon loading it. Do you want to open it now?",
+    "Yes, load it": "Yes, load it"
 }

--- a/i18n/ku.json
+++ b/i18n/ku.json
@@ -214,5 +214,7 @@
     "Your IP is not authorized to create pastes.": "Your IP is not authorized to create pastes.",
     "Trying to shorten a URL that isn't pointing at our instance.": "Trying to shorten a URL that isn't pointing at our instance.",
     "Error calling YOURLS. Probably a configuration issue, like wrong or missing \"apiurl\" or \"signature\".": "Error calling YOURLS. Probably a configuration issue, like wrong or missing \"apiurl\" or \"signature\".",
-    "Error parsing YOURLS response.": "Error parsing YOURLS response."
+    "Error parsing YOURLS response.": "Error parsing YOURLS response.",
+    "Burn after reading pastes can only be displayed once upon loading it. Do you want to open it now?": "Burn after reading pastes can only be displayed once upon loading it. Do you want to open it now?",
+    "Yes, load it": "Yes, load it"
 }

--- a/i18n/la.json
+++ b/i18n/la.json
@@ -214,5 +214,7 @@
     "Your IP is not authorized to create pastes.": "Your IP is not authorized to create pastes.",
     "Trying to shorten a URL that isn't pointing at our instance.": "Trying to shorten a URL that isn't pointing at our instance.",
     "Error calling YOURLS. Probably a configuration issue, like wrong or missing \"apiurl\" or \"signature\".": "Error calling YOURLS. Probably a configuration issue, like wrong or missing \"apiurl\" or \"signature\".",
-    "Error parsing YOURLS response.": "Error parsing YOURLS response."
+    "Error parsing YOURLS response.": "Error parsing YOURLS response.",
+    "Burn after reading pastes can only be displayed once upon loading it. Do you want to open it now?": "Burn after reading pastes can only be displayed once upon loading it. Do you want to open it now?",
+    "Yes, load it": "Yes, load it"
 }

--- a/i18n/lt.json
+++ b/i18n/lt.json
@@ -214,5 +214,7 @@
     "Your IP is not authorized to create pastes.": "Jūsų IP adresas neturi įgaliojimų kurti įdėjimų.",
     "Trying to shorten a URL that isn't pointing at our instance.": "Bandoma sutrumpinti URL adresą, kuris nenurodo į mūsų egzempliorių.",
     "Error calling YOURLS. Probably a configuration issue, like wrong or missing \"apiurl\" or \"signature\".": "Klaida iškviečiant YOURLS. Tikriausiai, konfigūracijos klaida, pavyzdžiui, neteisingi „apiurl“ ar „signature“, arba jų nėra.",
-    "Error parsing YOURLS response.": "Klaida nagrinėjant YOURLS atsaką."
+    "Error parsing YOURLS response.": "Klaida nagrinėjant YOURLS atsaką.",
+    "Burn after reading pastes can only be displayed once upon loading it. Do you want to open it now?": "Burn after reading pastes can only be displayed once upon loading it. Do you want to open it now?",
+    "Yes, load it": "Yes, load it"
 }

--- a/i18n/nl.json
+++ b/i18n/nl.json
@@ -214,5 +214,7 @@
     "Your IP is not authorized to create pastes.": "Je IP-adres is niet gemachtigd om pastes te maken.",
     "Trying to shorten a URL that isn't pointing at our instance.": "Proberen om een URL te verkorten dat niet naar ons systeem wijst.",
     "Error calling YOURLS. Probably a configuration issue, like wrong or missing \"apiurl\" or \"signature\".": "Foutmelding ophalen YOURLS. Waarschijnlijk een configuratiefout, zoals een verkeerde of missende \"apiurl\" of \"signature\".",
-    "Error parsing YOURLS response.": "Foutmelding bij parsen van YOURLS respons."
+    "Error parsing YOURLS response.": "Foutmelding bij parsen van YOURLS respons.",
+    "Burn after reading pastes can only be displayed once upon loading it. Do you want to open it now?": "Burn after reading pastes can only be displayed once upon loading it. Do you want to open it now?",
+    "Yes, load it": "Yes, load it"
 }

--- a/i18n/no.json
+++ b/i18n/no.json
@@ -214,5 +214,7 @@
     "Your IP is not authorized to create pastes.": "Your IP is not authorized to create pastes.",
     "Trying to shorten a URL that isn't pointing at our instance.": "Trying to shorten a URL that isn't pointing at our instance.",
     "Error calling YOURLS. Probably a configuration issue, like wrong or missing \"apiurl\" or \"signature\".": "Error calling YOURLS. Probably a configuration issue, like wrong or missing \"apiurl\" or \"signature\".",
-    "Error parsing YOURLS response.": "Error parsing YOURLS response."
+    "Error parsing YOURLS response.": "Error parsing YOURLS response.",
+    "Burn after reading pastes can only be displayed once upon loading it. Do you want to open it now?": "Burn after reading pastes can only be displayed once upon loading it. Do you want to open it now?",
+    "Yes, load it": "Yes, load it"
 }

--- a/i18n/oc.json
+++ b/i18n/oc.json
@@ -214,5 +214,7 @@
     "Your IP is not authorized to create pastes.": "Vòstra adreça IP a pas l’autorizacion de crear de tèxtes.",
     "Trying to shorten a URL that isn't pointing at our instance.": "Ensag d’abracar una URL que mena pas a nòstra instància.",
     "Error calling YOURLS. Probably a configuration issue, like wrong or missing \"apiurl\" or \"signature\".": "Error en cridant YOURLS. Es probablament un problèma de configuracion, quicòm coma « apirul » o « signature » marrit o absent.",
-    "Error parsing YOURLS response.": "Error d'analisi de la responsa YOURLS."
+    "Error parsing YOURLS response.": "Error d'analisi de la responsa YOURLS.",
+    "Burn after reading pastes can only be displayed once upon loading it. Do you want to open it now?": "Burn after reading pastes can only be displayed once upon loading it. Do you want to open it now?",
+    "Yes, load it": "Yes, load it"
 }

--- a/i18n/pl.json
+++ b/i18n/pl.json
@@ -214,5 +214,7 @@
     "Your IP is not authorized to create pastes.": "Your IP is not authorized to create pastes.",
     "Trying to shorten a URL that isn't pointing at our instance.": "Trying to shorten a URL that isn't pointing at our instance.",
     "Error calling YOURLS. Probably a configuration issue, like wrong or missing \"apiurl\" or \"signature\".": "Error calling YOURLS. Probably a configuration issue, like wrong or missing \"apiurl\" or \"signature\".",
-    "Error parsing YOURLS response.": "Error parsing YOURLS response."
+    "Error parsing YOURLS response.": "Error parsing YOURLS response.",
+    "Burn after reading pastes can only be displayed once upon loading it. Do you want to open it now?": "Burn after reading pastes can only be displayed once upon loading it. Do you want to open it now?",
+    "Yes, load it": "Yes, load it"
 }

--- a/i18n/pt.json
+++ b/i18n/pt.json
@@ -214,5 +214,7 @@
     "Your IP is not authorized to create pastes.": "Seu IP não está autorizado a criar cópias.",
     "Trying to shorten a URL that isn't pointing at our instance.": "Tentando encurtar uma URL que não aponta para a nossa instância.",
     "Error calling YOURLS. Probably a configuration issue, like wrong or missing \"apiurl\" or \"signature\".": "Error calling YOURLS. Probably a configuration issue, like wrong or missing \"apiurl\" or \"signature\".",
-    "Error parsing YOURLS response.": "Error parsing YOURLS response."
+    "Error parsing YOURLS response.": "Error parsing YOURLS response.",
+    "Burn after reading pastes can only be displayed once upon loading it. Do you want to open it now?": "Burn after reading pastes can only be displayed once upon loading it. Do you want to open it now?",
+    "Yes, load it": "Yes, load it"
 }

--- a/i18n/ru.json
+++ b/i18n/ru.json
@@ -214,5 +214,7 @@
     "Your IP is not authorized to create pastes.": "Вашему IP адресу не разрешено создавать записи.",
     "Trying to shorten a URL that isn't pointing at our instance.": "Trying to shorten a URL that isn't pointing at our instance.",
     "Error calling YOURLS. Probably a configuration issue, like wrong or missing \"apiurl\" or \"signature\".": "Error calling YOURLS. Probably a configuration issue, like wrong or missing \"apiurl\" or \"signature\".",
-    "Error parsing YOURLS response.": "Error parsing YOURLS response."
+    "Error parsing YOURLS response.": "Error parsing YOURLS response.",
+    "Burn after reading pastes can only be displayed once upon loading it. Do you want to open it now?": "Burn after reading pastes can only be displayed once upon loading it. Do you want to open it now?",
+    "Yes, load it": "Yes, load it"
 }

--- a/i18n/sk.json
+++ b/i18n/sk.json
@@ -214,5 +214,7 @@
     "Your IP is not authorized to create pastes.": "Vaša IP adresa nie je oprávnená vytvárať príspevky.",
     "Trying to shorten a URL that isn't pointing at our instance.": "Pokúšate sa skrátiť adresu URL, ktorá neukazuje na túto inštanciu.",
     "Error calling YOURLS. Probably a configuration issue, like wrong or missing \"apiurl\" or \"signature\".": "Error calling YOURLS. Probably a configuration issue, like wrong or missing \"apiurl\" or \"signature\".",
-    "Error parsing YOURLS response.": "Error parsing YOURLS response."
+    "Error parsing YOURLS response.": "Error parsing YOURLS response.",
+    "Burn after reading pastes can only be displayed once upon loading it. Do you want to open it now?": "Burn after reading pastes can only be displayed once upon loading it. Do you want to open it now?",
+    "Yes, load it": "Yes, load it"
 }

--- a/i18n/sl.json
+++ b/i18n/sl.json
@@ -214,5 +214,7 @@
     "Your IP is not authorized to create pastes.": "Your IP is not authorized to create pastes.",
     "Trying to shorten a URL that isn't pointing at our instance.": "Trying to shorten a URL that isn't pointing at our instance.",
     "Error calling YOURLS. Probably a configuration issue, like wrong or missing \"apiurl\" or \"signature\".": "Error calling YOURLS. Probably a configuration issue, like wrong or missing \"apiurl\" or \"signature\".",
-    "Error parsing YOURLS response.": "Error parsing YOURLS response."
+    "Error parsing YOURLS response.": "Error parsing YOURLS response.",
+    "Burn after reading pastes can only be displayed once upon loading it. Do you want to open it now?": "Burn after reading pastes can only be displayed once upon loading it. Do you want to open it now?",
+    "Yes, load it": "Yes, load it"
 }

--- a/i18n/sv.json
+++ b/i18n/sv.json
@@ -214,5 +214,7 @@
     "Your IP is not authorized to create pastes.": "Your IP is not authorized to create pastes.",
     "Trying to shorten a URL that isn't pointing at our instance.": "Trying to shorten a URL that isn't pointing at our instance.",
     "Error calling YOURLS. Probably a configuration issue, like wrong or missing \"apiurl\" or \"signature\".": "Error calling YOURLS. Probably a configuration issue, like wrong or missing \"apiurl\" or \"signature\".",
-    "Error parsing YOURLS response.": "Error parsing YOURLS response."
+    "Error parsing YOURLS response.": "Error parsing YOURLS response.",
+    "Burn after reading pastes can only be displayed once upon loading it. Do you want to open it now?": "Burn after reading pastes can only be displayed once upon loading it. Do you want to open it now?",
+    "Yes, load it": "Yes, load it"
 }

--- a/i18n/th.json
+++ b/i18n/th.json
@@ -214,5 +214,7 @@
     "Your IP is not authorized to create pastes.": "IP ของคุณไม่ได้รับอนุญาตให้สร้างการฝากโค้ด",
     "Trying to shorten a URL that isn't pointing at our instance.": "กำลังพยายามใช้เครื่องมือสร้างลิงก์ย่อ ที่ไม่ได้ชี้ไปที่อินสแตนซ์ของเรา",
     "Error calling YOURLS. Probably a configuration issue, like wrong or missing \"apiurl\" or \"signature\".": "เกิดข้อผิดพลาดในการเรียก YOURLS อาจเป็นปัญหามาจากการกำหนดค่า เช่น \"apiurl\" หรือ \"signature\" ไม่ถูกต้องหรือขาดหายไป",
-    "Error parsing YOURLS response.": "เกิดข้อผิดพลาดในการแยกวิเคราะห์การตอบสนองของ YOURLS"
+    "Error parsing YOURLS response.": "เกิดข้อผิดพลาดในการแยกวิเคราะห์การตอบสนองของ YOURLS",
+    "Burn after reading pastes can only be displayed once upon loading it. Do you want to open it now?": "Burn after reading pastes can only be displayed once upon loading it. Do you want to open it now?",
+    "Yes, load it": "Yes, load it"
 }

--- a/i18n/tr.json
+++ b/i18n/tr.json
@@ -214,5 +214,7 @@
     "Your IP is not authorized to create pastes.": "IP adresinizin yazı oluşturmaya yetkisi yoktur.",
     "Trying to shorten a URL that isn't pointing at our instance.": "Trying to shorten a URL that isn't pointing at our instance.",
     "Error calling YOURLS. Probably a configuration issue, like wrong or missing \"apiurl\" or \"signature\".": "Error calling YOURLS. Probably a configuration issue, like wrong or missing \"apiurl\" or \"signature\".",
-    "Error parsing YOURLS response.": "Error parsing YOURLS response."
+    "Error parsing YOURLS response.": "Error parsing YOURLS response.",
+    "Burn after reading pastes can only be displayed once upon loading it. Do you want to open it now?": "Burn after reading pastes can only be displayed once upon loading it. Do you want to open it now?",
+    "Yes, load it": "Yes, load it"
 }

--- a/i18n/uk.json
+++ b/i18n/uk.json
@@ -214,5 +214,7 @@
     "Your IP is not authorized to create pastes.": "Вашому IP не дозволено створювати вставки.",
     "Trying to shorten a URL that isn't pointing at our instance.": "Trying to shorten a URL that isn't pointing at our instance.",
     "Error calling YOURLS. Probably a configuration issue, like wrong or missing \"apiurl\" or \"signature\".": "Error calling YOURLS. Probably a configuration issue, like wrong or missing \"apiurl\" or \"signature\".",
-    "Error parsing YOURLS response.": "Error parsing YOURLS response."
+    "Error parsing YOURLS response.": "Error parsing YOURLS response.",
+    "Burn after reading pastes can only be displayed once upon loading it. Do you want to open it now?": "Burn after reading pastes can only be displayed once upon loading it. Do you want to open it now?",
+    "Yes, load it": "Yes, load it"
 }

--- a/i18n/zh.json
+++ b/i18n/zh.json
@@ -214,5 +214,7 @@
     "Your IP is not authorized to create pastes.": "您的 IP 无权创建粘贴。",
     "Trying to shorten a URL that isn't pointing at our instance.": "尝试缩短一个不指向我们实例的URL。",
     "Error calling YOURLS. Probably a configuration issue, like wrong or missing \"apiurl\" or \"signature\".": "调用 YOURLS 时出错。可能是配置问题，例如“apiurl”或“signature”错误或缺失。",
-    "Error parsing YOURLS response.": "解析 YOURLS 响应时出错。"
+    "Error parsing YOURLS response.": "解析 YOURLS 响应时出错。",
+    "Burn after reading pastes can only be displayed once upon loading it. Do you want to open it now?": "Burn after reading pastes can only be displayed once upon loading it. Do you want to open it now?",
+    "Yes, load it": "Yes, load it"
 }

--- a/js/privatebin.js
+++ b/js/privatebin.js
@@ -4862,7 +4862,8 @@ jQuery.PrivateBin = (function($, RawDeflate) {
 
             const pw = TopNav.getPassword()
 
-            if(pw && pw.length) {
+            // only execute when it is a single time view
+            if(pw && pw.length && TopNav.getBurnAfterReading()) {
 
                 const sm =  CryptTool.getSymmetricKey();
 
@@ -5032,9 +5033,12 @@ jQuery.PrivateBin = (function($, RawDeflate) {
 
             // prepare server interaction
             ServerInteraction.prepare();
-            // This is not needed when encrypting browser side
-            // ServerInteraction.setCryptParameters(TopNav.getPassword());
-            ServerInteraction.setCryptParameters('');
+            if(!TopNav.getBurnAfterReading()) {
+                ServerInteraction.setCryptParameters(TopNav.getPassword());
+            } else {
+                // not needed in this scenario
+                ServerInteraction.setCryptParameters('');
+            }
 
             // set success/fail functions
             ServerInteraction.setSuccess(showCreatedPaste);

--- a/js/privatebin.js
+++ b/js/privatebin.js
@@ -82,7 +82,7 @@ jQuery.PrivateBin = (function($, RawDeflate) {
      *
      * @private
      */
-    const loadConfirmPrefix = '#?';
+    const loadConfirmPrefix = '#-';
 
     /**
      * CryptoData class
@@ -2303,7 +2303,12 @@ jQuery.PrivateBin = (function($, RawDeflate) {
                     backdrop: 'static',
                     keyboard: false
                 });
+                // focus password input
                 $passwordDecrypt.focus();
+                // then re-focus it, when modal causes it to loose focus again
+                setTimeout(function () {
+                    $passwordDecrypt.focus();
+                }, 500);
                 return;
             }
 
@@ -2363,13 +2368,7 @@ jQuery.PrivateBin = (function($, RawDeflate) {
             $passwordForm = $('#passwordform');
             $passwordModal = $('#passwordmodal');
 
-            // bind events
-
-            // focus password input when it is shown
-            $passwordModal.on('shown.bs.Model', function () {
-                $passwordDecrypt.focus();
-            });
-            // handle Model password submission
+            // bind events - handle Model password submission
             $passwordForm.submit(submitPasswordModal);
         };
 
@@ -3603,7 +3602,6 @@ jQuery.PrivateBin = (function($, RawDeflate) {
                 if (fadeOut === true) {
                     setTimeout(function () {
                         $comment.removeClass('highlight');
-
                     }, 300);
                 }
             };

--- a/tpl/bootstrap.php
+++ b/tpl/bootstrap.php
@@ -73,7 +73,7 @@ endif;
 ?>
 		<script type="text/javascript" data-cfasync="false" src="js/purify-3.0.6.js" integrity="sha512-N3y6/HOk3pbsw3lFh4O8CKKEVwu1B2CF8kinhjURf8Yqa5OfSUt+/arozxFW+TUPOPw3TsDCRT/0u7BGRTEVUw==" crossorigin="anonymous"></script>
 		<script type="text/javascript" data-cfasync="false" src="js/legacy.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-LYos+qXHIRqFf5ZPNphvtTB0cgzHUizu2wwcOwcwz/VIpRv9lpcBgPYz4uq6jx0INwCAj6Fbnl5HoKiLufS2jg==" crossorigin="anonymous"></script>
-		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-m/JO/NGsP+FEHPACdYe60BFkURk+NVCBaMsIUOUC5J1EnVE2XgVKF6Z+YSDd+9M4ISu0SivYxCZBEl8qW8u1Jg==" crossorigin="anonymous"></script>
+		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-zHSMNVafjkfbJWyExunMI9NvD/oSdifOiPCUGKdf4GHeCjl/IRi8RYyGoAzZPekqRDhhkl13SlfkUiQYKD0g5Q==" crossorigin="anonymous"></script>
 		<!-- icon -->
 		<link rel="apple-touch-icon" href="<?php echo I18n::encode($BASEPATH); ?>img/apple-touch-icon.png" sizes="180x180" />
 		<link rel="icon" type="image/png" href="img/favicon-32x32.png" sizes="32x32" />
@@ -123,21 +123,31 @@ if (count($class)) {
 				</div>
 			</div>
 		</div>
+		<div id="loadconfirmmodal" tabindex="-1" class="modal fade" role="dialog" aria-hidden="true">
+			<div class="modal-dialog" role="document">
+				<div class="modal-content">
+					<div class="modal-header">
+						<button type="button" class="close" data-dismiss="modal" aria-label="<?php echo I18n::_('Close') ?>"><span aria-hidden="true">&times;</span></button>
+						<h4 class="modal-title"><?php echo I18n::_('Burn after reading pastes can only be displayed once upon loading it. Do you want to open it now?') ?></h4>
+					</div>
+					<div class="modal-body text-center">
+						<button id="loadconfirm-open-now" type="button" class="btn btn-success" data-dismiss="modal"><span class="glyphicon glyphicon-download"></span> <?php echo I18n::_('Yes, load it') ?></button>
+					</div>
+				</div>
+			</div>
+		</div>
 <?php
 if ($QRCODE) :
 ?>
-		<div id="qrcodemodal" tabindex="-1" class="modal fade" aria-labelledby="qrcodemodalTitle" role="dialog" aria-hidden="true">
+		<div id="qrcodemodal" tabindex="-1" class="modal fade" role="dialog" aria-hidden="true">
 			<div class="modal-dialog" role="document">
 				<div class="modal-content">
+					<div class="modal-header">
+						<button type="button" class="close" data-dismiss="modal" aria-label="<?php echo I18n::_('Close') ?>"><span aria-hidden="true">&times;</span></button>
+						<h4 class="modal-title"><?php echo I18n::_('QR code') ?></h4>
+					</div>
 					<div class="modal-body">
 						<div class="mx-auto" id="qrcode-display"></div>
-					</div>
-					<div class="row">
-						<div class="btn-group col-xs-12">
-							<span class="col-xs-12">
-								<button type="button" class="btn btn-primary btn-block" data-dismiss="modal"><?php echo I18n::_('Close') ?></button>
-							</span>
-						</div>
 					</div>
 				</div>
 			</div>
@@ -146,23 +156,19 @@ if ($QRCODE) :
 endif;
 if ($EMAIL) :
 ?>
-		<div id="emailconfirmmodal" tabindex="-1" class="modal fade" aria-labelledby="emailconfirmmodalTitle" role="dialog" aria-hidden="true">
+		<div id="emailconfirmmodal" tabindex="-1" class="modal fade" role="dialog" aria-hidden="true">
 			<div class="modal-dialog" role="document">
 				<div class="modal-content">
-					<div class="modal-body">
-						<div id="emailconfirm-display"></div>
+					<div class="modal-header">
+						<button type="button" class="close" data-dismiss="modal" aria-label="<?php echo I18n::_('Close') ?>"><span aria-hidden="true">&times;</span></button>
+						<h4 class="modal-title"><?php echo I18n::_('Recipient may become aware of your timezone, convert time to UTC?') ?></h4>
 					</div>
-					<div class="row">
-						<div class="btn-group col-xs-12" data-toggle="buttons">
-							<span class="col-xs-12 col-md-4">
-								<button id="emailconfirm-timezone-current" type="button" class="btn btn-danger btn-block" data-dismiss="modal"><?php echo I18n::_('Use Current Timezone') ?></button>
-							</span>
-							<span class="col-xs-12 col-md-4">
-								<button id="emailconfirm-timezone-utc" type="button" class="btn btn-default btn-block" data-dismiss="modal"><?php echo I18n::_('Convert To UTC') ?></button>
-							</span>
-							<span class="col-xs-12 col-md-4">
-								<button type="button" class="btn btn-primary btn-block" data-dismiss="modal"><?php echo I18n::_('Close') ?></button>
-							</span>
+					<div class="modal-body row">
+						<div class="col-xs-12 col-md-6">
+							<button id="emailconfirm-timezone-current" type="button" class="btn btn-danger"><span class="glyphicon glyphicon-time"></span> <?php echo I18n::_('Use Current Timezone') ?></button>
+						</div>
+						<div class="col-xs-12 col-md-6 text-right">
+							<button id="emailconfirm-timezone-utc" type="button" class="btn btn-success"><span class="glyphicon glyphicon-globe"></span> <?php echo I18n::_('Convert To UTC') ?></button>
 						</div>
 					</div>
 				</div>

--- a/tpl/bootstrap.php
+++ b/tpl/bootstrap.php
@@ -73,7 +73,7 @@ endif;
 ?>
 		<script type="text/javascript" data-cfasync="false" src="js/purify-3.0.6.js" integrity="sha512-N3y6/HOk3pbsw3lFh4O8CKKEVwu1B2CF8kinhjURf8Yqa5OfSUt+/arozxFW+TUPOPw3TsDCRT/0u7BGRTEVUw==" crossorigin="anonymous"></script>
 		<script type="text/javascript" data-cfasync="false" src="js/legacy.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-LYos+qXHIRqFf5ZPNphvtTB0cgzHUizu2wwcOwcwz/VIpRv9lpcBgPYz4uq6jx0INwCAj6Fbnl5HoKiLufS2jg==" crossorigin="anonymous"></script>
-		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-TwHs7AU0ZWg8bylMgHXtPjnTeGeqSGHknoD3GENdI+xUjJYlup5vNNgL9pg3KSTgPnN49HqNt7h1NdqjHZ1Rfg==" crossorigin="anonymous"></script>
+		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-6dEOyWPTHhugOFSpHhuQHbnu3y4OzuP5mExo7isG36hG1AF1U2hgMuXKX1oyDAmsztoshqS/FWKV8Pd8JthAdg==" crossorigin="anonymous"></script>
 		<!-- icon -->
 		<link rel="apple-touch-icon" href="<?php echo I18n::encode($BASEPATH); ?>img/apple-touch-icon.png" sizes="180x180" />
 		<link rel="icon" type="image/png" href="img/favicon-32x32.png" sizes="32x32" />

--- a/tpl/page.php
+++ b/tpl/page.php
@@ -51,7 +51,7 @@ endif;
 ?>
 		<script type="text/javascript" data-cfasync="false" src="js/purify-3.0.6.js" integrity="sha512-N3y6/HOk3pbsw3lFh4O8CKKEVwu1B2CF8kinhjURf8Yqa5OfSUt+/arozxFW+TUPOPw3TsDCRT/0u7BGRTEVUw==" crossorigin="anonymous"></script>
 		<script type="text/javascript" data-cfasync="false" src="js/legacy.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-LYos+qXHIRqFf5ZPNphvtTB0cgzHUizu2wwcOwcwz/VIpRv9lpcBgPYz4uq6jx0INwCAj6Fbnl5HoKiLufS2jg==" crossorigin="anonymous"></script>
-		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-m/JO/NGsP+FEHPACdYe60BFkURk+NVCBaMsIUOUC5J1EnVE2XgVKF6Z+YSDd+9M4ISu0SivYxCZBEl8qW8u1Jg==" crossorigin="anonymous"></script>
+		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-zHSMNVafjkfbJWyExunMI9NvD/oSdifOiPCUGKdf4GHeCjl/IRi8RYyGoAzZPekqRDhhkl13SlfkUiQYKD0g5Q==" crossorigin="anonymous"></script>
 		<!-- icon -->
 		<link rel="apple-touch-icon" href="img/apple-touch-icon.png?<?php echo rawurlencode($VERSION); ?>" sizes="180x180" />
 		<link rel="icon" type="image/png" href="img/favicon-32x32.png?<?php echo rawurlencode($VERSION); ?>" sizes="32x32" />

--- a/tpl/page.php
+++ b/tpl/page.php
@@ -51,7 +51,7 @@ endif;
 ?>
 		<script type="text/javascript" data-cfasync="false" src="js/purify-3.0.6.js" integrity="sha512-N3y6/HOk3pbsw3lFh4O8CKKEVwu1B2CF8kinhjURf8Yqa5OfSUt+/arozxFW+TUPOPw3TsDCRT/0u7BGRTEVUw==" crossorigin="anonymous"></script>
 		<script type="text/javascript" data-cfasync="false" src="js/legacy.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-LYos+qXHIRqFf5ZPNphvtTB0cgzHUizu2wwcOwcwz/VIpRv9lpcBgPYz4uq6jx0INwCAj6Fbnl5HoKiLufS2jg==" crossorigin="anonymous"></script>
-		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-TwHs7AU0ZWg8bylMgHXtPjnTeGeqSGHknoD3GENdI+xUjJYlup5vNNgL9pg3KSTgPnN49HqNt7h1NdqjHZ1Rfg==" crossorigin="anonymous"></script>
+		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-6dEOyWPTHhugOFSpHhuQHbnu3y4OzuP5mExo7isG36hG1AF1U2hgMuXKX1oyDAmsztoshqS/FWKV8Pd8JthAdg==" crossorigin="anonymous"></script>
 		<!-- icon -->
 		<link rel="apple-touch-icon" href="img/apple-touch-icon.png?<?php echo rawurlencode($VERSION); ?>" sizes="180x180" />
 		<link rel="icon" type="image/png" href="img/favicon-32x32.png?<?php echo rawurlencode($VERSION); ?>" sizes="32x32" />


### PR DESCRIPTION
This PR is derived from #1231 but with a slightly less complex goal.

When creating burn after reading pastes, a "?" is inserted at the start of the URL fragment (.../?aaaa#bbbb becomes .../?aaaa#**?**bbbb). This way the server doesn't get sent this, though it still knows that the paste is of the burn after reading type. If this character is detected upon loading a paste, the user is asked to confirm loading it, by clicking a button:

![load confirmation dialog](https://github.com/PrivateBin/PrivateBin/assets/1017622/7fb9f360-effe-4c05-be87-b5970d39bb34)

While this is done automatically for burn after reading pastes, it doesn't prevent anyone from manually adding it to a regular URL to get it to ask for non burn after reading pastes (hence the slightly vague message) or removing it from burn after reading URL to instantly load it, if this isn't required.

## Changes
* Ask before loading burn after reading pastes
* fixes #1039 - email buttons overlapping in some languages, by moving the third button up to a close button (X): 
![email dialog](https://github.com/PrivateBin/PrivateBin/assets/1017622/6f682ae6-4db4-484f-b4c8-df4290d7520d)
* fixes #1191 - language change URL mangling by preventing the default click action
* adds focus to password input in modal
* prevents needless reload on visiting default URL
* moving the close button in the QR code dialog up to a close button (X):
![qr code dialog](https://github.com/PrivateBin/PrivateBin/assets/1017622/0e1fa2fb-9ee6-44bc-a052-afb673634daf)

## ToDo
* [ ] discuss if we could remove the isBadBot() mechanism from legacy.js
* [ ] discuss the wording of the new dialog - I feel it sounds a bit off, but had no better ideas.
