### PR TITLE
Fix phpunit doc missing crucial step of installing GCS

### DIFF
--- a/doc/Running Unit Tests.md
+++ b/doc/Running Unit Tests.md
@@ -48,6 +48,9 @@ Because the unit tests depend on this, you also need to install the optional. Ot
 composer require google/cloud-storage
 ```
 
+If you do this and want to develop further, please go into `.gitignore` and adjust it to ignore the whole
+vendor directory. Otherwise your `git status` will be filled with lot's of unrelated PHP files.
+
 To run the tests, change into the `tst` directory and run phpunit:
 
 ```console

--- a/doc/Running Unit Tests.md
+++ b/doc/Running Unit Tests.md
@@ -43,6 +43,11 @@ Example for Debian and Ubuntu:
 $ sudo apt install phpunit php-gd php-sqlite3 php-xdebug
 ```
 
+Because the unit tests depend on this, you also need to install the optional. Otherwise they won't run:
+```console
+composer require google/cloud-storage
+```
+
 To run the tests, change into the `tst` directory and run phpunit:
 
 ```console


### PR DESCRIPTION
I tried following the steps when running, for https://github.com/PrivateBin/PrivateBin/pull/1421, but this crucial one step is missing.

Maybe more was missing, most tests failed so hmm… but I only wanted it for the SRI generation and this was hard enough.

(And no, I did not feel like trying to run a container in a [dev]container, so these manual steps should better work.)

Maybe we can improve that further here, I the things I've noticed in this or the other PR.
