### PR TITLE
Remove SAFE_FOR_JQUERY from DOMPurify as it has been removed

### DIFF
--- a/js/privatebin.js
+++ b/js/privatebin.js
@@ -58,7 +58,6 @@ jQuery.PrivateBin = (function($, RawDeflate) {
      */
      const purifyHtmlConfig = {
         ALLOWED_URI_REGEXP: /^(?:(?:(?:f|ht)tps?|mailto|magnet):)/i,
-        SAFE_FOR_JQUERY: true,
         USE_PROFILES: {
             html: true
         }


### PR DESCRIPTION
DOMPurify removed this configuration option, so I guess it has no effect and can be removed.

See docs: https://github.com/cure53/DOMPurify?tab=readme-ov-file#removed-configuration
>  SAFE_FOR_JQUERY 	2.1.0 	No replacement required.

The PR https://github.com/cure53/DOMPurify/pull/474 also links the commits, which removed it.
