### PR TITLE
Added some more error logging for database and filesystem store backends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # PrivateBin version history
 
 ## 2.0.0 (not yet released)
+* ADDED: Error logging in database and filesystem backend (#1554)
 * CHANGED: Remove page template (#265)
 * CHANGED: Jdenticons are now used as the default icons
 * CHANGED: Upgrading libraries to: jdenticon 2.0.0

--- a/lib/Data/Database.php
+++ b/lib/Data/Database.php
@@ -188,6 +188,7 @@ class Database extends AbstractData
                 )
             );
         } catch (Exception $e) {
+            error_log('Error while attempting to insert a paste into the database: ' . $e->getMessage() . PHP_EOL);
             return false;
         }
     }
@@ -333,6 +334,7 @@ class Database extends AbstractData
                 )
             );
         } catch (Exception $e) {
+            error_log('Error while attempting to insert a comment into the database: ' . $e->getMessage() . PHP_EOL);
             return false;
         }
     }
@@ -915,8 +917,12 @@ class Database extends AbstractData
                 try {
                     $row                = $this->_select('SELECT sqlite_version() AS "v"', array(), true);
                     $supportsDropColumn = version_compare($row['v'], '3.35.0', '>=');
+                    if (!$supportsDropColumn) {
+                        error_log('Error: the available SQLite version (' . $row['v'] . ') does not support dropping columns. SQLite version 3.35.0 or later is necessary. The migration will not be fully complete, and you will need to delete the "postdate" column of the "paste" table yourself!');
+                    }
                 } catch (PDOException $e) {
                     $supportsDropColumn = false;
+                    error_log('Error while checking the SQLite version. The migration will not be fully complete, and you will need to delete the "postdate" column of the "paste" table yourself!');
                 }
             }
             if ($supportsDropColumn) {

--- a/lib/Data/Filesystem.php
+++ b/lib/Data/Filesystem.php
@@ -456,6 +456,7 @@ class Filesystem extends AbstractData
                 self::PROTECTION_LINE . PHP_EOL . Json::encode($data)
             );
         } catch (Exception $e) {
+            error_log('Error while trying to store data to the filesystem at path "' . $filename . '": ' . $e->getMessage() . PHP_EOL);
             return false;
         }
     }


### PR DESCRIPTION

This PR fixes #1554

## Changes

* Added some more `error_log(...)` for catch-all failure modes in the database and filesystem store backends

## ToDo

* [x] Changelog entry
