### PR TITLE
prevent bypassing YOURLS proxy URL filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * FIXED: Reset password input field on creation of new paste (#1194)
 * FIXED: Allow database schema upgrade to skip versions (#1343)
 * FIXED: `bootstrap5` dark mode toggle unset on dark browser preference (#1340)
+* FIXED: Prevent bypassing YOURLS proxy URL filter, allowing to shorten non-self URLs
 
 ## 1.7.3 (2024-05-13)
 * CHANGED: Various tweaks of the `bootstrap5` template, suggested by the community

--- a/lib/YourlsProxy.php
+++ b/lib/YourlsProxy.php
@@ -47,7 +47,7 @@ class YourlsProxy
      */
     public function __construct(Configuration $conf, $link)
     {
-        if (strpos($link, $conf->getKey('basepath') . '?') === false) {
+        if (strpos($link, $conf->getKey('basepath') . '?') !== 0) {
             $this->_error = 'Trying to shorten a URL that isn\'t pointing at our instance.';
             return;
         }

--- a/tst/JsonApiTest.php
+++ b/tst/JsonApiTest.php
@@ -325,6 +325,9 @@ class JsonApiTest extends TestCase
      */
     public function testShortenViaYourlsFailure()
     {
+        $options                            = parse_ini_file(CONF, true);
+        $options['main']['basepath']        = 'https://example.com/path'; // missing slash gets added by Configuration constructor
+        Helper::createIniFile(CONF, $options);
         $_SERVER['REQUEST_URI'] = '/path/shortenviayourls?link=https%3A%2F%2Fexample.com%2Fpath%2F%3Ffoo%23bar';
         $_GET['link']           = 'https://example.com/path/?foo#bar';
         ob_start();

--- a/tst/YourlsProxyTest.php
+++ b/tst/YourlsProxyTest.php
@@ -54,6 +54,13 @@ class YourlsProxyTest extends TestCase
         $this->assertEquals($yourls->getError(), 'Trying to shorten a URL that isn\'t pointing at our instance.');
     }
 
+    public function testSneakyForeignUrl()
+    {
+        $yourls = new YourlsProxy($this->_conf, 'https://other.example.com/?q=https://example.com/?foo#bar');
+        $this->assertTrue($yourls->isError());
+        $this->assertEquals($yourls->getError(), 'Trying to shorten a URL that isn\'t pointing at our instance.');
+    }
+
     public function testYourlsError()
     {
         // when statusCode is not 200, shorturl may not have been set


### PR DESCRIPTION
Kudos @nbviglk for reporting this via email.

## Changes
* prevent bypassing YOURLS proxy URL filter, allowing to shorten non-self URLs

## ToDo
* [ ] get this reviewed, anyone can think of additional ways of circumventing this?
