### PR TITLE
undo attachment hint translation change

### DIFF
--- a/i18n/ar.json
+++ b/i18n/ar.json
@@ -172,7 +172,7 @@
     "Cloned: '%s'": "مستنسخ: '%s'",
     "The cloned file '%s' was attached to this document.": "تم إرفاق الملف المستنسخ '%s' بهذا اللصق.",
     "Attach a file": "أرفق ملف",
-    "alternatively drag & drop a file or document an image from the clipboard": "بدلاً من ذلك، اسحب ملفًا وأسقطه أو الصق صورة من الحافظة",
+    "alternatively drag & drop a file or paste an image from the clipboard": "بدلاً من ذلك، اسحب ملفًا وأسقطه أو الصق صورة من الحافظة",
     "File too large, to display a preview. Please download the attachment.": "الملف كبير جدًا، بحيث لا يمكن عرض معاينة. الرجاء تنزيل المرفق.",
     "Remove attachment": "أزِل المرفق",
     "Your browser does not support uploading encrypted files. Please use a newer browser.": "متصفحك لا يدعم رفع الملفات المشفرة. الرجاء استخدام متصفح أحدث.",

--- a/i18n/bg.json
+++ b/i18n/bg.json
@@ -172,7 +172,7 @@
     "Cloned: '%s'": "Дублирано: '%s'",
     "The cloned file '%s' was attached to this document.": "Дублирания файл '%s' беше прикачен.",
     "Attach a file": "Прикачи файл",
-    "alternatively drag & drop a file or document an image from the clipboard": "Също можеш да пуснеш файла върху този прозорец или да поставиш изображение от клипборда",
+    "alternatively drag & drop a file or paste an image from the clipboard": "Също можеш да пуснеш файла върху този прозорец или да поставиш изображение от клипборда",
     "File too large, to display a preview. Please download the attachment.": "Файла е твърде голям, за да се представи визуализация. Моля, свалете файла.",
     "Remove attachment": "Премахнете файла",
     "Your browser does not support uploading encrypted files. Please use a newer browser.": "Браузърът ви не поддържа прикачване на шифровани файлове. Моля, използвайте по-нов браузър",

--- a/i18n/ca.json
+++ b/i18n/ca.json
@@ -172,7 +172,7 @@
     "Cloned: '%s'": "Cloned: '%s'",
     "The cloned file '%s' was attached to this document.": "The cloned file '%s' was attached to this document.",
     "Attach a file": "Adjuntar un fitxer",
-    "alternatively drag & drop a file or document an image from the clipboard": "alternativament, pots arrossegar i deixar anar un fitxer o enganxar una imatge des del porta-retalls",
+    "alternatively drag & drop a file or paste an image from the clipboard": "alternativament, pots arrossegar i deixar anar un fitxer o enganxar una imatge des del porta-retalls",
     "File too large, to display a preview. Please download the attachment.": "El fitxer és massa gran per fer una vista prèvia. Si us plau, descarrega l'adjunt.",
     "Remove attachment": "Remove attachment",
     "Your browser does not support uploading encrypted files. Please use a newer browser.": "Your browser does not support uploading encrypted files. Please use a newer browser.",

--- a/i18n/co.json
+++ b/i18n/co.json
@@ -172,7 +172,7 @@
     "Cloned: '%s'": "Duppiatu : « %s »",
     "The cloned file '%s' was attached to this document.": "U schedariu duppiatu  « %s » hè statu aghjuntu à st’appiccicu.",
     "Attach a file": "Aghjunghje un schedariu",
-    "alternatively drag & drop a file or document an image from the clipboard": "in alternanza, sguillà è depone un schedariu o incullà una fiura da u preme’papei",
+    "alternatively drag & drop a file or paste an image from the clipboard": "in alternanza, sguillà è depone un schedariu o incullà una fiura da u preme’papei",
     "File too large, to display a preview. Please download the attachment.": "Schedariu troppu maiò per affissà una fighjulata. Scaricate a pezza ghjunta.",
     "Remove attachment": "Caccià a pezza ghjunta",
     "Your browser does not support uploading encrypted files. Please use a newer browser.": "U vostru navigatore ùn accetta micca l’inviu di i schedarii cifrati. Impiegate un navigatore più recente.",

--- a/i18n/cs.json
+++ b/i18n/cs.json
@@ -172,7 +172,7 @@
     "Cloned: '%s'": "Naklonováno: '%s'",
     "The cloned file '%s' was attached to this document.": "Naklonovaný soubor „%s“ byl připojen k tomuto příspěvku.",
     "Attach a file": "Připojit soubor",
