### PR TITLE
Boostrap5 make Expires and Burn after reading more prominant

### DIFF
--- a/tpl/bootstrap5.php
+++ b/tpl/bootstrap5.php
@@ -201,7 +201,7 @@ endif;
 ?>
 						</li>
 						<li id="expiration" class="nav-item d-flex hidden">
-							<label for="pasteExpiration" class="form-label my-auto me-1"><?php echo I18n::_('Expires'); ?>:</label>
+							<label for="pasteExpiration" class="form-label my-auto me-1 text-danger"><?php echo I18n::_('Expires'); ?>:</label>
 							<select id="pasteExpiration" name="pasteExpiration" class="form-select">
 <?php
 foreach ($EXPIRE as $key => $value) :
@@ -223,7 +223,7 @@ if ($BURNAFTERREADINGSELECTED) :
 ?> checked="checked"<?php
 endif;
 ?> />
-								<label class="form-check-label" for="burnafterreading">
+								<label class="form-check-label text-warning" for="burnafterreading">
 									<?php echo I18n::_('Burn after reading'), PHP_EOL; ?>
 								</label>
 							</div>


### PR DESCRIPTION
I personally like making `Expires` and `Burn after reading` more prominant, show the options exist more clearly. Which should hopefully lead to people thinking about using the options, rather than skimming over them with the normal font colour.


## Changes
* Make `Expires` text red
* Make `Burn after reading` text orange

![image](https://github.com/user-attachments/assets/04daf020-e3d6-4c54-b899-91d0d868809e)
