### PR TITLE
Change SECURITY.md to hint for acceping vulnerability reports via the GitHub mail

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,5 +14,8 @@ a response within a week (usually during the next weekend). The respondee will
 reply from their personal address and can offer you their GPG public key to
 support end-to-end encrypted communication on sensitive topics or attachments.
 
+You can also [use the corresponding GitHub form](https://github.com/PrivateBin/PrivateBin/security/advisories/new)
+to report a new vulnerability directly on GitHub.
+
 You can also contact us via the regular issue tracker if the risk of early
 publication is low or you would request input from other PrivateBin users.


### PR DESCRIPTION
This seems to be a new feature and I've had this tested (with a different account) that this can be used by anyone.

IMHO, this is a convenient feature, as we'd need to publish it anyway there.