-    "alternatively drag & drop a file or document an image from the clipboard": "případně přetáhněte soubor nebo vložte obrázek ze schránky",
+    "alternatively drag & drop a file or paste an image from the clipboard": "případně přetáhněte soubor nebo vložte obrázek ze schránky",
     "File too large, to display a preview. Please download the attachment.": "Soubor je příliš velký pro zobrazení náhledu. Stáhněte si přílohu.",
     "Remove attachment": "Odstranit přílohu",
     "Your browser does not support uploading encrypted files. Please use a newer browser.": "Váš prohlížeč nepodporuje nahrávání šifrovaných souborů. Použijte modernější verzi prohlížeče.",

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -172,7 +172,7 @@
     "Cloned: '%s'": "Geklont: '%s'",
     "The cloned file '%s' was attached to this document.": "Die geklonte Datei '%s' wurde angehängt.",
     "Attach a file": "Datei anhängen",
-    "alternatively drag & drop a file or document an image from the clipboard": "Eine Datei kann auch durch ziehen und loslassen ausgewählt oder ein Bild aus der Zwischenablage einfügt werden.",
+    "alternatively drag & drop a file or paste an image from the clipboard": "Eine Datei kann auch durch ziehen und loslassen ausgewählt oder ein Bild aus der Zwischenablage einfügt werden.",
     "File too large, to display a preview. Please download the attachment.": "Datei zu groß, um als Vorschau angezeigt zu werden. Bitte Anhang herunterladen.",
     "Remove attachment": "Anhang entfernen",
     "Your browser does not support uploading encrypted files. Please use a newer browser.": "Dein Browser unterstützt das hochladen von verschlüsselten Dateien nicht. Bitte verwende einen neueren Browser.",

--- a/i18n/el.json
+++ b/i18n/el.json
@@ -172,7 +172,7 @@
     "Cloned: '%s'": "Κλώνος: '%s'",
     "The cloned file '%s' was attached to this document.": "Το κλωνοποιημένο αρχείο '%s' επισυνάφθηκε στ αυτή την επικόλληση.",
     "Attach a file": "Επισύναψη αρχείου",
-    "alternatively drag & drop a file or document an image from the clipboard": "εναλλακτικά σύρετε το αρχείο ή επικολλήστε μία εικόνα από το clipboard",
+    "alternatively drag & drop a file or paste an image from the clipboard": "εναλλακτικά σύρετε το αρχείο ή επικολλήστε μία εικόνα από το clipboard",
     "File too large, to display a preview. Please download the attachment.": "Πολύ μεγάλο αρχείο για προεπισκόπηση. Παρακαλώ κατεβάστε το επισυναπτόμενο.",
     "Remove attachment": "Αφαίρεση επισυναπτόμενου",
     "Your browser does not support uploading encrypted files. Please use a newer browser.": "Ο φυλλομετρητής (browser) σας δεν υποστηρίζει κρυπτογραφημένα αρχεία. Παρακαλώ χρησιμοποιήστε νεότερο φιλομετρητή.",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -172,7 +172,7 @@
     "Cloned: '%s'": "Cloned: '%s'",
     "The cloned file '%s' was attached to this document.": "The cloned file '%s' was attached to this document.",
     "Attach a file": "Attach a file",
-    "alternatively drag & drop a file or document an image from the clipboard": "alternatively drag & drop a file or document an image from the clipboard",
+    "alternatively drag & drop a file or paste an image from the clipboard": "alternatively drag & drop a file or paste an image from the clipboard",
     "File too large, to display a preview. Please download the attachment.": "File too large, to display a preview. Please download the attachment.",
     "Remove attachment": "Remove attachment",
     "Your browser does not support uploading encrypted files. Please use a newer browser.": "Your browser does not support uploading encrypted files. Please use a newer browser.",

--- a/i18n/es.json
+++ b/i18n/es.json
@@ -172,7 +172,7 @@
     "Cloned: '%s'": "Clonado: '%s'.",
     "The cloned file '%s' was attached to this document.": "El archivo clonado '%s' ha sido adjuntado a este texto.",
     "Attach a file": "Adjuntar archivo",
-    "alternatively drag & drop a file or document an image from the clipboard": "alternativamente, arrastre y suelte un archivo o pegue una imagen desde el portapapeles",
+    "alternatively drag & drop a file or paste an image from the clipboard": "alternativamente, arrastre y suelte un archivo o pegue una imagen desde el portapapeles",
     "File too large, to display a preview. Please download the attachment.": "Archivo demasiado grande para mostrar una vista previa. Por favor, descargue el archivo adjunto.",
     "Remove attachment": "Remover adjunto",
     "Your browser does not support uploading encrypted files. Please use a newer browser.": "Tu navegador no admite la carga de archivos cifrados. Utilice un navegador más reciente.",

