### PR TITLE
Rephrase the WebAssembly error on unsupported browser

### DIFF
--- a/js/privatebin.js
+++ b/js/privatebin.js
@@ -1068,7 +1068,7 @@ jQuery.PrivateBin = (function($, RawDeflate) {
             if (mode === 'zlib' || mode === 'none') {
                 if (mode === 'zlib') {
                     if (typeof zlib === 'undefined') {
-                        throw 'Error decompressing paste, due to missing WebAssembly support.'
+                        throw 'Error decompressing paste, your browser does not support WebAssembly. Please use another browser to view this paste.'
                     }
                     data = zlib.inflate(
                         new Uint8Array(data)
@@ -1305,7 +1305,7 @@ jQuery.PrivateBin = (function($, RawDeflate) {
             spec[1] = atob(spec[1]);
             if (spec[7] === 'zlib') {
                 if (typeof zlib === 'undefined') {
-                    throw 'Error decompressing paste, due to missing WebAssembly support.'
+                    throw 'Error decompressing paste, your browser does not support WebAssembly. Please use another browser to view this paste.'
                 }
             }
             try {


### PR DESCRIPTION
Rephrase the WebAssembly error on unsupported browser

This PR fixes https://github.com/PrivateBin/PrivateBin/issues/1310

## Changes
<!-- List all the changes you have done -->
* js/privatebin.js: Rephrase error message on missing zlib support in browser
