### PR TITLE
shortened paste URL does not appear in email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.7.2 (not yet released)
 * CHANGED: "Send" button now labeled "Create" (#946)
 * FIXED: Add cache control headers also to API calls (#1263)
+* FIXED: Shortened paste URL does not appear in email (#606)
 
 ## 1.7.1 (2024-02-11)
 * FIXED: zlib 1.3.1 wasm file reference
@@ -28,7 +29,7 @@
 
 ## 1.6.0 (2023-09-11)
 * ADDED: Translations for Japanese & Arabic
-* ADDED: Configuration option to disable Email button (#1164)
+* ADDED: Configuration option to disable email button (#1164)
 * CHANGED: Minimum required PHP version is 7.3, due to upgrading PHPunit (#707)
 * CHANGED: Removed PHP 5 polyfill for random_bytes()
 

--- a/js/privatebin.js
+++ b/js/privatebin.js
@@ -3965,7 +3965,7 @@ jQuery.PrivateBin = (function($, RawDeflate) {
             }
             emailBody += I18n._('Link:');
             emailBody += EOL;
-            emailBody += `${window.location.href}`;
+            emailBody += $('#pasteurl').attr('href'); // might have been shortened
             return emailBody;
         }
 

--- a/tpl/bootstrap.php
+++ b/tpl/bootstrap.php
@@ -73,7 +73,7 @@ endif;
 ?>
 		<script type="text/javascript" data-cfasync="false" src="js/purify-3.0.8.js" integrity="sha512-wWBDKh5wYGtJ1Df+PPZIn59jHVBnJ4/Yb2W/pVnzaXab8cmlZnHVx+FEBGu5JX39s3P2Qlt+aNQou0XnjW86hg==" crossorigin="anonymous"></script>
 		<script type="text/javascript" data-cfasync="false" src="js/legacy.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-LYos+qXHIRqFf5ZPNphvtTB0cgzHUizu2wwcOwcwz/VIpRv9lpcBgPYz4uq6jx0INwCAj6Fbnl5HoKiLufS2jg==" crossorigin="anonymous"></script>
-		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-OshNUdVPw5hnnHTh/83UJfR2yFu7bKBurjEeJ9PPr6F9u9f4eeqA5yZ88XR3RmAr7sIDwKGSvQvlVvTe5DrSZg==" crossorigin="anonymous"></script>
+		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-B5PWlo7wh39YRHm8rkP5KUyJkoBgL1/TY7ldx6d041+L20/0QLuCN3V2FUK0BpvOUl1CRb7IHbnS80HFMoGFrg==" crossorigin="anonymous"></script>
 		<!-- icon -->
 		<link rel="apple-touch-icon" href="<?php echo I18n::encode($BASEPATH); ?>img/apple-touch-icon.png" sizes="180x180" />
 		<link rel="icon" type="image/png" href="img/favicon-32x32.png" sizes="32x32" />

--- a/tpl/page.php
+++ b/tpl/page.php
@@ -51,7 +51,7 @@ endif;
 ?>
 		<script type="text/javascript" data-cfasync="false" src="js/purify-3.0.8.js" integrity="sha512-wWBDKh5wYGtJ1Df+PPZIn59jHVBnJ4/Yb2W/pVnzaXab8cmlZnHVx+FEBGu5JX39s3P2Qlt+aNQou0XnjW86hg==" crossorigin="anonymous"></script>
 		<script type="text/javascript" data-cfasync="false" src="js/legacy.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-LYos+qXHIRqFf5ZPNphvtTB0cgzHUizu2wwcOwcwz/VIpRv9lpcBgPYz4uq6jx0INwCAj6Fbnl5HoKiLufS2jg==" crossorigin="anonymous"></script>
-		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-OshNUdVPw5hnnHTh/83UJfR2yFu7bKBurjEeJ9PPr6F9u9f4eeqA5yZ88XR3RmAr7sIDwKGSvQvlVvTe5DrSZg==" crossorigin="anonymous"></script>
+		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-B5PWlo7wh39YRHm8rkP5KUyJkoBgL1/TY7ldx6d041+L20/0QLuCN3V2FUK0BpvOUl1CRb7IHbnS80HFMoGFrg==" crossorigin="anonymous"></script>
 		<!-- icon -->
 		<link rel="apple-touch-icon" href="img/apple-touch-icon.png?<?php echo rawurlencode($VERSION); ?>" sizes="180x180" />
 		<link rel="icon" type="image/png" href="img/favicon-32x32.png?<?php echo rawurlencode($VERSION); ?>" sizes="32x32" />


### PR DESCRIPTION
This PR fixes #606

## Changes
* paste URL for email is picked from element with ID `pasteurl` instead of `window`, which should contain the shortened URL
