### PR TITLE
Do not instanciate the Configuration more than once

### DIFF
--- a/lib/Controller.php
+++ b/lib/Controller.php
@@ -190,8 +190,6 @@ class Controller
      */
     private function _setDefaultLanguage()
     {
-        $this->_conf = new Configuration;
-
         $lang = $this->_conf->getKey('languagedefault');
         I18n::setLanguageFallback($lang);
         // force default language, if language selection is disabled and a default is set
@@ -208,8 +206,6 @@ class Controller
      */
     private function _setDefaultTemplate()
     {
-        $this->_conf = new Configuration;
-
         $templates = $this->_conf->getKey('availabletemplates');
         $template  = $this->_conf->getKey('template');
         TemplateSwitcher::setAvailableTemplates($templates);


### PR DESCRIPTION
This PR removes two `new Configuration` lines since they are not needed.

## Changes

* In the Controller class, I removed a couple of lines `$this->_conf = new Configuration;`.
  The Configuration class is already instanciated inside the `_init()` method.

This change improves the TTFB by almost 9%. It's not much since the load is fast already, but still.