### PR TITLE
remove version number from doc blocs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 CURRENT_VERSION = 1.7.3
 VERSION ?= 1.7.4
-VERSION_FILES = index.php bin/ cfg/ *.md doc/Installation.md css/ i18n/ img/ js/package.json js/privatebin.js lib/ Makefile tpl/ tst/
+VERSION_FILES = README.md SECURITY.md doc/Installation.md js/package*.json lib/Controller.php Makefile
 REGEX_CURRENT_VERSION := $(shell echo $(CURRENT_VERSION) | sed "s/\./\\\./g")
 REGEX_VERSION := $(shell echo $(VERSION) | sed "s/\./\\\./g")
 
@@ -29,12 +29,11 @@ doc-php: ## Generate JS code documentation.
 	phpdoc --visibility=public,protected,private --target=doc/phpdoc --directory=lib/
 
 increment: ## Increment and commit new version number, set target version using `make increment VERSION=1.2.3`.
-	for F in `grep -l -R $(REGEX_CURRENT_VERSION) $(VERSION_FILES) | grep -v -e tst/log/ -e ":0" -e CHANGELOG.md`; \
+	for F in `grep -l -R $(REGEX_CURRENT_VERSION) $(VERSION_FILES)`; \
 	do \
 		sed -i "s/$(REGEX_CURRENT_VERSION)/$(REGEX_VERSION)/g" $$F; \
 	done
-	cd tst && phpunit --no-coverage && cd ..
-	git add $(VERSION_FILES) tpl/
+	git add $(VERSION_FILES)
 	git commit -m "incrementing version"
 
 sign: ## Sign a release.

--- a/bin/administration
+++ b/bin/administration
@@ -1,6 +1,5 @@
 #!/usr/bin/env php
 <?php
-
 /**
  * PrivateBin
  *
@@ -9,7 +8,6 @@
  * @link      https://github.com/PrivateBin/PrivateBin
  * @copyright 2012 Sébastien SAUVAGE (sebsauvage.net)
  * @license   https://www.opensource.org/licenses/zlib-license.php The zlib/libpng License
- * @version   1.7.3
  */
 
 namespace PrivateBin;

--- a/bin/configuration-test-generator
+++ b/bin/configuration-test-generator
@@ -1,6 +1,14 @@
 #!/usr/bin/env php
 <?php
 /**
+ * PrivateBin
+ *
+ * a zero-knowledge paste bin
+ *
+ * @link      https://github.com/PrivateBin/PrivateBin
+ * @copyright 2012 Sébastien SAUVAGE (sebsauvage.net)
+ * @license   https://www.opensource.org/licenses/zlib-license.php The zlib/libpng License
+ *
  * generates a config unit test class
  *
  * This generator is meant to test all possible configuration combinations

--- a/bin/icon-test
+++ b/bin/icon-test
@@ -1,8 +1,16 @@
 #!/usr/bin/env php
 <?php
+/**
+ * PrivateBin
+ *
+ * a zero-knowledge paste bin
+ *
+ * @link      https://github.com/PrivateBin/PrivateBin
+ * @copyright 2012 Sébastien SAUVAGE (sebsauvage.net)
+ * @license   https://www.opensource.org/licenses/zlib-license.php The zlib/libpng License
+ */
+
 define('ITERATIONS', 100000);
-
-
 
 require dirname(__FILE__) . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'autoload.php';
 use Identicon\Generator\GdGenerator;
@@ -11,8 +19,6 @@ use Identicon\Generator\SvgGenerator;
 use Identicon\Identicon;
 use Jdenticon\Identicon as Jdenticon;
 use PrivateBin\Vizhash16x16;
