### PR TITLE
Simpler PostgreSQL table lookup query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.7.4 (not yet released)
 * CHANGED: Saving markdown pastes uses `.md` extension instead of `.txt` (#1293)
 * CHANGED: Enable strict type checking in PHP (#1350)
+* CHANGED: Simpler PostgreSQL table lookup query (#1361)
 * FIXED: Reset password input field on creation of new paste (#1194)
 * FIXED: Allow database schema upgrade to skip versions (#1343)
 * FIXED: `bootstrap5` dark mode toggle unset on dark browser preference (#1340)

--- a/lib/Data/Database.php
+++ b/lib/Data/Database.php
@@ -598,18 +598,8 @@ class Database extends AbstractData
                 $sql = 'SELECT table_name FROM all_tables';
                 break;
             case 'pgsql':
-                $sql = 'SELECT c."relname" AS "table_name" '
-                     . 'FROM "pg_class" c, "pg_user" u '
-                     . 'WHERE c."relowner" = u."usesysid" AND c."relkind" = \'r\' '
-                     . 'AND NOT EXISTS (SELECT 1 FROM "pg_views" WHERE "viewname" = c."relname") '
-                     . "AND c.\"relname\" !~ '^(pg_|sql_)' "
-                     . 'UNION '
-                     . 'SELECT c."relname" AS "table_name" '
-                     . 'FROM "pg_class" c '
-                     . "WHERE c.\"relkind\" = 'r' "
-                     . 'AND NOT EXISTS (SELECT 1 FROM "pg_views" WHERE "viewname" = c."relname") '
-                     . 'AND NOT EXISTS (SELECT 1 FROM "pg_user" WHERE "usesysid" = c."relowner") '
-                     . "AND c.\"relname\" !~ '^pg_'";
+                $sql = 'SELECT "tablename" FROM "pg_catalog"."pg_tables" '
+                     . 'WHERE "schemaname" NOT IN (\'pg_catalog\', \'information_schema\')';
                 break;
             case 'sqlite':
                 $sql = 'SELECT "name" FROM "sqlite_master" WHERE "type"=\'table\' '


### PR DESCRIPTION
This PR fixes #1361.

## Changes
* Simpler PostgreSQL table lookup query, doesn't require permission to read the user table

Note that while I did validate the query on a PostgreSQL 16.1 docker container, we have no PG unit tests and I have no PrivateBin + Postgres setup available to test this on. I would appreciate if someone with a PG setup could test this branch and let us know if this causes any problems or if there would be a better/more robust/simpler query.