### PR TITLE
enable strict types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.7.4 (not yet released)
 * CHANGED: Saving markdown pastes uses `.md` extension instead of `.txt` (#1293)
+* CHANGED: Enable strict type checking in PHP (#1350)
 * FIXED: Reset password input field on creation of new paste (#1194)
 * FIXED: Allow database schema upgrade to skip versions (#1343)
 

--- a/bin/administration
+++ b/bin/administration
@@ -1,5 +1,5 @@
 #!/usr/bin/env php
-<?php
+<?php declare(strict_types=1);
 /**
  * PrivateBin
  *

--- a/bin/configuration-test-generator
+++ b/bin/configuration-test-generator
@@ -1,5 +1,5 @@
 #!/usr/bin/env php
-<?php
+<?php declare(strict_types=1);
 /**
  * PrivateBin
  *
@@ -413,7 +413,7 @@ class ConfigurationTestGenerator
     private function _getHeader()
     {
         return <<<'EOT'
-<?php
+<?php declare(strict_types=1);
 /**
  * DO NOT EDIT: This file is generated automatically using configGenerator.php
  */

--- a/bin/icon-test
+++ b/bin/icon-test
@@ -1,5 +1,5 @@
 #!/usr/bin/env php
-<?php
+<?php declare(strict_types=1);
 /**
  * PrivateBin
  *

--- a/bin/migrate
+++ b/bin/migrate
@@ -1,5 +1,5 @@
 #!/usr/bin/env php
-<?php
+<?php declare(strict_types=1);
 /**
  * PrivateBin
  *

--- a/index.php
+++ b/index.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /**
  * PrivateBin
  *

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /**
  * PrivateBin
  *

--- a/lib/Controller.php
+++ b/lib/Controller.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /**
  * PrivateBin
  *

--- a/lib/Data/AbstractData.php
+++ b/lib/Data/AbstractData.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /**
  * PrivateBin
  *

--- a/lib/Data/AbstractData.php
+++ b/lib/Data/AbstractData.php
@@ -181,7 +181,7 @@ abstract class AbstractData
     protected function getOpenSlot(array &$comments, $postdate)
     {
         if (array_key_exists($postdate, $comments)) {
-            $parts = explode('.', $postdate, 2);
+            $parts = explode('.', (string) $postdate, 2);
             if (!array_key_exists(1, $parts)) {
                 $parts[1] = 0;
             }

--- a/lib/Data/Database.php
+++ b/lib/Data/Database.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /**
  * PrivateBin
  *

--- a/lib/Data/Filesystem.php
+++ b/lib/Data/Filesystem.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /**
  * PrivateBin
  *

--- a/lib/Data/GoogleCloudStorage.php
+++ b/lib/Data/GoogleCloudStorage.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /**
  * PrivateBin
  *

--- a/lib/Data/S3Storage.php
+++ b/lib/Data/S3Storage.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /**
  * PrivateBin
  *

--- a/lib/Filter.php
+++ b/lib/Filter.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /**
  * PrivateBin
  *

--- a/lib/FormatV2.php
+++ b/lib/FormatV2.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /**
  * PrivateBin
  *

--- a/lib/I18n.php
+++ b/lib/I18n.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /**
  * PrivateBin
  *

--- a/lib/Json.php
+++ b/lib/Json.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /**
  * PrivateBin
  *

--- a/lib/Model.php
+++ b/lib/Model.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /**
  * PrivateBin
  *

--- a/lib/Model/AbstractModel.php
+++ b/lib/Model/AbstractModel.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /**
  * PrivateBin
  *

--- a/lib/Model/Comment.php
+++ b/lib/Model/Comment.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /**
  * PrivateBin
  *

--- a/lib/Model/Paste.php
+++ b/lib/Model/Paste.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /**
  * PrivateBin
  *

--- a/lib/Persistence/AbstractPersistence.php
+++ b/lib/Persistence/AbstractPersistence.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /**
  * PrivateBin
  *

--- a/lib/Persistence/PurgeLimiter.php
+++ b/lib/Persistence/PurgeLimiter.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /**
  * PrivateBin
  *

--- a/lib/Persistence/ServerSalt.php
+++ b/lib/Persistence/ServerSalt.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /**
  * PrivateBin
  *

--- a/lib/Persistence/TrafficLimiter.php
+++ b/lib/Persistence/TrafficLimiter.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /**
  * PrivateBin

--- a/lib/Request.php
+++ b/lib/Request.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /**
  * PrivateBin
  *

--- a/lib/View.php
+++ b/lib/View.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /**
  * PrivateBin
  *

--- a/lib/Vizhash16x16.php
+++ b/lib/Vizhash16x16.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /**
  * VizHash_GD
  *

--- a/lib/YourlsProxy.php
+++ b/lib/YourlsProxy.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /**
  * PrivateBin
  *

--- a/tst/Bootstrap.php
+++ b/tst/Bootstrap.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 use Google\Cloud\Core\Exception\BadRequestException;
 use Google\Cloud\Core\Exception\NotFoundException;

--- a/tst/ConfigurationTest.php
+++ b/tst/ConfigurationTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 use PrivateBin\Configuration;

--- a/tst/ControllerTest.php
+++ b/tst/ControllerTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 use PrivateBin\Controller;

--- a/tst/ControllerWithDbTest.php
+++ b/tst/ControllerWithDbTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 use PrivateBin\Data\Database;
 use PrivateBin\Persistence\ServerSalt;

--- a/tst/ControllerWithGcsTest.php
+++ b/tst/ControllerWithGcsTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 use Google\Auth\HttpHandler\HttpHandlerFactory;
 use GuzzleHttp\Client;

--- a/tst/Data/DatabaseTest.php
+++ b/tst/Data/DatabaseTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 use PrivateBin\Controller;

--- a/tst/Data/FilesystemTest.php
+++ b/tst/Data/FilesystemTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 use PrivateBin\Data\Filesystem;

--- a/tst/Data/GoogleCloudStorageTest.php
+++ b/tst/Data/GoogleCloudStorageTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 use Google\Auth\HttpHandler\HttpHandlerFactory;
 use GuzzleHttp\Client;

--- a/tst/FilterTest.php
+++ b/tst/FilterTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 use PrivateBin\Filter;

--- a/tst/FormatV2Test.php
+++ b/tst/FormatV2Test.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 use PrivateBin\FormatV2;

--- a/tst/I18nTest.php
+++ b/tst/I18nTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 use PrivateBin\I18n;

--- a/tst/I18nTest.php
+++ b/tst/I18nTest.php
@@ -198,7 +198,7 @@ class I18nTest extends TestCase
         $languageCount = 0;
         foreach ($languageIterator as $file) {
             ++$languageCount;
-            $this->assertTrue(copy($file, $path . DIRECTORY_SEPARATOR . $file->getBasename()));
+            $this->assertTrue(copy($file->getPathname(), $path . DIRECTORY_SEPARATOR . $file->getBasename()));
         }
 
         I18nMock::resetPath($path);

--- a/tst/JsonApiTest.php
+++ b/tst/JsonApiTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 use PrivateBin\Controller;

--- a/tst/MigrateTest.php
+++ b/tst/MigrateTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 use PHPUnit\Framework\TestCase;
 use PrivateBin\Data\Database;
 use PrivateBin\Data\Filesystem;

--- a/tst/ModelTest.php
+++ b/tst/ModelTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 use Identicon\Identicon;
 use PHPUnit\Framework\TestCase;

--- a/tst/Persistence/PurgeLimiterTest.php
+++ b/tst/Persistence/PurgeLimiterTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 use PrivateBin\Data\Filesystem;

--- a/tst/Persistence/ServerSaltTest.php
+++ b/tst/Persistence/ServerSaltTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 use PrivateBin\Data\Filesystem;

--- a/tst/Persistence/TrafficLimiterTest.php
+++ b/tst/Persistence/TrafficLimiterTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 use PrivateBin\Data\Filesystem;

--- a/tst/RequestTest.php
+++ b/tst/RequestTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 use PrivateBin\Request;

--- a/tst/ViewTest.php
+++ b/tst/ViewTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 use PrivateBin\I18n;

--- a/tst/Vizhash16x16Test.php
+++ b/tst/Vizhash16x16Test.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 use PrivateBin\Data\Filesystem;

--- a/tst/YourlsProxyTest.php
+++ b/tst/YourlsProxyTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 use PrivateBin\Configuration;


### PR DESCRIPTION
This PR addresses a discussion in #816.

## Changes
* enable strict types for all PHP files
* address two unit test failures / issues flushed out by this
