### PR TITLE
Add --delete-all option to administration script for mass paste deletion

### DIFF
--- a/bin/administration
+++ b/bin/administration
@@ -344,13 +344,13 @@ EOT, PHP_EOL;
 
         $class = 'PrivateBin\\Data\\' . $this->_conf->getKey('class', 'model');
         $this->_store = new $class($this->_conf->getSection('model_options'));
-		
-		if ($this->_option('l', 'list-ids') !== null) {
-			$this->_list_ids();
-		}
-		if ($this->_option(null, 'delete-all') !== null) {
-			$this->_delete_all();
-		}
+
+        if ($this->_option('l', 'list-ids') !== null) {
+            $this->_list_ids();
+        }
+        if ($this->_option(null, 'delete-all') !== null) {
+            $this->_delete_all();
+        }
         if (($pasteId = $this->_option('d', 'delete')) !== null) {
             $this->_delete($pasteId);
         }

--- a/bin/administration
+++ b/bin/administration
@@ -73,6 +73,35 @@ class Administration
     }
 
     /**
+     * lists all stored paste IDs
+     *
+     * @access private
+     */
+    private function _list_ids()
+    {
+        $ids = $this->_store->getAllPastes();
+        foreach ($ids as $pasteid) {
+            echo $pasteid, PHP_EOL;
+        }
+        exit;
+    }
+
+    /**
+     * deletes all stored pastes (regardless of expiration)
+     *
+     * @access private
+     */
+    private function _delete_all()
+    {
+        $ids = $this->_store->getAllPastes();
+        foreach ($ids as $pasteid) {
+            echo "Deleting paste ID: $pasteid" . PHP_EOL;
+            $this->_store->delete($pasteid);
+        }
+        exit("All pastes successfully deleted" . PHP_EOL);
+    }
+
+    /**
      * removes empty directories, if current storage model uses Filesystem
      *
      * @access private
@@ -124,7 +153,7 @@ class Administration
     {
         echo <<<'EOT'
 Usage:
-  administration [--delete <paste id> | --empty-dirs | --help | --purge | --statistics]
+	administration [--delete <paste id> | --empty-dirs | --help | --purge | --statistics | --list-ids]
 
 Options:
   -d, --delete      deletes the requested paste ID
@@ -133,6 +162,7 @@ Options:
   -h, --help        displays this help message
   -p, --purge       purge all expired pastes
   -s, --statistics  reads all stored pastes and comments and reports statistics
+  -l, --list-ids    lists all paste IDs
 EOT, PHP_EOL;
         exit($code);
     }
@@ -177,7 +207,8 @@ EOT, PHP_EOL;
             self::_help(2);
         }
 
-        $this->_opts = getopt('hd:eps', array('help', 'delete:', 'empty-dirs', 'purge', 'statistics'));
+		$this->_opts = getopt('hd:epsl', array('help', 'delete:', 'empty-dirs', 'purge', 'statistics', 'list-ids', 'delete-all'));
+
         if (!$this->_opts) {
             self::_error_echo('unsupported arguments given');
             echo PHP_EOL;
@@ -307,7 +338,13 @@ EOT, PHP_EOL;
 
         $class = 'PrivateBin\\Data\\' . $this->_conf->getKey('class', 'model');
         $this->_store = new $class($this->_conf->getSection('model_options'));
-
+		
+		if ($this->_option('l', 'list-ids') !== null) {
+			$this->_list_ids();
+		}
+		if ($this->_option(null, 'delete-all') !== null) {
+			$this->_delete_all();
+		}
         if (($pasteId = $this->_option('d', 'delete')) !== null) {
             $this->_delete($pasteId);
         }

--- a/bin/administration
+++ b/bin/administration
@@ -213,7 +213,7 @@ EOT, PHP_EOL;
             self::_help(2);
         }
 
-		$this->_opts = getopt('hd:epsl', array('help', 'delete:', 'empty-dirs', 'purge', 'statistics', 'list-ids', 'delete-all'));
+        $this->_opts = getopt('hd:epsl', array('help', 'delete:', 'empty-dirs', 'purge', 'statistics', 'list-ids', 'delete-all'));
 
         if (!$this->_opts) {
             self::_error_echo('unsupported arguments given');

--- a/bin/administration
+++ b/bin/administration
@@ -162,7 +162,13 @@ Options:
   -h, --help        displays this help message
   -p, --purge       purge all expired pastes
   -s, --statistics  reads all stored pastes and comments and reports statistics
+  --delete-all      deletes all paste IDs
+  -e, --empty-dirs  removes empty directories (only if Filesystem storage is
+                    configured)
+  -h, --help        displays this help message
   -l, --list-ids    lists all paste IDs
+  -p, --purge       purge all expired pastes
+  -s, --statistics  reads all stored pastes and comments and reports statistics
 EOT, PHP_EOL;
         exit($code);
     }

--- a/bin/administration
+++ b/bin/administration
@@ -153,7 +153,7 @@ class Administration
     {
         echo <<<'EOT'
 Usage:
-	administration [--delete <paste id> | --empty-dirs | --help | --purge | --statistics | --list-ids]
+  administration [--delete <paste id> | --delete-all | --empty-dirs | --help | --list-ids | --purge | --statistics]
 
 Options:
   -d, --delete      deletes the requested paste ID


### PR DESCRIPTION
# Enhance Administration Script with `--list-ids` and `--delete-all` Options

This PR introduces **two new options** to the `bin/administration` script, improving PrivateBin's administrative capabilities:

- `--list-ids`: Lists all stored paste IDs.
- `--delete-all`: Deletes all stored pastes at once.

These features simplify maintenance and cleanup tasks, especially useful for **privacy compliance** or **bulk management** of pastes. They complement the existing `--delete` option by enabling mass operations directly from the CLI.

## Changes Included:

- Added `_list_ids()` and `_delete_all()` methods to the administration script.
- Provides informative console output for each operation, ensuring **transparency** during execution.
- Aligned with the current **coding style** and **structure** of the project.

Tested successfully in a production environment with both **filesystem** and **database** storage models.

Looking forward to your feedback and suggestions!