--- a/i18n/et.json
+++ b/i18n/et.json
@@ -172,7 +172,7 @@
     "Cloned: '%s'": "Kloonitud: '%s'",
     "The cloned file '%s' was attached to this document.": "Kloonitud fail '%s' manustati sellele kleepele.",
     "Attach a file": "Manusta fail",
-    "alternatively drag & drop a file or document an image from the clipboard": "teise võimalusena lohista fail või kleebi pilt lõikelaualt",
+    "alternatively drag & drop a file or paste an image from the clipboard": "teise võimalusena lohista fail või kleebi pilt lõikelaualt",
     "File too large, to display a preview. Please download the attachment.": "Fail on eelvaate kuvamiseks liiga suur. Palun laadi manus alla.",
     "Remove attachment": "Eemalda manus",
     "Your browser does not support uploading encrypted files. Please use a newer browser.": "Sinu brauser ei toeta krüpteeritud failide üleslaadimist. Palun kasuta uuemat brauserit.",

--- a/i18n/fi.json
+++ b/i18n/fi.json
@@ -172,7 +172,7 @@
     "Cloned: '%s'": "Kloonattu: '%s'",
     "The cloned file '%s' was attached to this document.": "Kloonattu tiedosto '%s' liitettiin tähän pasteen",
     "Attach a file": "Liitä tiedosto",
-    "alternatively drag & drop a file or document an image from the clipboard": "vaihtoehtoisesti vedä & pudota tiedosto tai liitä kuva leikepöydältä",
+    "alternatively drag & drop a file or paste an image from the clipboard": "vaihtoehtoisesti vedä & pudota tiedosto tai liitä kuva leikepöydältä",
     "File too large, to display a preview. Please download the attachment.": "Tiedosto on liian iso esikatselun näyttämiseksi. Lataathan liitteen.",
     "Remove attachment": "Poista liite",
     "Your browser does not support uploading encrypted files. Please use a newer browser.": "Selaimesi ei tue salattujen tiedostojen lataamista. Käytäthän uudempaa selainta.",

--- a/i18n/fr.json
+++ b/i18n/fr.json
@@ -172,7 +172,7 @@
     "Cloned: '%s'": "Cloner '%s'",
     "The cloned file '%s' was attached to this document.": "Le fichier cloné '%s' a été attaché à ce document.",
     "Attach a file": "Attacher un fichier",
-    "alternatively drag & drop a file or document an image from the clipboard": "au choix, glisser & déposer un fichier ou coller une image à partir du presse-papiers",
+    "alternatively drag & drop a file or paste an image from the clipboard": "au choix, glisser & déposer un fichier ou coller une image à partir du presse-papiers",
     "File too large, to display a preview. Please download the attachment.": "Fichier trop volumineux, pour afficher un aperçu. Veuillez télécharger la pièce jointe.",
     "Remove attachment": "Enlever la pièce jointe",
     "Your browser does not support uploading encrypted files. Please use a newer browser.": "Votre navigateur ne supporte pas l'envoi de fichiers chiffrés. Merci d'utiliser un navigateur plus récent.",

--- a/i18n/he.json
+++ b/i18n/he.json
@@ -172,7 +172,7 @@
     "Cloned: '%s'": "שוכפל: '%s'",
     "The cloned file '%s' was attached to this document.": "הקובץ '%s' שהועתק צורף להדבקה זו.",
     "Attach a file": "צירוף קובץ",
-    "alternatively drag & drop a file or document an image from the clipboard": "לחלופין, ניתן לגרור ולשחרר קובץ או להדביק תמונה מהלוח.",
+    "alternatively drag & drop a file or paste an image from the clipboard": "לחלופין, ניתן לגרור ולשחרר קובץ או להדביק תמונה מהלוח.",
     "File too large, to display a preview. Please download the attachment.": "הקובץ גדול מדי כדי להציג תצוגה מקדימה. אנא הורד את הקובץ המצורף.",
     "Remove attachment": "הסר קובץ מצורף",
     "Your browser does not support uploading encrypted files. Please use a newer browser.": "הדפדפן שלך אינו תומך בהעלאת קבצים מוצפנים. אנא השתמש בדפדפן עדכני יותר.",

--- a/i18n/hi.json
+++ b/i18n/hi.json
@@ -172,7 +172,7 @@
     "Cloned: '%s'": "Cloned: '%s'",
     "The cloned file '%s' was attached to this document.": "The cloned file '%s' was attached to this document.",
     "Attach a file": "Attach a file",
