### PR TITLE
Allow non persistent SQL connections

### DIFF
--- a/lib/Data/Database.php
+++ b/lib/Data/Database.php
@@ -72,7 +72,9 @@ class Database extends AbstractData
             // set default options
             $options['opt'][PDO::ATTR_ERRMODE]          = PDO::ERRMODE_EXCEPTION;
             $options['opt'][PDO::ATTR_EMULATE_PREPARES] = false;
-            $options['opt'][PDO::ATTR_PERSISTENT]       = true;
+            if (!array_key_exists(PDO::ATTR_PERSISTENT, $options['opt'])) {
+                $options['opt'][PDO::ATTR_PERSISTENT] = true;
+            }
             $db_tables_exist                            = true;
 
             // setup type and dabase connection


### PR DESCRIPTION
There is no way to use non persistent SQL connections as the `PDO::ATTR_PERSISTENT` is always `true` in `Database.php` file.

The PR allow to set this flag to `false` using parameter `opt[12]` from `conf.php`.