### PR TITLE
input sanitation & removing some obsolete version checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## 1.7.2 (not yet released)
 * ADDED: Allow use of `shortenviayourls` in query parameters (#1267)
+* ADDED: Input sanitation to some not yet filtered query and server parameters
 * CHANGED: "Send" button now labeled "Create" (#946)
+* CHANGED: drop some PHP < 5.6 fallbacks, minimum version is PHP 7.3 as of release 1.6.0
 * FIXED: Add cache control headers also to API calls (#1263)
 * FIXED: Shortened paste URL does not appear in email (#606)
 

--- a/lib/Model/AbstractModel.php
+++ b/lib/Model/AbstractModel.php
@@ -108,7 +108,7 @@ abstract class AbstractModel
         $this->_data = $data;
 
         // calculate a 64 bit checksum to avoid collisions
-        $this->setId(hash(version_compare(PHP_VERSION, '5.6', '<') ? 'fnv164' : 'fnv1a64', $data['ct']));
+        $this->setId(hash('fnv1a64', $data['ct']));
     }
 
     /**

--- a/tst/Bootstrap.php
+++ b/tst/Bootstrap.php
@@ -696,7 +696,7 @@ class Helper
      */
     public static function getPasteId()
     {
-        return version_compare(PHP_VERSION, '5.6', '<') ? hash('fnv164', self::$pasteV2['ct']) : self::$pasteid;
+        return self::$pasteid;
     }
 
     /**


### PR DESCRIPTION
## Changes
* Add more input sanitation, using filter_vars instead of filter_input, because our unit tests depend on manipulating global arrays, which are not used by filter_input - we would have to mock the function in the unit testing, it therefore is cleaner to use the same code paths in testing as in production. Note that some inputs in I18n and TrafficLimiter remain unfiltered, since we already validate them by other means (IP lib and/or preg_match).
* our minimum PHP version is 7.3, so we can drop the two < 5.6 fallback checks
