### PR TITLE
bootstrap5 textarea height relative to viewport height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.7.4 (not yet released)
 * CHANGED: Saving markdown pastes uses `.md` extension instead of `.txt` (#1293)
 * CHANGED: Enable strict type checking in PHP (#1350)
+* CHANGED: Various tweaks of the `bootstrap5` template, suggested by the community
 * FIXED: Reset password input field on creation of new paste (#1194)
 * FIXED: Allow database schema upgrade to skip versions (#1343)
 

--- a/css/bootstrap5/privatebin.css
+++ b/css/bootstrap5/privatebin.css
@@ -36,6 +36,10 @@
 	margin-bottom: 10px;
 }
 
+#message {
+	height: 70vh;
+}
+
 #message, .replymessage {
 	font-family: monospace;
 	resize: vertical;


### PR DESCRIPTION
This PR fixes #1349

## Changes
* sets the height of the `#message` textarea to 70% of the view port height

The value was picked as a compromise to look decent over a large range of display height. You can experiment with it yourself on [one of the instances using the bootstrap5 template](https://snip.dssr.ch/) using your browsers inspect element function and setting the CSS height property of the element to various `vh` factors.

![70vh @ 1720x1269](https://github.com/PrivateBin/PrivateBin/assets/1017622/b8ddfe36-097c-4867-aa41-5716a1e37b67)

![70vh @ 1440x860](https://github.com/PrivateBin/PrivateBin/assets/1017622/cca7c05e-a40f-48d1-aacf-01df27d8815b)

![70vh @ 360x760](https://github.com/PrivateBin/PrivateBin/assets/1017622/006712ad-574e-4cef-afa6-e4f22be9bcf1)