### PR TITLE
fix(configuration): Use "model_options[opt]" section from "conf.php"

### DIFF
--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -12,7 +12,6 @@
 namespace PrivateBin;
 
 use Exception;
-use PDO;
 
 /**
  * Configuration

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -166,7 +166,7 @@ class Configuration
                     'tbl' => null,
                     'usr' => null,
                     'pwd' => null,
-                    'opt' => array(PDO::ATTR_PERSISTENT => true),
+                    'opt' => array(),
                 );
             } elseif (
                 $section == 'model_options' && in_array(
@@ -235,6 +235,8 @@ class Configuration
                             $result = (int) $config[$section][$key];
                         } elseif (is_string($val) && !empty($config[$section][$key])) {
                             $result = (string) $config[$section][$key];
+                        } elseif (is_array($val) && is_array($config[$section][$key])) {
+                            $result = $config[$section][$key];
                         }
                     }
                     $this->_configuration[$section][$key] = $result;


### PR DESCRIPTION
This PR fixes `model_options[opt]` section from configuration file (`conf.php`) being ignored.