### PR TITLE
bootstrap 5 attachment dropdown sizing

### DIFF
--- a/css/bootstrap5/privatebin.css
+++ b/css/bootstrap5/privatebin.css
@@ -56,6 +56,10 @@
 	transition: background-color 0.75s ease-out;
 }
 
+.dropdown-menu {
+	--bs-dropdown-min-width: 23rem;
+}
+
 li.L0, li.L1, li.L2, li.L3, li.L5, li.L6, li.L7, li.L8 {
 	list-style-type: decimal !important;
 }

--- a/tpl/bootstrap5.php
+++ b/tpl/bootstrap5.php
@@ -258,7 +258,7 @@ if ($FILEUPLOAD) :
 ?>
 						<li id="attach" class="nav-item hidden dropdown me-2">
 							<a href="#" class="nav-link dropdown-toggle" data-bs-toggle="dropdown" role="button" aria-expanded="false"><?php echo I18n::_('Attach a file'); ?></a>
-							<ul class="dropdown-menu">
+							<ul class="dropdown-menu px-2">
 								<li id="filewrap">
 									<div>
 										<input type="file" id="file" name="file" class="form-control" />


### PR DESCRIPTION
This PR fixes  #1313

## Before
![attachment dropdown - before](https://github.com/PrivateBin/PrivateBin/assets/1017622/ed25afd3-ac57-4221-84b3-b308d4379198)

## After
![attachment dropdown - after](https://github.com/PrivateBin/PrivateBin/assets/1017622/c8431efd-a2d5-4075-b91e-f5da526854b4)

![attachment dropdown - mobile](https://github.com/PrivateBin/PrivateBin/assets/1017622/82b5194c-96b3-46b4-b7a7-b7cbb05d8a15)