-    "alternatively drag & drop a file or document an image from the clipboard": "alternatively drag & drop a file or document an image from the clipboard",
+    "alternatively drag & drop a file or paste an image from the clipboard": "alternatively drag & drop a file or paste an image from the clipboard",
     "File too large, to display a preview. Please download the attachment.": "File too large, to display a preview. Please download the attachment.",
     "Remove attachment": "Remove attachment",
     "Your browser does not support uploading encrypted files. Please use a newer browser.": "Your browser does not support uploading encrypted files. Please use a newer browser.",

--- a/i18n/hu.json
+++ b/i18n/hu.json
@@ -172,7 +172,7 @@
     "Cloned: '%s'": "'%s' másolva",
     "The cloned file '%s' was attached to this document.": "A másolt '%s' csatolmányt hozzáadtuk ehhez a bejegyzéshez.",
     "Attach a file": "Fájl csatolása",
-    "alternatively drag & drop a file or document an image from the clipboard": "vagy húzz ide egy fájlt, netán illessz be egy képet a vágólapról.",
+    "alternatively drag & drop a file or paste an image from the clipboard": "vagy húzz ide egy fájlt, netán illessz be egy képet a vágólapról.",
     "File too large, to display a preview. Please download the attachment.": "A fájl túl nagy ahhoz, hogy előnézete legyen. Töltsd le, hogy megtekinthesd.",
     "Remove attachment": "Csatolmány eltávolítása",
     "Your browser does not support uploading encrypted files. Please use a newer browser.": "A böngésződ nem támogatja titkosított fájlok feltöltését. Használj újabbat.",

--- a/i18n/id.json
+++ b/i18n/id.json
@@ -172,7 +172,7 @@
     "Cloned: '%s'": "Diklon: '%s'",
     "The cloned file '%s' was attached to this document.": "Berkas yang di-klon '%s' telah dilampirkan pada document ini.",
     "Attach a file": "Lampirkan sebuah berkas",
-    "alternatively drag & drop a file or document an image from the clipboard": "sebagai alternatif, seret & jatuhkan berkas atau tempel sebuah gambar dari papan klip",
+    "alternatively drag & drop a file or paste an image from the clipboard": "sebagai alternatif, seret & jatuhkan berkas atau tempel sebuah gambar dari papan klip",
     "File too large, to display a preview. Please download the attachment.": "File terlalu besar untuk menampilkan pratinjau. Silakan unduh lampirannya.",
     "Remove attachment": "Hapus lampiran",
     "Your browser does not support uploading encrypted files. Please use a newer browser.": "Browser Anda tidak mendukung pengunggahan file terenkripsi. Harap gunakan browser yang lebih baru.",

--- a/i18n/it.json
+++ b/i18n/it.json
@@ -172,7 +172,7 @@
     "Cloned: '%s'": "Clonato: '%s'",
     "The cloned file '%s' was attached to this document.": "Il file clonato '%s' era allegato a questo messaggio.",
     "Attach a file": "Allega un file",
-    "alternatively drag & drop a file or document an image from the clipboard": "in alternativa trascina e rilascia un file o incolla un'immagine dagli appunti",
+    "alternatively drag & drop a file or paste an image from the clipboard": "in alternativa trascina e rilascia un file o incolla un'immagine dagli appunti",
     "File too large, to display a preview. Please download the attachment.": "File troppo grande, per visualizzare un'anteprima. Sei pregato di scaricare l'allegato.",
     "Remove attachment": "Rimuovi allegato",
     "Your browser does not support uploading encrypted files. Please use a newer browser.": "Il tuo browser non supporta l'invio di file cifrati. Utilizza un browser più recente.",

--- a/i18n/ja.json
+++ b/i18n/ja.json
@@ -172,7 +172,7 @@
     "Cloned: '%s'": "複製済：'%s'",
     "The cloned file '%s' was attached to this document.": "複製されたファイル '%s' がこのペーストに添付されました。",
     "Attach a file": "ファイルを添付",
-    "alternatively drag & drop a file or document an image from the clipboard": "代わりに、ファイルをドラッグ&ドロップまたはクリップボードから画像を貼り付け",
+    "alternatively drag & drop a file or paste an image from the clipboard": "代わりに、ファイルをドラッグ&ドロップまたはクリップボードから画像を貼り付け",
     "File too large, to display a preview. Please download the attachment.": "ファイルが大きすぎるため、プレビューを表示できません。ダウンロードしてください。",
     "Remove attachment": "添付ファイルを削除",
     "Your browser does not support uploading encrypted files. Please use a newer browser.": "お使いのブラウザーは暗号化されたファイルのアップロードをサポートしていません。新しいブラウザーを使用してください。",

--- a/i18n/jbo.json
+++ b/i18n/jbo.json
@@ -172,7 +172,7 @@
     "Cloned: '%s'": "Cloned: '%s'",
     "The cloned file '%s' was attached to this document.": "The cloned file '%s' was attached to this document.",
     "Attach a file": "Attach a file",
