### PR TITLE
expiration time selection fix for bootstrap template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # PrivateBin version history
 
 ## 1.7.3 (not yet released)
+* FIXED: Selected expiration not being applied, when using bootstrap template (#1309)
 
 ## 1.7.2 (2024-05-05)
 * ADDED: Allow use of `shortenviayourls` in query parameters (#1267)

--- a/js/privatebin.js
+++ b/js/privatebin.js
@@ -4371,7 +4371,7 @@ jQuery.PrivateBin = (function($, RawDeflate) {
          */
         me.getExpiration = function()
         {
-            return Model.getExpirationDefault() || pasteExpiration;
+            return pasteExpiration;
         };
 
         /**
@@ -4554,6 +4554,10 @@ jQuery.PrivateBin = (function($, RawDeflate) {
             // bootstrap template drop downs
             $('ul.dropdown-menu li a', $('#expiration').parent()).click(updateExpiration);
             $('ul.dropdown-menu li a', $('#formatter').parent()).click(updateFormat);
+            // bootstrap5 & page drop downs
+            $('#pasteExpiration').on('change', function() {
+                pasteExpiration = Model.getExpirationDefault();
+            });
             $('#pasteFormatter').on('change', function() {
                 PasteViewer.setFormat(Model.getFormatDefault());
             });
@@ -4565,7 +4569,7 @@ jQuery.PrivateBin = (function($, RawDeflate) {
             // get default values from template or fall back to set value
             burnAfterReadingDefault = me.getBurnAfterReading();
             openDiscussionDefault = me.getOpenDiscussion();
-            pasteExpiration = Model.getExpirationDefault() || pasteExpiration;
+            pasteExpiration = Model.getExpirationDefault();
 
             createButtonsDisplayed = false;
             viewButtonsDisplayed = false;

--- a/js/test/TopNav.js
+++ b/js/test/TopNav.js
@@ -456,8 +456,14 @@ describe('TopNav', function () {
         it(
             'returns the currently selected expiration date',
             function () {
+                $('body').html(
+                    '<select id="pasteExpiration" name="pasteExpiration">' +
+                    '<option value="1day">1 day</option>' +
+                    '<option value="never">Never</option></select>'
+                );
                 $.PrivateBin.TopNav.init();
-                assert.ok($.PrivateBin.TopNav.getExpiration() === null);
+                assert.ok($.PrivateBin.TopNav.getExpiration() === '1day');
+                cleanup();
             }
         );
     });

--- a/tpl/bootstrap.php
+++ b/tpl/bootstrap.php
@@ -73,7 +73,7 @@ endif;
 ?>
 		<script type="text/javascript" data-cfasync="false" src="js/purify-3.1.2.js" integrity="sha512-voYCOVXik5/jcT+McTiptsB00iB0NWQrhBmSwSEfj0IH3UDphU8w12JV8w1y+m8FRaozbzW4efHSEWKZpOA+JQ==" crossorigin="anonymous"></script>
 		<script type="text/javascript" data-cfasync="false" src="js/legacy.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-LYos+qXHIRqFf5ZPNphvtTB0cgzHUizu2wwcOwcwz/VIpRv9lpcBgPYz4uq6jx0INwCAj6Fbnl5HoKiLufS2jg==" crossorigin="anonymous"></script>
-		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-QnwyZIEFZg8uvFAsnXbeHTNarA4hPhGcMv8RTAIS4cOgR6oh0ofxjY3OdiGzccArf6VeFFKjqkFo94CrcUXkxQ==" crossorigin="anonymous"></script>
+		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-gVZBjRO45BZ7OeSspLHUVNmNF98wdxk3zebL5KUV/3Ty607YkD6CZw1ORqKpAGvKrKFp/jcaWV5uwpCqfoQGlw==" crossorigin="anonymous"></script>
 		<!-- icon -->
 		<link rel="apple-touch-icon" href="<?php echo I18n::encode($BASEPATH); ?>img/apple-touch-icon.png" sizes="180x180" />
 		<link rel="icon" type="image/png" href="img/favicon-32x32.png" sizes="32x32" />

--- a/tpl/bootstrap5.php
+++ b/tpl/bootstrap5.php
@@ -57,7 +57,7 @@ endif;
 ?>
 		<script type="text/javascript" data-cfasync="false" src="js/purify-3.1.2.js" integrity="sha512-voYCOVXik5/jcT+McTiptsB00iB0NWQrhBmSwSEfj0IH3UDphU8w12JV8w1y+m8FRaozbzW4efHSEWKZpOA+JQ==" crossorigin="anonymous"></script>
 		<script type="text/javascript" data-cfasync="false" src="js/legacy.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-LYos+qXHIRqFf5ZPNphvtTB0cgzHUizu2wwcOwcwz/VIpRv9lpcBgPYz4uq6jx0INwCAj6Fbnl5HoKiLufS2jg==" crossorigin="anonymous"></script>
-		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-QnwyZIEFZg8uvFAsnXbeHTNarA4hPhGcMv8RTAIS4cOgR6oh0ofxjY3OdiGzccArf6VeFFKjqkFo94CrcUXkxQ==" crossorigin="anonymous"></script>
+		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-gVZBjRO45BZ7OeSspLHUVNmNF98wdxk3zebL5KUV/3Ty607YkD6CZw1ORqKpAGvKrKFp/jcaWV5uwpCqfoQGlw==" crossorigin="anonymous"></script>
 		<!-- icon -->
 		<link rel="apple-touch-icon" href="<?php echo I18n::encode($BASEPATH); ?>img/apple-touch-icon.png" sizes="180x180" />
 		<link rel="icon" type="image/png" href="img/favicon-32x32.png" sizes="32x32" />

--- a/tpl/page.php
+++ b/tpl/page.php
@@ -51,7 +51,7 @@ endif;
 ?>
 		<script type="text/javascript" data-cfasync="false" src="js/purify-3.1.2.js" integrity="sha512-voYCOVXik5/jcT+McTiptsB00iB0NWQrhBmSwSEfj0IH3UDphU8w12JV8w1y+m8FRaozbzW4efHSEWKZpOA+JQ==" crossorigin="anonymous"></script>
 		<script type="text/javascript" data-cfasync="false" src="js/legacy.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-LYos+qXHIRqFf5ZPNphvtTB0cgzHUizu2wwcOwcwz/VIpRv9lpcBgPYz4uq6jx0INwCAj6Fbnl5HoKiLufS2jg==" crossorigin="anonymous"></script>
-		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-QnwyZIEFZg8uvFAsnXbeHTNarA4hPhGcMv8RTAIS4cOgR6oh0ofxjY3OdiGzccArf6VeFFKjqkFo94CrcUXkxQ==" crossorigin="anonymous"></script>
+		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-gVZBjRO45BZ7OeSspLHUVNmNF98wdxk3zebL5KUV/3Ty607YkD6CZw1ORqKpAGvKrKFp/jcaWV5uwpCqfoQGlw==" crossorigin="anonymous"></script>
 		<!-- icon -->
 		<link rel="apple-touch-icon" href="img/apple-touch-icon.png?<?php echo rawurlencode($VERSION); ?>" sizes="180x180" />
 		<link rel="icon" type="image/png" href="img/favicon-32x32.png?<?php echo rawurlencode($VERSION); ?>" sizes="32x32" />


### PR DESCRIPTION
This PR fixes expiration time selection for bootstrap template.

* undue the regression introduced for bootstrap5 (line 4374)
* document the template specific code paths
* add an onchange event handler for bootstrap5 & page templates
* remove unnecessary fallback in line 4572, pasteExpiration is `null` during the init call, getExpirationDefault will return the currently selected value of the select element - it would only be empty if no expirations got configured, which would cause other breakage
