### PR TITLE
Mark PHP v8.4 tests as experimental

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,8 @@ jobs:
 
   Composer:
     runs-on: ubuntu-latest
+    # https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#handling-failures
+    continue-on-error: ${{ matrix.experimental }}
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,6 +20,10 @@ jobs:
     strategy:
       matrix:
         php-versions: ['7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
+        include:
+          # 8.4 is experimental due to Guzzle causing failures https://github.com/PrivateBin/PrivateBin/issues/1301
+          - php-versions: '8.4'
+            experimental: true
     name: PHP ${{ matrix.php-versions }} unit tests on ${{ matrix.operating-system }}
     env:
       extensions: gd, sqlite3


### PR DESCRIPTION
As per this doc: https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#handling-failures

Workaround for https://github.com/PrivateBin/PrivateBin/issues/1301 for now. I hope this ignores failures?

