### PR TITLE
Update conf.sample.php

### DIFF
--- a/cfg/conf.sample.php
+++ b/cfg/conf.sample.php
@@ -38,6 +38,8 @@ defaultformatter = "plaintext"
 sizelimit = 10485760
 
 ; template to include, default is "bootstrap" (tpl/bootstrap.php)
+; Also available is a dark version ("bootstrap-dark",) and
+; a theme that resembles the classic ZeroBin style ("page".)
 template = "bootstrap"
 
 ; (optional) info text to display


### PR DESCRIPTION
## Changes
<!-- List all the changes you have done -->
* Comment addition to `conf.sample.php` that mentions the other strings to use for the included themes. The "bootstrap-dark" one in particular is perhaps not obvious to any user who doesn't look at the contents of `tpl/bootstrap.php`

## ToDo
N/A