-    "alternatively drag & drop a file or document an image from the clipboard": "alternatively drag & drop a file or document an image from the clipboard",
+    "alternatively drag & drop a file or paste an image from the clipboard": "alternatively drag & drop a file or paste an image from the clipboard",
     "File too large, to display a preview. Please download the attachment.": "File too large, to display a preview. Please download the attachment.",
     "Remove attachment": "Remove attachment",
     "Your browser does not support uploading encrypted files. Please use a newer browser.": "Your browser does not support uploading encrypted files. Please use a newer browser.",

--- a/i18n/ko.json
+++ b/i18n/ko.json
@@ -172,7 +172,7 @@
     "Cloned: '%s'": "Cloned: '%s'",
     "The cloned file '%s' was attached to this document.": "The cloned file '%s' was attached to this document.",
     "Attach a file": "Attach a file",
-    "alternatively drag & drop a file or document an image from the clipboard": "alternatively drag & drop a file or document an image from the clipboard",
+    "alternatively drag & drop a file or paste an image from the clipboard": "alternatively drag & drop a file or paste an image from the clipboard",
     "File too large, to display a preview. Please download the attachment.": "File too large, to display a preview. Please download the attachment.",
     "Remove attachment": "Remove attachment",
     "Your browser does not support uploading encrypted files. Please use a newer browser.": "Your browser does not support uploading encrypted files. Please use a newer browser.",

--- a/i18n/ku.json
+++ b/i18n/ku.json
@@ -172,7 +172,7 @@
     "Cloned: '%s'": "Cloned: '%s'",
     "The cloned file '%s' was attached to this document.": "The cloned file '%s' was attached to this document.",
     "Attach a file": "Attach a file",
-    "alternatively drag & drop a file or document an image from the clipboard": "alternatively drag & drop a file or document an image from the clipboard",
+    "alternatively drag & drop a file or paste an image from the clipboard": "alternatively drag & drop a file or paste an image from the clipboard",
     "File too large, to display a preview. Please download the attachment.": "File too large, to display a preview. Please download the attachment.",
     "Remove attachment": "Remove attachment",
     "Your browser does not support uploading encrypted files. Please use a newer browser.": "Your browser does not support uploading encrypted files. Please use a newer browser.",

--- a/i18n/la.json
+++ b/i18n/la.json
@@ -172,7 +172,7 @@
     "Cloned: '%s'": "Cloned: '%s'",
     "The cloned file '%s' was attached to this document.": "The cloned file '%s' was attached to this document.",
     "Attach a file": "Attach a file",
-    "alternatively drag & drop a file or document an image from the clipboard": "alternatively drag & drop a file or document an image from the clipboard",
+    "alternatively drag & drop a file or paste an image from the clipboard": "alternatively drag & drop a file or paste an image from the clipboard",
     "File too large, to display a preview. Please download the attachment.": "File too large, to display a preview. Please download the attachment.",
     "Remove attachment": "Remove attachment",
     "Your browser does not support uploading encrypted files. Please use a newer browser.": "Your browser does not support uploading encrypted files. Please use a newer browser.",

--- a/i18n/lt.json
+++ b/i18n/lt.json
@@ -172,7 +172,7 @@
     "Cloned: '%s'": "Dubliuota: „%s“",
     "The cloned file '%s' was attached to this document.": "Dubliuotas failas „%s“ buvo pridėtas į šį įdėjimą.",
     "Attach a file": "Pridėti failą",
-    "alternatively drag & drop a file or document an image from the clipboard": "arba kitaip - tempkite failą arba įdėkite paveikslą iš iškarpinės",
+    "alternatively drag & drop a file or paste an image from the clipboard": "arba kitaip - tempkite failą arba įdėkite paveikslą iš iškarpinės",
     "File too large, to display a preview. Please download the attachment.": "Failas per didelis, kad būtų rodoma peržiūra. Atsisiųskite priedą.",
     "Remove attachment": "Šalinti priedą",
     "Your browser does not support uploading encrypted files. Please use a newer browser.": "Jūsų naršyklė nepalaiko šifruotų failų įkėlimo. Naudokite naujesnę naršyklę.",

--- a/i18n/nl.json
+++ b/i18n/nl.json
@@ -172,7 +172,7 @@
     "Cloned: '%s'": "Gekloond: '%s'",
     "The cloned file '%s' was attached to this document.": "Het gekloonde bestand '%s' is bijgevoegd aan de document.",
     "Attach a file": "Een bestand toevoegen",
