### PR TITLE
Fix configuration combinations test errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * CHANGED: Set bootstrap5 template as default for PrivateBin (#1572)
 * FIXED: Name mismatches in attached files (#1584)
 * FIXED: Unable to paste attachments from clipboard (#1589)
+* FIXED: Configuration combinations test errors
 
 ## 1.7.8 (2025-06-30)
 * FIXED: Duplicate attachment for every comment (#1577)

--- a/bin/configuration-test-generator
+++ b/bin/configuration-test-generator
@@ -536,7 +536,8 @@ EOT;
                 break;
             case 'Delete':
                 $code .= PHP_EOL . <<<'EOT'
-        $this->_model->create(Helper::getPasteId(), Helper::getPaste());
+        $paste = Helper::getPaste();
+        $this->_model->create(Helper::getPasteId(), $paste);
         $this->assertTrue($this->_model->exists(Helper::getPasteId()), 'paste exists before deleting data');
         $_GET['pasteid'] = Helper::getPasteId();
         $_GET['deletetoken'] = hash_hmac('sha256', Helper::getPasteId(), $this->_model->read(Helper::getPasteId())['meta']['salt']);
@@ -574,7 +575,7 @@ EOT;
                 $code .= <<<'EOT'
 
         $this->assertMatchesRegularExpression(
-            '#<div[^>]*id="status"[^>]*>.*Paste was properly deleted[^<]*</div>#s',
+            '#<div[^>]*id="status"[^>]*>.*Paste was properly deleted[^<]*(<button|<\/div>)#s',
             $content,
             'outputs deleted status correctly'
         );


### PR DESCRIPTION
<!-- This is a template for your Pull Request. This are just some suggestions for you. You do not have to use all of them. -->

<!-- If your PR fixes an issue, mention it here. You can also just copy the URL - GitHub will convert it for you.
If this PR fixes several issues, please prepend each issue url/number with the word "fix"/"fixes" or "close"/"closes" as this automatically closes the issues you mentioned when the PR is merged.
-->

## Changes
<!-- List all the changes you have done -->
* Fix configuration combinations test errors

I found out that `ConfigurationCombinationsTest`, which is automatically generated when running `php bin/configuration-test-generator`, fails. I added a few small fixes to make the test pass.
