### PR TITLE
Add upload test results job

### DIFF
--- a/.github/workflows/test-results.yml
+++ b/.github/workflows/test-results.yml
@@ -1,0 +1,42 @@
+name: Test Results
+
+on:
+  workflow_run:
+    workflows: ["Tests"]
+    types:
+      - completed
+permissions: {}
+
+jobs:
+  test-results:
+    name: Test Results
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion != 'skipped'
+
+    permissions:
+      checks: write
+
+      # needed unless run with comment_mode: off
+      pull-requests: write
+
+      # required by download step to access artifacts API
+      actions: read
+
+    steps:
+       - name: Download and Extract Artifacts
+         uses: dawidd6/action-download-artifact@e7466d1a7587ed14867642c2ca74b5bcc1e19a2d
+         with:
+            run_id: ${{ github.event.workflow_run.id }}
+            path: artifacts
+
+       - name: Publish Test Results
+         uses: EnricoMi/publish-unit-test-result-action@v2
+         with:
+            check_name: "Test Results (${{ github.event.workflow_run.event || github.event_name }})"
+            commit: ${{ github.event.workflow_run.head_sha }}
+            event_file: artifacts/Event File/event.json
+            event_name: ${{ github.event.workflow_run.event }}
+            files: |
+                artifacts/**/*.xml
+                artifacts/**/*.trx
+                artifacts/**/*.json

--- a/.github/workflows/test-results.yml
+++ b/.github/workflows/test-results.yml
@@ -26,17 +26,17 @@ jobs:
        - name: Download and Extract Artifacts
          uses: dawidd6/action-download-artifact@e7466d1a7587ed14867642c2ca74b5bcc1e19a2d
          with:
-            run_id: ${{ github.event.workflow_run.id }}
-            path: artifacts
+          run_id: ${{ github.event.workflow_run.id }}
+          path: artifacts
 
        - name: Publish Test Results
          uses: EnricoMi/publish-unit-test-result-action@v2
          with:
-            check_name: "Test Results (${{ github.event.workflow_run.event || github.event_name }})"
-            commit: ${{ github.event.workflow_run.head_sha }}
-            event_file: artifacts/Event File/event.json
-            event_name: ${{ github.event.workflow_run.event }}
-            files: |
-                artifacts/**/*.xml
-                artifacts/**/*.trx
-                artifacts/**/*.json
+          check_name: "Test Results (${{ github.event.workflow_run.event || github.event_name }})"
+          commit: ${{ github.event.workflow_run.head_sha }}
+          event_file: artifacts/Event File/event.json
+          event_name: ${{ github.event.workflow_run.event }}
+          files: |
+            artifacts/**/*.xml
+            artifacts/**/*.trx
+            artifacts/**/*.json

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,8 @@ jobs:
 
   Composer:
     runs-on: ubuntu-latest
+    # https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#handling-failures
+    continue-on-error: ${{ matrix.experimental }}
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -130,7 +130,7 @@ jobs:
       working-directory: js
 
     - name: Run unit tests
-      run: npm ci-test
+      run: npm run ci-test
       working-directory: js
       
     - name: Upload Test Results

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -130,7 +130,7 @@ jobs:
       working-directory: js
 
     - name: Run unit tests
-      run: npm test --reporter-option output=mocha-results.xml
+      run: npm ci-test
       working-directory: js
       
     - name: Upload Test Results
@@ -138,7 +138,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: Test Results (Mocha)
-        path: tst/mocha-results.xml
+        path: js/mocha-results.xml
 
   publish-test-results:
     name: "Publish Tests Results"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     # https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#handling-failures
     continue-on-error: ${{ matrix.experimental }}
+    
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -97,8 +98,15 @@ jobs:
 
     # testing
     - name: Run unit tests
-      run: ../vendor/bin/phpunit --no-coverage
+      run: ../vendor/bin/phpunit --no-coverage --log-junit results.xml
       working-directory: tst
+
+    - name: Upload Test Results
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: Test Results (PHP ${{ matrix.php-versions }})
+        path: tst/results.xml
 
   Mocha:
     runs-on: ubuntu-latest