-    "alternatively drag & drop a file or document an image from the clipboard": "Je kunt ook een bestand slepen en neerzetten of een afbeelding plakken van het klembord",
+    "alternatively drag & drop a file or paste an image from the clipboard": "Je kunt ook een bestand slepen en neerzetten of een afbeelding plakken van het klembord",
     "File too large, to display a preview. Please download the attachment.": "Het bestand is te groot om voorbeeld weer te geven. Aub de bijlage downloaden.",
     "Remove attachment": "Bijlage verwijderen",
     "Your browser does not support uploading encrypted files. Please use a newer browser.": "Je browser biedt geen ondersteuning voor het uploaden van gecodeerde bestanden. Gebruik alstublieft een nieuwere browser.",

--- a/i18n/no.json
+++ b/i18n/no.json
@@ -172,7 +172,7 @@
     "Cloned: '%s'": "Kopiert: '%s'",
     "The cloned file '%s' was attached to this document.": "Den klonede filen '%s' var koblet til denne innlimingen.",
     "Attach a file": "Legg til fil",
-    "alternatively drag & drop a file or document an image from the clipboard": "alternativt dra og slipp en fil, eller lim inn et bilde fra utklippstavlen",
+    "alternatively drag & drop a file or paste an image from the clipboard": "alternativt dra og slipp en fil, eller lim inn et bilde fra utklippstavlen",
     "File too large, to display a preview. Please download the attachment.": "Filen er for stor, for å vise en forhåndsvisning. Last ned vedlegget.",
     "Remove attachment": "Slett vedlegg",
     "Your browser does not support uploading encrypted files. Please use a newer browser.": "Nettleseren din støtter ikke å laste opp krypterte filer. Vennligst bruk en nyere nettleser.",

--- a/i18n/oc.json
+++ b/i18n/oc.json
@@ -172,7 +172,7 @@
     "Cloned: '%s'": "Clonar : '%s'",
     "The cloned file '%s' was attached to this document.": "Aqueste fichièr clonat '%s' es estat ajustat a aqueste tèxte.",
     "Attach a file": "Juntar un fichièr",
-    "alternatively drag & drop a file or document an image from the clipboard": "autrament lisatz lo fichièr o pegatz l’imatge del quichapapièrs",
+    "alternatively drag & drop a file or paste an image from the clipboard": "autrament lisatz lo fichièr o pegatz l’imatge del quichapapièrs",
     "File too large, to display a preview. Please download the attachment.": "Fichièr tròp pesuc per mostrar un apercebut. Telecargatz la pèca junta.",
     "Remove attachment": "Levar la pèça junta",
     "Your browser does not support uploading encrypted files. Please use a newer browser.": "Vòstre navigator es pas compatible amb lo mandadís de fichièrs chifrats. Mercés d’emplegar un navigator mai recent.",

--- a/i18n/pl.json
+++ b/i18n/pl.json
@@ -172,7 +172,7 @@
     "Cloned: '%s'": "Sklonowano: '%s'",
     "The cloned file '%s' was attached to this document.": "Sklonowany plik '%s' był dołączony do tego dokumentu.",
     "Attach a file": "Załącz plik",
-    "alternatively drag & drop a file or document an image from the clipboard": "Alternatywnie przeciągnij i upuść plik albo wklej obraz ze schowka",
+    "alternatively drag & drop a file or paste an image from the clipboard": "Alternatywnie przeciągnij i upuść plik albo wklej obraz ze schowka",
     "File too large, to display a preview. Please download the attachment.": "Plik zbyt duży aby wyświetlić podgląd. Proszę pobrać załącznik.",
     "Remove attachment": "Usuń załącznik",
     "Your browser does not support uploading encrypted files. Please use a newer browser.": "Twoja przeglądarka nie wspiera wysyłania zaszyfrowanych plików. Użyj nowszej przeglądarki.",

--- a/i18n/pt.json
+++ b/i18n/pt.json
@@ -172,7 +172,7 @@
     "Cloned: '%s'": "Clonado: '%s'",
     "The cloned file '%s' was attached to this document.": "O arquivo clonado '%s' foi anexado a essa cópia.",
     "Attach a file": "Anexar um arquivo",
-    "alternatively drag & drop a file or document an image from the clipboard": "alternativamente, arraste e solte um arquivo ou cole uma imagem da área de transferência",
+    "alternatively drag & drop a file or paste an image from the clipboard": "alternativamente, arraste e solte um arquivo ou cole uma imagem da área de transferência",
     "File too large, to display a preview. Please download the attachment.": "Arquivo muito grande para exibir uma prévia. Por favor, faça o download do anexo.",
     "Remove attachment": "Remover anexo",
     "Your browser does not support uploading encrypted files. Please use a newer browser.": "Seu navegador não permite subir arquivos cifrados. Por favor, utilize um navegador mais recente.",