-
-
 
 $vizhash = new Vizhash16x16();
 $identiconGenerators = array(

--- a/bin/migrate
+++ b/bin/migrate
@@ -1,7 +1,16 @@
 #!/usr/bin/env php
 <?php
+/**
+ * PrivateBin
+ *
+ * a zero-knowledge paste bin
+ *
+ * @link      https://github.com/PrivateBin/PrivateBin
+ * @copyright 2012 Sébastien SAUVAGE (sebsauvage.net)
+ * @license   https://www.opensource.org/licenses/zlib-license.php The zlib/libpng License
+ */
 
-// change this, if your php files and data is outside of your webservers document root
+// change this, if your php files and data are outside of your webservers document root
 define('PATH', dirname(__FILE__) . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR);
 
 define('PUBLIC_PATH', __DIR__ . DIRECTORY_SEPARATOR);

--- a/css/bootstrap/privatebin.css
+++ b/css/bootstrap/privatebin.css
@@ -6,7 +6,6 @@
  * @link      https://github.com/PrivateBin/PrivateBin
  * @copyright 2012 Sébastien SAUVAGE (sebsauvage.net)
  * @license   https://www.opensource.org/licenses/zlib-license.php The zlib/libpng License
- * @version   1.7.3
  */
 
 @import url("../common.css");

--- a/css/bootstrap5/privatebin.css
+++ b/css/bootstrap5/privatebin.css
@@ -6,7 +6,6 @@
  * @link      https://github.com/PrivateBin/PrivateBin
  * @copyright 2012 Sébastien SAUVAGE (sebsauvage.net)
  * @license   https://www.opensource.org/licenses/zlib-license.php The zlib/libpng License
- * @version   1.7.3
  */
 
 @import url("../common.css");

--- a/css/common.css
+++ b/css/common.css
@@ -6,7 +6,6 @@
  * @link      https://github.com/PrivateBin/PrivateBin
  * @copyright 2012 Sébastien SAUVAGE (sebsauvage.net)
  * @license   https://www.opensource.org/licenses/zlib-license.php The zlib/libpng License
- * @version   1.7.3
  */
 
 #attachmentPreview img {

--- a/css/noscript.css
+++ b/css/noscript.css
@@ -6,7 +6,6 @@
  * @link      https://github.com/PrivateBin/PrivateBin
  * @copyright 2012 Sébastien SAUVAGE (sebsauvage.net)
  * @license   https://www.opensource.org/licenses/zlib-license.php The zlib/libpng License
- * @version   1.7.3
  */
 
 .noscript-hide {

--- a/css/privatebin.css
+++ b/css/privatebin.css
@@ -6,7 +6,6 @@
  * @link      https://github.com/PrivateBin/PrivateBin
  * @copyright 2012 Sébastien SAUVAGE (sebsauvage.net)
  * @license   https://www.opensource.org/licenses/zlib-license.php The zlib/libpng License
- * @version   1.7.3
  */
 
 @import url("common.css");

--- a/index.php
+++ b/index.php
@@ -7,7 +7,6 @@
  * @link      https://github.com/PrivateBin/PrivateBin
  * @copyright 2012 Sébastien SAUVAGE (sebsauvage.net)
  * @license   https://www.opensource.org/licenses/zlib-license.php The zlib/libpng License
- * @version   1.7.3
  */
 
 // change this, if your php files and data is outside of your webservers document root

--- a/js/privatebin.js
+++ b/js/privatebin.js
@@ -6,7 +6,6 @@
  * @see       {@link https://github.com/PrivateBin/PrivateBin}
  * @copyright 2012 Sébastien SAUVAGE ({@link http://sebsauvage.net})
  * @license   {@link https://www.opensource.org/licenses/zlib-license.php The zlib/libpng License}
- * @version   1.7.3
  * @name      PrivateBin
  * @namespace
  */

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -7,7 +7,6 @@
  * @link      https://github.com/PrivateBin/PrivateBin
  * @copyright 2012 Sébastien SAUVAGE (sebsauvage.net)
  * @license   https://www.opensource.org/licenses/zlib-license.php The zlib/libpng License
- * @version   1.7.3
  */
 
 namespace PrivateBin;

--- a/lib/Controller.php
+++ b/lib/Controller.php
@@ -7,7 +7,6 @@
  * @link      https://github.com/PrivateBin/PrivateBin
  * @copyright 2012 Sébastien SAUVAGE (sebsauvage.net)
  * @license   https://www.opensource.org/licenses/zlib-license.php The zlib/libpng License
- * @version   1.7.3
  */
 
 namespace PrivateBin;

--- a/lib/Data/AbstractData.php
+++ b/lib/Data/AbstractData.php
@@ -7,7 +7,6 @@
  * @link      https://github.com/PrivateBin/PrivateBin
  * @copyright 2012 Sébastien SAUVAGE (sebsauvage.net)
  * @license   https://www.opensource.org/licenses/zlib-license.php The zlib/libpng License
- * @version   1.7.3
  */
 
 namespace PrivateBin\Data;

--- a/lib/Data/Database.php
+++ b/lib/Data/Database.php
@@ -7,7 +7,6 @@
  * @link      https://github.com/PrivateBin/PrivateBin
  * @copyright 2012 Sébastien SAUVAGE (sebsauvage.net)
  * @license   https://www.opensource.org/licenses/zlib-license.php The zlib/libpng License
- * @version   1.7.3
  */
 
 namespace PrivateBin\Data;

--- a/lib/Data/Filesystem.php
+++ b/lib/Data/Filesystem.php
@@ -7,7 +7,6 @@
  * @link      https://github.com/PrivateBin/PrivateBin
  * @copyright 2012 Sébastien SAUVAGE (sebsauvage.net)
  * @license   https://www.opensource.org/licenses/zlib-license.php The zlib/libpng License
- * @version   1.7.3
  */
 
 namespace PrivateBin\Data;

--- a/lib/Data/GoogleCloudStorage.php
+++ b/lib/Data/GoogleCloudStorage.php
@@ -1,4 +1,13 @@
 <?php
+/**
+ * PrivateBin
+ *
+ * a zero-knowledge paste bin
+ *
+ * @link      https://github.com/PrivateBin/PrivateBin
+ * @copyright 2012 Sébastien SAUVAGE (sebsauvage.net)
+ * @license   https://www.opensource.org/licenses/zlib-license.php The zlib/libpng License
+ */
 
 namespace PrivateBin\Data;
 

--- a/lib/Data/S3Storage.php
+++ b/lib/Data/S3Storage.php
@@ -1,15 +1,15 @@
 <?php
 /**
- * S3.php
+ * PrivateBin
  *
- * an S3 compatible data backend for PrivateBin with CEPH/RadosGW in mind
- * see https://docs.ceph.com/en/latest/radosgw/s3/php/
- * based on lib/Data/GoogleCloudStorage.php from PrivateBin version 1.7.3
+ * a zero-knowledge paste bin
  *
  * @link      https://github.com/PrivateBin/PrivateBin
  * @copyright 2022 Felix J. Ogris (https://ogris.de/)
  * @license   https://www.opensource.org/licenses/zlib-license.php The zlib/libpng License
- * @version   1.4.1
+ *
+ * an S3 compatible data backend for PrivateBin with CEPH/RadosGW in mind
+ * see https://docs.ceph.com/en/latest/radosgw/s3/php/
  *
  * Installation:
  *   1. Make sure you have composer.lock and composer.json in the document root of your PasteBin

--- a/lib/Filter.php
+++ b/lib/Filter.php
@@ -7,7 +7,6 @@
  * @link      https://github.com/PrivateBin/PrivateBin
  * @copyright 2012 Sébastien SAUVAGE (sebsauvage.net)
  * @license   https://www.opensource.org/licenses/zlib-license.php The zlib/libpng License
- * @version   1.7.3
  */
 
 namespace PrivateBin;

--- a/lib/FormatV2.php
+++ b/lib/FormatV2.php
@@ -7,7 +7,6 @@
  * @link      https://github.com/PrivateBin/PrivateBin
  * @copyright 2012 Sébastien SAUVAGE (sebsauvage.net)
  * @license   https://www.opensource.org/licenses/zlib-license.php The zlib/libpng License
- * @version   1.7.3
  */
 
 namespace PrivateBin;

--- a/lib/I18n.php
+++ b/lib/I18n.php
@@ -7,7 +7,6 @@
  * @link      https://github.com/PrivateBin/PrivateBin
  * @copyright 2012 Sébastien SAUVAGE (sebsauvage.net)
  * @license   https://www.opensource.org/licenses/zlib-license.php The zlib/libpng License
- * @version   1.7.3
  */
 
 namespace PrivateBin;

--- a/lib/Json.php
+++ b/lib/Json.php
@@ -7,7 +7,6 @@
  * @link      https://github.com/PrivateBin/PrivateBin
  * @copyright 2012 Sébastien SAUVAGE (sebsauvage.net)
  * @license   https://www.opensource.org/licenses/zlib-license.php The zlib/libpng License
- * @version   1.7.3
  */
 
 namespace PrivateBin;

--- a/lib/Model.php
+++ b/lib/Model.php
@@ -7,7 +7,6 @@
  * @link      https://github.com/PrivateBin/PrivateBin
  * @copyright 2012 Sébastien SAUVAGE (sebsauvage.net)
  * @license   https://www.opensource.org/licenses/zlib-license.php The zlib/libpng License
- * @version   1.7.3
  */
 
 namespace PrivateBin;

--- a/lib/Model/AbstractModel.php
+++ b/lib/Model/AbstractModel.php
@@ -7,7 +7,6 @@
  * @link      https://github.com/PrivateBin/PrivateBin
  * @copyright 2012 Sébastien SAUVAGE (sebsauvage.net)
  * @license   https://www.opensource.org/licenses/zlib-license.php The zlib/libpng License
- * @version   1.7.3
  */
 
 namespace PrivateBin\Model;

--- a/lib/Model/Comment.php
+++ b/lib/Model/Comment.php
@@ -7,7 +7,6 @@
  * @link      https://github.com/PrivateBin/PrivateBin
  * @copyright 2012 Sébastien SAUVAGE (sebsauvage.net)
  * @license   https://www.opensource.org/licenses/zlib-license.php The zlib/libpng License
- * @version   1.7.3
  */
 
 namespace PrivateBin\Model;

--- a/lib/Model/Paste.php
+++ b/lib/Model/Paste.php
@@ -7,7 +7,6 @@
  * @link      https://github.com/PrivateBin/PrivateBin
  * @copyright 2012 Sébastien SAUVAGE (sebsauvage.net)
  * @license   https://www.opensource.org/licenses/zlib-license.php The zlib/libpng License
- * @version   1.7.3
  */
 
 namespace PrivateBin\Model;

--- a/lib/Persistence/AbstractPersistence.php
+++ b/lib/Persistence/AbstractPersistence.php
@@ -7,7 +7,6 @@
  * @link      https://github.com/PrivateBin/PrivateBin
  * @copyright 2012 Sébastien SAUVAGE (sebsauvage.net)
  * @license   https://www.opensource.org/licenses/zlib-license.php The zlib/libpng License
- * @version   1.7.3
  */
 
 namespace PrivateBin\Persistence;

--- a/lib/Persistence/PurgeLimiter.php
+++ b/lib/Persistence/PurgeLimiter.php
@@ -7,7 +7,6 @@
  * @link      https://github.com/PrivateBin/PrivateBin
  * @copyright 2012 Sébastien SAUVAGE (sebsauvage.net)
  * @license   https://www.opensource.org/licenses/zlib-license.php The zlib/libpng License
- * @version   1.7.3
  */
 
 namespace PrivateBin\Persistence;

--- a/lib/Persistence/ServerSalt.php
+++ b/lib/Persistence/ServerSalt.php
@@ -7,7 +7,6 @@
  * @link      https://github.com/PrivateBin/PrivateBin
  * @copyright 2012 Sébastien SAUVAGE (sebsauvage.net)
  * @license   https://www.opensource.org/licenses/zlib-license.php The zlib/libpng License
- * @version   1.7.3
  */
 
 namespace PrivateBin\Persistence;

--- a/lib/Persistence/TrafficLimiter.php
+++ b/lib/Persistence/TrafficLimiter.php
@@ -8,7 +8,6 @@
  * @link      https://github.com/PrivateBin/PrivateBin
  * @copyright 2012 Sébastien SAUVAGE (sebsauvage.net)
  * @license   https://www.opensource.org/licenses/zlib-license.php The zlib/libpng License
- * @version   1.7.3
  */
 
 namespace PrivateBin\Persistence;

--- a/lib/Request.php
+++ b/lib/Request.php
@@ -7,7 +7,6 @@
  * @link      https://github.com/PrivateBin/PrivateBin
  * @copyright 2012 Sébastien SAUVAGE (sebsauvage.net)
  * @license   https://www.opensource.org/licenses/zlib-license.php The zlib/libpng License
- * @version   1.7.3
  */
 
 namespace PrivateBin;

--- a/lib/View.php
+++ b/lib/View.php
@@ -7,7 +7,6 @@
  * @link      https://github.com/PrivateBin/PrivateBin
  * @copyright 2012 Sébastien SAUVAGE (sebsauvage.net)
  * @license   https://www.opensource.org/licenses/zlib-license.php The zlib/libpng License
- * @version   1.7.3
  */
 
 namespace PrivateBin;

--- a/lib/Vizhash16x16.php
+++ b/lib/Vizhash16x16.php
@@ -3,12 +3,11 @@
  * VizHash_GD
  *
  * Visual Hash implementation in php4+GD,
- * stripped down and modified version for PrivateBin
+ * stripped down from version 0.0.5 beta, modified for PrivateBin
  *
  * @link      https://sebsauvage.net/wiki/doku.php?id=php:vizhash_gd
  * @copyright 2012 Sébastien SAUVAGE (sebsauvage.net)
  * @license   https://www.opensource.org/licenses/zlib-license.php The zlib/libpng License
- * @version   0.0.5 beta PrivateBin 1.7.3
  */
 
 namespace PrivateBin;

--- a/lib/YourlsProxy.php
+++ b/lib/YourlsProxy.php
@@ -7,7 +7,6 @@
  * @link      https://github.com/PrivateBin/PrivateBin
  * @copyright 2012 Sébastien SAUVAGE (sebsauvage.net)
  * @license   https://www.opensource.org/licenses/zlib-license.php The zlib/libpng License
- * @version   1.7.3
  */
 
 namespace PrivateBin;

--- a/tpl/bootstrap.php
+++ b/tpl/bootstrap.php
@@ -73,7 +73,7 @@ endif;
 ?>
 		<script type="text/javascript" data-cfasync="false" src="js/purify-3.1.3.js" integrity="sha512-t/FKG/ucQVMWTWVouSMABSEx1r+uSyAI9eNDq0KEr9mPhkgxpJztHI/E72JIpv/+VwPs/Q4husxj14TE9Ps/wg==" crossorigin="anonymous"></script>
 		<script type="text/javascript" data-cfasync="false" src="js/legacy.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-LYos+qXHIRqFf5ZPNphvtTB0cgzHUizu2wwcOwcwz/VIpRv9lpcBgPYz4uq6jx0INwCAj6Fbnl5HoKiLufS2jg==" crossorigin="anonymous"></script>
-		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-zpTPe2Mntv4/cR6XYcmAxKHbIhfj4QsW0dqoBcZzT9BAveLJl7TFnUo+PRVD2tJCEMtR9uSYHeRzNzTCME9VVA==" crossorigin="anonymous"></script>
+		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-ZufHPyPUQirmH53EFdfMBk9H9stN8Bdwel3ZyKs8qUDSjHy8qjdQRSQFxhpOMioCF/F31jEkhGHQKEFJHnGTeQ==" crossorigin="anonymous"></script>
 		<!-- icon -->
 		<link rel="apple-touch-icon" href="<?php echo I18n::encode($BASEPATH); ?>img/apple-touch-icon.png" sizes="180x180" />
 		<link rel="icon" type="image/png" href="img/favicon-32x32.png" sizes="32x32" />

--- a/tpl/bootstrap5.php
+++ b/tpl/bootstrap5.php
@@ -57,7 +57,7 @@ endif;
 ?>
 		<script type="text/javascript" data-cfasync="false" src="js/purify-3.1.3.js" integrity="sha512-t/FKG/ucQVMWTWVouSMABSEx1r+uSyAI9eNDq0KEr9mPhkgxpJztHI/E72JIpv/+VwPs/Q4husxj14TE9Ps/wg==" crossorigin="anonymous"></script>
 		<script type="text/javascript" data-cfasync="false" src="js/legacy.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-LYos+qXHIRqFf5ZPNphvtTB0cgzHUizu2wwcOwcwz/VIpRv9lpcBgPYz4uq6jx0INwCAj6Fbnl5HoKiLufS2jg==" crossorigin="anonymous"></script>
-		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-zpTPe2Mntv4/cR6XYcmAxKHbIhfj4QsW0dqoBcZzT9BAveLJl7TFnUo+PRVD2tJCEMtR9uSYHeRzNzTCME9VVA==" crossorigin="anonymous"></script>
+		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-ZufHPyPUQirmH53EFdfMBk9H9stN8Bdwel3ZyKs8qUDSjHy8qjdQRSQFxhpOMioCF/F31jEkhGHQKEFJHnGTeQ==" crossorigin="anonymous"></script>
 		<!-- icon -->
 		<link rel="apple-touch-icon" href="<?php echo I18n::encode($BASEPATH); ?>img/apple-touch-icon.png" sizes="180x180" />
 		<link rel="icon" type="image/png" href="img/favicon-32x32.png" sizes="32x32" />

--- a/tpl/page.php
+++ b/tpl/page.php
@@ -51,7 +51,7 @@ endif;
 ?>
 		<script type="text/javascript" data-cfasync="false" src="js/purify-3.1.3.js" integrity="sha512-t/FKG/ucQVMWTWVouSMABSEx1r+uSyAI9eNDq0KEr9mPhkgxpJztHI/E72JIpv/+VwPs/Q4husxj14TE9Ps/wg==" crossorigin="anonymous"></script>
 		<script type="text/javascript" data-cfasync="false" src="js/legacy.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-LYos+qXHIRqFf5ZPNphvtTB0cgzHUizu2wwcOwcwz/VIpRv9lpcBgPYz4uq6jx0INwCAj6Fbnl5HoKiLufS2jg==" crossorigin="anonymous"></script>
-		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-zpTPe2Mntv4/cR6XYcmAxKHbIhfj4QsW0dqoBcZzT9BAveLJl7TFnUo+PRVD2tJCEMtR9uSYHeRzNzTCME9VVA==" crossorigin="anonymous"></script>
+		<script type="text/javascript" data-cfasync="false" src="js/privatebin.js?<?php echo rawurlencode($VERSION); ?>" integrity="sha512-ZufHPyPUQirmH53EFdfMBk9H9stN8Bdwel3ZyKs8qUDSjHy8qjdQRSQFxhpOMioCF/F31jEkhGHQKEFJHnGTeQ==" crossorigin="anonymous"></script>
 		<!-- icon -->
 		<link rel="apple-touch-icon" href="img/apple-touch-icon.png?<?php echo rawurlencode($VERSION); ?>" sizes="180x180" />
 		<link rel="icon" type="image/png" href="img/favicon-32x32.png?<?php echo rawurlencode($VERSION); ?>" sizes="32x32" />


### PR DESCRIPTION
This PR addresses a [discussion item in #1334](https://github.com/orgs/PrivateBin/discussions/1334#discussioncomment-9573519).

`@version` at file header level isn't used in code docs, it is intended for API versions at class or method level. See [phpdoc documentation](https://docs.phpdoc.org/latest/guide/references/phpdoc/tags/version.html), as well as our current [PHP](https://privatebin.info/codedoc/classes/PrivateBin-Configuration.html) & [JS](https://privatebin.info/jsdoc/Alert.html) docs not displaying/using the version property at all.

## Changes
- remove version number from doc blocs
- avoids needing to update all these files on version increment
- avoids needing to regenerate SRI hashes for privatebin.js through extra phpunit run
- simplifies VERSION_FILES list
- avoids having to filter above list during loop
- adds a few missing doc bloc headers
