### PR TITLE
bootstrap 5 code block improvements

### DIFF
--- a/css/bootstrap5/privatebin.css
+++ b/css/bootstrap5/privatebin.css
@@ -56,8 +56,18 @@
 	transition: background-color 0.75s ease-out;
 }
 
-li.L0, li.L1, li.L2, li.L3, li.L5, li.L6, li.L7, li.L8 {
+[data-bs-theme=light] pre, [data-bs-theme=light] .card {
+	background-color: RGBA(var(--bs-light-rgb), var(--bs-bg-opacity, 1));
+}
+
+li.L0, li.L1, li.L2, li.L3, li.L4, li.L5, li.L6, li.L7, li.L8, li.L9 {
+	color: revert !important;
 	list-style-type: decimal !important;
+}
+
+[data-bs-theme=dark] li.L1, [data-bs-theme=dark] li.L3, [data-bs-theme=dark] li.L5,
+[data-bs-theme=dark] li.L7, [data-bs-theme=dark] li.L9 {
+	background-color: var(--bs-gray-dark) !important;
 }
 
 .text-right button {

--- a/tpl/bootstrap5.php
+++ b/tpl/bootstrap5.php
@@ -426,8 +426,8 @@ endif;
 				<article class="row">
 					<div id="placeholder" class="col-md-12 hidden"><?php echo I18n::_('+++ no paste text +++'); ?></div>
 					<div id="attachmentPreview" class="col-md-12 text-center hidden"></div>
-					<div id="prettymessage" class="col-md-12 hidden">
-						<pre id="prettyprint" class="col-md-12 prettyprint linenums:1"></pre>
+					<div id="prettymessage" class="card col-md-12 hidden">
+						<pre id="prettyprint" class="card-body col-md-12 prettyprint linenums:1"></pre>
 					</div>
 					<div id="plaintext" class="col-md-12 hidden"></div>
 					<p class="col-md-12"><textarea id="message" name="message" cols="80" rows="25" class="form-control hidden"></textarea></p>


### PR DESCRIPTION
This PR closes #1314 

## Changes
* changes the plain & source code prettymessage containers into cards (border and rounded corners)
* in light mode, changes the background color of prettymessage containers and pre-blocks (for markdown) to a light grey

![code](https://github.com/PrivateBin/PrivateBin/assets/1017622/68222090-4ded-428c-be90-347612b8e37d)

![code-dark](https://github.com/PrivateBin/PrivateBin/assets/1017622/11b8e47b-d5f5-4faf-a9fd-19a0d30d6d31)

![code-plain](https://github.com/PrivateBin/PrivateBin/assets/1017622/92fa9a43-523e-4a1c-bab2-411c1278d0e7)

![code-plain-dark](https://github.com/PrivateBin/PrivateBin/assets/1017622/272b2b1f-e389-461f-a680-a70732df2bd8)

![code-markdown](https://github.com/PrivateBin/PrivateBin/assets/1017622/9b9061da-33dc-43a2-a751-68de080ea228)