--- a/i18n/ro.json
+++ b/i18n/ro.json
@@ -172,7 +172,7 @@
     "Cloned: '%s'": "S-a clonat: '%s'",
     "The cloned file '%s' was attached to this document.": "Fișierul clonat '%s' a fost atașat la acest document.",
     "Attach a file": "Atașați un fișier",
-    "alternatively drag & drop a file or document an image from the clipboard": "alternativ, trageți și plasați un fișier sau lipiți o imagine din clipboard",
+    "alternatively drag & drop a file or paste an image from the clipboard": "alternativ, trageți și plasați un fișier sau lipiți o imagine din clipboard",
     "File too large, to display a preview. Please download the attachment.": "Fișierul este prea mare pentru a afișa o previzualizare. Vă rugăm să descărcaţi fișierul.",
     "Remove attachment": "Eliminați fișierul atașat",
     "Your browser does not support uploading encrypted files. Please use a newer browser.": "Browserul dvs. nu acceptă încărcarea fișierelor criptate. Vă rugăm să folosiți un browser mai nou.",

--- a/i18n/ru.json
+++ b/i18n/ru.json
@@ -172,7 +172,7 @@
     "Cloned: '%s'": "Дублировано: '%s'",
     "The cloned file '%s' was attached to this document.": "Дубликат файла '%s' был прикреплен к этой записи.",
     "Attach a file": "Прикрепить файл",
-    "alternatively drag & drop a file or document an image from the clipboard": "так же можно перенести файл в окно браузера или вставить изображение из буфера",
+    "alternatively drag & drop a file or paste an image from the clipboard": "так же можно перенести файл в окно браузера или вставить изображение из буфера",
     "File too large, to display a preview. Please download the attachment.": "Файл слишком большой для отображения предпросмотра. Пожалуйста, скачайте прикрепленный файл.",
     "Remove attachment": "Удалить вложение",
     "Your browser does not support uploading encrypted files. Please use a newer browser.": "Ваш браузер не поддерживает отправку зашифрованных файлов. Используйте более новый браузер.",

--- a/i18n/sk.json
+++ b/i18n/sk.json
@@ -172,7 +172,7 @@
     "Cloned: '%s'": "Naklonované: '%s'",
     "The cloned file '%s' was attached to this document.": "K tomuto príspevku bol pripojený klonovaný súbor '%s'.",
     "Attach a file": "Priložiť súbor",
-    "alternatively drag & drop a file or document an image from the clipboard": "prípadne presuňte súbor myšou alebo vložte obrázok zo schránky",
+    "alternatively drag & drop a file or paste an image from the clipboard": "prípadne presuňte súbor myšou alebo vložte obrázok zo schránky",
     "File too large, to display a preview. Please download the attachment.": "Súbor je príliš veľký na zobrazenie ukážky. Stiahnite si prosím prílohu.",
     "Remove attachment": "Odstrániť prílohu",
     "Your browser does not support uploading encrypted files. Please use a newer browser.": "Váš prehliadač nepodporuje nahrávanie šifrovaných súborov. Použite prosím novší prehliadač.",

--- a/i18n/sl.json
+++ b/i18n/sl.json
@@ -172,7 +172,7 @@
     "Cloned: '%s'": "'%s' klonirana",
     "The cloned file '%s' was attached to this document.": "The cloned file '%s' was attached to this document.",
     "Attach a file": "Pripni datoteko",
-    "alternatively drag & drop a file or document an image from the clipboard": "alternatively drag & drop a file or document an image from the clipboard",
+    "alternatively drag & drop a file or paste an image from the clipboard": "alternatively drag & drop a file or paste an image from the clipboard",
     "File too large, to display a preview. Please download the attachment.": "File too large, to display a preview. Please download the attachment.",
     "Remove attachment": "Odstrani priponko",
     "Your browser does not support uploading encrypted files. Please use a newer browser.": "Tvoj brskalnik ne omogoča nalaganje zakodiranih datotek. Prosim uporabi novejši brskalnik.",

--- a/i18n/sv.json
+++ b/i18n/sv.json
@@ -172,7 +172,7 @@
     "Cloned: '%s'": "Cloned: '%s'",
     "The cloned file '%s' was attached to this document.": "The cloned file '%s' was attached to this document.",
     "Attach a file": "Attach a file",
-    "alternatively drag & drop a file or document an image from the clipboard": "alternatively drag & drop a file or document an image from the clipboard",
+    "alternatively drag & drop a file or paste an image from the clipboard": "alternatively drag & drop a file or paste an image from the clipboard",
     "File too large, to display a preview. Please download the attachment.": "File too large, to display a preview. Please download the attachment.",
     "Remove attachment": "Remove attachment",
     "Your browser does not support uploading encrypted files. Please use a newer browser.": "Your browser does not support uploading encrypted files. Please use a newer browser.",

