### PR TITLE
update CSP recommendation around bootstrap5 template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # PrivateBin version history
 
 ## 2.0.1 (not yet released)
-* CHANGED: Update CSP to display icons by default with bootstrap5 template
+* CHANGED: CSP recommendation around bootstrap5 template resolved in Firefox 131 (#1613)
 
 ## 2.0.0 (2025-07-28)
 * ADDED: Error logging in database and filesystem backend (#1554)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # PrivateBin version history
 
 ## 2.0.1 (not yet released)
+* CHANGED: Update CSP to display icons by default with bootstrap5 template
 
 ## 2.0.0 (2025-07-28)
 * ADDED: Error logging in database and filesystem backend (#1554)

--- a/cfg/conf.sample.php
+++ b/cfg/conf.sample.php
@@ -106,8 +106,6 @@ languageselection = false
 ; scripts or run your site behind certain DDoS-protection services.
 ; Check the documentation at https://content-security-policy.com/
 ; Notes:
-; - If you do not use the bootstrap5 theme, you can change default-src to 'none';
-;   'self' is required in bootstrap5 to enable display of the svg icons
 ; - By default this disallows to load images from third-party servers, e.g. when
 ;   they are embedded in documents. If you wish to allow that, you can adjust the
 ;   policy here. See https://github.com/PrivateBin/PrivateBin/wiki/FAQ#why-does-not-it-load-embedded-images
@@ -119,10 +117,10 @@ languageselection = false
 ;   See https://issues.chromium.org/issues/343754409
 ; - To allow displaying PDF previews in Firefox or Chrome, sandboxing must also
 ;   get turned off. The following CSP allows PDF previews:
-; cspheader = "default-src 'self'; base-uri 'self'; form-action 'none'; manifest-src 'self'; connect-src * blob:; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; font-src 'self'; frame-ancestors 'none'; frame-src blob:; img-src 'self' data: blob:; media-src blob:; object-src blob:"
+; cspheader = "default-src 'none'; base-uri 'self'; form-action 'none'; manifest-src 'self'; connect-src * blob:; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; font-src 'self'; frame-ancestors 'none'; frame-src blob:; img-src 'self' data: blob:; media-src blob:; object-src blob:"
 ;
 ; The recommended and default used CSP is:
-; cspheader = "default-src 'self'; base-uri 'self'; form-action 'none'; manifest-src 'self'; connect-src * blob:; script-src 'self' 'wasm-unsafe-eval'; style-src 'self'; font-src 'self'; frame-ancestors 'none'; frame-src blob:; img-src 'self' data: blob:; media-src blob:; object-src blob:; sandbox allow-same-origin allow-scripts allow-forms allow-modals allow-downloads"
+; cspheader = "default-src 'none'; base-uri 'self'; form-action 'none'; manifest-src 'self'; connect-src * blob:; script-src 'self' 'wasm-unsafe-eval'; style-src 'self'; font-src 'self'; frame-ancestors 'none'; frame-src blob:; img-src 'self' data: blob:; media-src blob:; object-src blob:; sandbox allow-same-origin allow-scripts allow-forms allow-modals allow-downloads"
 
 ; Enable or disable the warning message when the site is served over an insecure
 ; connection (insecure HTTP instead of HTTPS), defaults to true.

--- a/cfg/conf.sample.php
+++ b/cfg/conf.sample.php
@@ -106,8 +106,8 @@ languageselection = false
 ; scripts or run your site behind certain DDoS-protection services.
 ; Check the documentation at https://content-security-policy.com/
 ; Notes:
-; - If you use the bootstrap5 theme, you must change default-src to 'self' to
-;   enable display of the svg icons
+; - If you do not use the bootstrap5 theme, you can change default-src to 'none';
+;   'self' is required in bootstrap5 to enable display of the svg icons
 ; - By default this disallows to load images from third-party servers, e.g. when
 ;   they are embedded in documents. If you wish to allow that, you can adjust the
 ;   policy here. See https://github.com/PrivateBin/PrivateBin/wiki/FAQ#why-does-not-it-load-embedded-images
@@ -119,10 +119,10 @@ languageselection = false
 ;   See https://issues.chromium.org/issues/343754409
 ; - To allow displaying PDF previews in Firefox or Chrome, sandboxing must also
 ;   get turned off. The following CSP allows PDF previews:
-; cspheader = "default-src 'none'; base-uri 'self'; form-action 'none'; manifest-src 'self'; connect-src * blob:; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; font-src 'self'; frame-ancestors 'none'; frame-src blob:; img-src 'self' data: blob:; media-src blob:; object-src blob:"
+; cspheader = "default-src 'self'; base-uri 'self'; form-action 'none'; manifest-src 'self'; connect-src * blob:; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; font-src 'self'; frame-ancestors 'none'; frame-src blob:; img-src 'self' data: blob:; media-src blob:; object-src blob:"
 ;
 ; The recommended and default used CSP is:
-; cspheader = "default-src 'none'; base-uri 'self'; form-action 'none'; manifest-src 'self'; connect-src * blob:; script-src 'self' 'wasm-unsafe-eval'; style-src 'self'; font-src 'self'; frame-ancestors 'none'; frame-src blob:; img-src 'self' data: blob:; media-src blob:; object-src blob:; sandbox allow-same-origin allow-scripts allow-forms allow-modals allow-downloads"
+; cspheader = "default-src 'self'; base-uri 'self'; form-action 'none'; manifest-src 'self'; connect-src * blob:; script-src 'self' 'wasm-unsafe-eval'; style-src 'self'; font-src 'self'; frame-ancestors 'none'; frame-src blob:; img-src 'self' data: blob:; media-src blob:; object-src blob:; sandbox allow-same-origin allow-scripts allow-forms allow-modals allow-downloads"
 
 ; Enable or disable the warning message when the site is served over an insecure
 ; connection (insecure HTTP instead of HTTPS), defaults to true.

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -64,7 +64,7 @@ class Configuration
             'qrcode'                   => true,
             'email'                    => true,
             'icon'                     => 'jdenticon',
-            'cspheader'                => 'default-src \'none\'; base-uri \'self\'; form-action \'none\'; manifest-src \'self\'; connect-src * blob:; script-src \'self\' \'wasm-unsafe-eval\'; style-src \'self\'; font-src \'self\'; frame-ancestors \'none\'; frame-src blob:; img-src \'self\' data: blob:; media-src blob:; object-src blob:; sandbox allow-same-origin allow-scripts allow-forms allow-modals allow-downloads',
+            'cspheader'                => 'default-src \'self\'; base-uri \'self\'; form-action \'none\'; manifest-src \'self\'; connect-src * blob:; script-src \'self\' \'wasm-unsafe-eval\'; style-src \'self\'; font-src \'self\'; frame-ancestors \'none\'; frame-src blob:; img-src \'self\' data: blob:; media-src blob:; object-src blob:; sandbox allow-same-origin allow-scripts allow-forms allow-modals allow-downloads',
             'httpwarning'              => true,
             'compression'              => 'zlib',
         ),

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -64,7 +64,7 @@ class Configuration
             'qrcode'                   => true,
             'email'                    => true,
             'icon'                     => 'jdenticon',
-            'cspheader'                => 'default-src \'self\'; base-uri \'self\'; form-action \'none\'; manifest-src \'self\'; connect-src * blob:; script-src \'self\' \'wasm-unsafe-eval\'; style-src \'self\'; font-src \'self\'; frame-ancestors \'none\'; frame-src blob:; img-src \'self\' data: blob:; media-src blob:; object-src blob:; sandbox allow-same-origin allow-scripts allow-forms allow-modals allow-downloads',
+            'cspheader'                => 'default-src \'none\'; base-uri \'self\'; form-action \'none\'; manifest-src \'self\'; connect-src * blob:; script-src \'self\' \'wasm-unsafe-eval\'; style-src \'self\'; font-src \'self\'; frame-ancestors \'none\'; frame-src blob:; img-src \'self\' data: blob:; media-src blob:; object-src blob:; sandbox allow-same-origin allow-scripts allow-forms allow-modals allow-downloads',
             'httpwarning'              => true,
             'compression'              => 'zlib',
         ),


### PR DESCRIPTION
While not strictly necessary, it would be nice to display the button icons by default in the bootstrap5 template. I hadn't noticed this in the preps for 2.0.0 release, since on my installs where I tested with bootstrap5 templates, I had already manually changed the cspheader (and template) option to match this.

## Changes
* update CSP to display icons by default with bootstrap5 template

With 'self' now the default, we could remove all the explicit src-rules that already allow 'self', but that would make it more complicated for admins that _do_ want to use a bootstrap 3 based template.

Aside: I don't understand why the SVG-image-map as used for bootstrap5 does not work with just `img-src: 'self'`, which we always allowed. It somehow counts as a different type of source, only covered by the default rule.