### PR TITLE
in PHP matrix tests, we don't want to constrain the platform

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -88,6 +88,9 @@ jobs:
         restore-keys: ${{ runner.os }}-composer-${{ steps.get-date.outputs.date }}-
 
     # composer installation
+    - name: Unset platform requirement
+      run: composer config --unset platform
+
     - name: Setup PHPunit
       run: composer install -n
 


### PR DESCRIPTION
Setting the platform allow composer to prevent upgrades to versions that would exceed the configured version, for the matrix tests we want to use the latest ones for that release.