### PR TITLE
Allow to use another Configuration class

### DIFF
--- a/lib/Controller.php
+++ b/lib/Controller.php
@@ -112,10 +112,12 @@ class Controller
      *
      * initializes and runs PrivateBin
      *
+     * @param ?Configuration $config
+     *
      * @access public
      * @throws Exception
      */
-    public function __construct()
+    public function __construct(?Configuration $config = null)
     {
         if (version_compare(PHP_VERSION, self::MIN_PHP_VERSION) < 0) {
             error_log(I18n::_('%s requires php %s or above to work. Sorry.', I18n::_('PrivateBin'), self::MIN_PHP_VERSION));
@@ -126,7 +128,8 @@ class Controller
             return;
         }
 
-        // load config from ini file, initialize required classes
+        // load config (using ini file by default) & initialize required classes
+        $this->_conf = $config ?? new Configuration();
         $this->_init();
 
         switch ($this->_request->getOperation()) {
@@ -174,7 +177,6 @@ class Controller
      */
     private function _init()
     {
-        $this->_conf    = new Configuration;
         $this->_model   = new Model($this->_conf);
         $this->_request = new Request;
         $this->_urlBase = $this->_request->getRequestUri();

--- a/tst/ControllerTest.php
+++ b/tst/ControllerTest.php
@@ -1,6 +1,7 @@
 <?php declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
+use PrivateBin\Configuration;
 use PrivateBin\Controller;
 use PrivateBin\Data\Filesystem;
 use PrivateBin\Persistence\ServerSalt;
@@ -145,6 +146,20 @@ class ControllerTest extends TestCase
         $this->expectException(Exception::class);
         $this->expectExceptionCode(2);
         new Controller;
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testNonDefaultConf()
+    {
+        $newConfig   = new class extends Configuration {};
+        $configValue = (new ReflectionClass(Controller::class))->getProperty('_conf');
+        $configValue->setAccessible(true);
+        ob_start();
+        $controller = new Controller($newConfig);
+        ob_end_clean();
+        $this->assertSame($newConfig, $configValue->getValue($controller));
     }
 
     /**


### PR DESCRIPTION
This PR adds the possibility to load another Configuration class into the
main Controller.

The purpose is to be able to create a custom Configuration loader. Like instead
of reading a ini file, we could fetch the configuration from a database or something.

This PR depends on #1522.

## Changes

- **feat: Allow to change the Configuration in the _construct**