@@ -122,5 +130,37 @@ jobs:
       working-directory: js
 
     - name: Run unit tests
-      run: npm test
+      run: npm test --reporter-option output=mocha-results.xml
       working-directory: js
+      
+    - name: Upload Test Results
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: Test Results (Mocha)
+        path: tst/mocha-results.xml
+
+  publish-test-results:
+    name: "Publish Tests Results"
+    needs: ['PHPunit', 'Mocha']
+    runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      # only needed unless run with comment_mode: off
+      pull-requests: write
+    if: always()
+
+    steps:
+      - name: Download Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Publish Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        with:
+          check_name: "Test Results (${{ github.event.workflow_run.event || github.event_name }})"
+          files: |
+            artifacts/**/*.xml
+            artifacts/**/*.trx
+            artifacts/**/*.json

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -162,8 +162,9 @@ jobs:
 
     steps:
       - name: Download Artifacts
-        uses: actions/download-artifact@v4
+        uses: dawidd6/action-download-artifact@v3
         with:
+          run_id: ${{ github.event.workflow_run.id }}
           path: artifacts
 
       - name: Publish Test Results

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -139,7 +139,17 @@ jobs:
       with:
         name: Test Results (Mocha)
         path: js/mocha-results.xml
-
+  
+  event_file:
+    name: "Event File"
+    runs-on: ubuntu-latest
+    steps:
+    - name: Upload
+      uses: actions/upload-artifact@v4
+      with:
+        name: Event File
+        path: ${{ github.event_path }}
+          
   publish-test-results:
     name: "Publish Tests Results"
     needs: ['PHPunit', 'Mocha']
@@ -160,6 +170,9 @@ jobs:
         uses: EnricoMi/publish-unit-test-result-action@v2
         with:
           check_name: "Test Results (${{ github.event.workflow_run.event || github.event_name }})"
+          commit: ${{ github.event.workflow_run.head_sha }}
+          event_file: artifacts/Event File/event.json
+          event_name: ${{ github.event.workflow_run.event }}
           files: |
             artifacts/**/*.xml
             artifacts/**/*.trx

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,6 +20,10 @@ jobs:
     strategy:
       matrix:
         php-versions: ['7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
+        include:
+          # 8.4 is experimental due to Guzzle causing failures https://github.com/PrivateBin/PrivateBin/issues/1301
+          - php-versions: '8.4'
+            experimental: true
     name: PHP ${{ matrix.php-versions }} unit tests on ${{ matrix.operating-system }}
     env:
       extensions: gd, sqlite3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -149,32 +149,4 @@ jobs:
       with:
         name: Event File
         path: ${{ github.event_path }}
-          
-  publish-test-results:
-    name: "Publish Tests Results"
-    needs: ['PHPunit', 'Mocha']
-    runs-on: ubuntu-latest
-    permissions:
-      checks: write
-      # only needed unless run with comment_mode: off
-      pull-requests: write
-    if: always()
 
-    steps:
-      - name: Download Artifacts
-        uses: dawidd6/action-download-artifact@v3
-        with:
-          run_id: ${{ github.event.workflow_run.id }}
-          path: artifacts
-
-      - name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
-        with:
-          check_name: "Test Results (${{ github.event.workflow_run.event || github.event_name }})"
-          commit: ${{ github.event.workflow_run.head_sha }}
-          event_file: artifacts/Event File/event.json
-          event_name: ${{ github.event.workflow_run.event }}
-          files: |
-            artifacts/**/*.xml
-            artifacts/**/*.trx
-            artifacts/**/*.json

--- a/js/package.json
+++ b/js/package.json
@@ -15,7 +15,8 @@
     "@peculiar/webcrypto": "^1.1.1"
   },
   "scripts": {
-    "test": "mocha"
+    "test": "mocha",
+    "ci-test": "mocha --reporter-option output=mocha-results.xml"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
As per https://github.com/marketplace/actions/publish-test-results#use-with-matrix-strategy only one job should upload all results.

