### PR TITLE
Doc'n'test mopup

### DIFF
--- a/cfg/conf.sample.php
+++ b/cfg/conf.sample.php
@@ -37,9 +37,12 @@ defaultformatter = "plaintext"
 ; size limit per paste or comment in bytes, defaults to 10 Mebibytes
 sizelimit = 10485760
 
-; template to include, default is "bootstrap" (tpl/bootstrap.php)
-; Also available is a dark version ("bootstrap-dark",) and
-; a theme that resembles the classic ZeroBin style ("page".)
+; template to include, default is "bootstrap" (tpl/bootstrap.php), also
+; available are "page" (tpl/page.php), the classic ZeroBin style and several
+; bootstrap variants: "bootstrap-dark", "bootstrap-compact", "bootstrap-page",
+; which can be combined with "-dark" and "-compact" for "bootstrap-dark-page"
+; and finally "bootstrap-compact-page" - previews at:
+; https://privatebin.info/screenshots.html
 template = "bootstrap"
 
 ; (optional) info text to display
@@ -242,7 +245,7 @@ dir = PATH "data"
 ; - AWS_ACCESS_KEY_ID
 ; - AWS_SECRET_ACCESS_KEY
 ; - AWS_SESSION_TOKEN (if needed)
-; for more details, see https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/guide_credentials.html#default-credential-chain 
+; for more details, see https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/guide_credentials.html#default-credential-chain
 ;class = S3Storage
 ;[model_options]
 ;region = "eu-central-1"

--- a/composer.json
+++ b/composer.json
@@ -30,8 +30,8 @@
 		"yzalis/identicon": "2.0.0"
 	},
 	"suggest" : {
-		"google/cloud-storage" : "1.32.0",
-		"aws/aws-sdk-php" : "3.275.1"
+		"google/cloud-storage" : "1.41.0",
+		"aws/aws-sdk-php" : "3.302.0"
 	},
 	"require-dev" : {
 		"phpunit/phpunit" : "^9"

--- a/doc/Installation.md
+++ b/doc/Installation.md
@@ -22,6 +22,7 @@ for more information.
 ### Minimal Requirements
 
 - PHP version 7.3 or above
+- ctype extension
 - GD extension (when using identicon or vizhash icons, jdenticon works without it)
 - zlib extension
 - some disk space or a database supported by [PDO](https://php.net/manual/book.pdo.php)

--- a/lib/Vizhash16x16.php
+++ b/lib/Vizhash16x16.php
@@ -109,9 +109,9 @@ class Vizhash16x16
         for ($i = 0; $i < 7; ++$i) {
             $action = $this->getInt();
             $color  = imagecolorallocate($image, $r, $g, $b);
-            $r      = $r0      = ($r0 + $this->getInt() / 25) % 256;
-            $g      = $g0      = ($g0 + $this->getInt() / 25) % 256;
-            $b      = $b0      = ($b0 + $this->getInt() / 25) % 256;
+            $r      = $r0      = ((int) $r0 + $this->getInt() / 25) % 256;
+            $g      = $g0      = ((int) $g0 + $this->getInt() / 25) % 256;
+            $b      = $b0      = ((int) $b0 + $this->getInt() / 25) % 256;
             $this->drawshape($image, $action, $color);
         }
 
@@ -136,7 +136,7 @@ class Vizhash16x16
     {
         $v = $this->VALUES[$this->VALUES_INDEX];
         ++$this->VALUES_INDEX;
-        $this->VALUES_INDEX %= count($this->VALUES); // Warp around the array
+        $this->VALUES_INDEX %= count($this->VALUES); // Wrap around the array
         return $v;
     }
 
@@ -148,7 +148,7 @@ class Vizhash16x16
      */
     private function getX()
     {
-        return $this->width * $this->getInt() / 256;
+        return (int) $this->width * $this->getInt() / 256;
     }
 
     /**
@@ -159,7 +159,7 @@ class Vizhash16x16
      */
     private function getY()
     {
-        return $this->height * $this->getInt() / 256;
+        return (int) $this->height * $this->getInt() / 256;
     }
 
     /**
@@ -190,9 +190,9 @@ class Vizhash16x16
             ($color2[2] - $color1[2]) / $size,
         );
         for ($i = 0; $i < $size; ++$i) {
-            $r = $color1[0] + ($diffs[0] * $i);
-            $g = $color1[1] + ($diffs[1] * $i);
-            $b = $color1[2] + ($diffs[2] * $i);
+            $r = $color1[0] + ((int) $diffs[0] * $i);
+            $g = $color1[1] + ((int) $diffs[1] * $i);
+            $b = $color1[2] + ((int) $diffs[2] * $i);
             if ($direction == 'h') {
                 imageline($img, $i, 0, $i, $sizeinv, imagecolorallocate($img, $r, $g, $b));
             } else {
@@ -222,7 +222,7 @@ class Vizhash16x16
                 break;
             case 3:
                 $points = array($this->getX(), $this->getY(), $this->getX(), $this->getY(), $this->getX(), $this->getY(), $this->getX(), $this->getY());
-                imagefilledpolygon($image, $points, 4, $color);
+                version_compare(PHP_VERSION, '8.1', '<') ? imagefilledpolygon($image, $points, 4, $color) : imagefilledpolygon($image, $points, $color);
                 break;
             default:
                 $start = $this->getInt() * 360 / 256;

--- a/tst/Bootstrap.php
+++ b/tst/Bootstrap.php
@@ -508,6 +508,11 @@ class ConnectionInterfaceStub implements ConnectionInterface
         throw new BadMethodCallException('not supported by this stub');
     }
 
+    public function restoreObject(array $args = array())
+    {
+        throw new BadMethodCallException('not supported by this stub');
+    }
+
     public function copyObject(array $args = array())
     {
         throw new BadMethodCallException('not supported by this stub');


### PR DESCRIPTION
This PR improves some recently introduced changes and deals with PHP 8.1 & 8.2 deprecations that weren't flagged on the ubuntu-based github actions.

Given that the PHP 8.4 tests do currently fail with deprecation warnings in Guzzle (dependency of GCS library), phpunit seems correctly set up to fail on these, so I suspect the github php.ini defaults to a different error level than the one used in the alpine-based unit test image, where I noticed these errors after a [recent update](https://github.com/PrivateBin/docker-unit-testing/commit/da3d9f22e76f9787428522027a31e37407c0af56) (which was triggered by the ctype extension being missing in that install).

## Changes
* update documentation
  * clarify all template options & link to previews
  * document new ctype extension requirement
* bump versions of optional cloud storage dependencies
* handle PHP deprecation warnings
  * PHP 8.2 deprecates implicit conversion from float to int if it loses precision, hence the explicit conversion.
  * PHP 8.1 deprecates the (optional since PHP 8.0) 3rd parameter of imagefilledpolygon(), but 7.3 & 7.4 require it.