--- a/i18n/th.json
+++ b/i18n/th.json
@@ -172,7 +172,7 @@
     "Cloned: '%s'": "โคลนแล้ว: '%s'",
     "The cloned file '%s' was attached to this document.": "การโคลนข้อมูลการฝากโค้ด มีไฟล์ '%s' แนบมาด้วย",
     "Attach a file": "แนบไฟล์",
-    "alternatively drag & drop a file or document an image from the clipboard": "หรือสามารถลากและวางไฟล์หรือวางรูปภาพจากคลิปบอร์ดได้",
+    "alternatively drag & drop a file or paste an image from the clipboard": "หรือสามารถลากและวางไฟล์หรือวางรูปภาพจากคลิปบอร์ดได้",
     "File too large, to display a preview. Please download the attachment.": "ไฟล์มีขนาดใหญ่เกินไปที่จะแสดงตัวอย่าง กรุณาดาวน์โหลดเป็นไฟล์แนบแทน",
     "Remove attachment": "ลบไฟล์แนบ",
     "Your browser does not support uploading encrypted files. Please use a newer browser.": "เบราว์เซอร์ของคุณไม่สนับสนุนการอัปโหลดไฟล์แบบเข้ารหัสได้ กรุณาใช้เบราว์เซอร์ที่ใหม่กว่า",

--- a/i18n/tr.json
+++ b/i18n/tr.json
@@ -172,7 +172,7 @@
     "Cloned: '%s'": "Klonlandı: '%s'",
     "The cloned file '%s' was attached to this document.": "Klonlanmış dosya '%s' bu yazıya eklendi.",
     "Attach a file": "Dosya ekle",
-    "alternatively drag & drop a file or document an image from the clipboard": "alternatif olarak dosyayı yapıştırabilir veya sürükleyip bırakabilirsiniz",
+    "alternatively drag & drop a file or paste an image from the clipboard": "alternatif olarak dosyayı yapıştırabilir veya sürükleyip bırakabilirsiniz",
     "File too large, to display a preview. Please download the attachment.": "Dosya önizleme için çok büyük. Lütfen eki indirin.",
     "Remove attachment": "Eki sil",
     "Your browser does not support uploading encrypted files. Please use a newer browser.": "Tarayıcınız şifreli dosyaları yüklemeyi desteklemiyor. Lütfen daha yeni bir tarayıcı kullanın.",

--- a/i18n/uk.json
+++ b/i18n/uk.json
@@ -172,7 +172,7 @@
     "Cloned: '%s'": "Дубльовано: '%s'",
     "The cloned file '%s' was attached to this document.": "Дублікат файлу '%s' був прикріплений до цього запису.",
     "Attach a file": "Прикріпити файл",
-    "alternatively drag & drop a file or document an image from the clipboard": "також можна перенести файл у вікно переглядача чи вставити зображення з буфера",
+    "alternatively drag & drop a file or paste an image from the clipboard": "також можна перенести файл у вікно переглядача чи вставити зображення з буфера",
     "File too large, to display a preview. Please download the attachment.": "Файл завеликий для відображення передогляду. Будь ласка, звантажте прикріплений файл.",
     "Remove attachment": "Видалити вкладення",
     "Your browser does not support uploading encrypted files. Please use a newer browser.": "Ваш переглядач не підтримує відправлення зашифрованих файлів. Використовуйте сучасніший переглядач.",

--- a/i18n/zh.json
+++ b/i18n/zh.json
@@ -172,7 +172,7 @@
     "Cloned: '%s'": "副本：“%s”",
     "The cloned file '%s' was attached to this document.": "副本“%s”已附加到此粘贴内容。",
     "Attach a file": "添加一个附件",
-    "alternatively drag & drop a file or document an image from the clipboard": "拖放文件或从剪贴板粘贴图片",
+    "alternatively drag & drop a file or paste an image from the clipboard": "拖放文件或从剪贴板粘贴图片",
     "File too large, to display a preview. Please download the attachment.": "文件过大，无法显示预览。请下载附件。",
     "Remove attachment": "移除附件",
     "Your browser does not support uploading encrypted files. Please use a newer browser.": "您的浏览器不支持上传加密的文件，请使用新版本的浏览器。",


### PR DESCRIPTION
Here paste refers to the act of "pasting" a copied item from the clipboard, not a document. The message is used in the templates and there was not updated, now the translation files mismatch.

## Changes
* undo attachment hint translation change