### PR TITLE
Use protected instead of private $_configuration

### DIFF
--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -25,7 +25,7 @@ class Configuration
      *
      * @var array
      */
-    private $_configuration;
+    protected $_configuration;
 
     /**
      * default configuration


### PR DESCRIPTION
I would like to make this little change.

Why?
Because we need to override the Configuration object.

Overriding the Configuration and not being able to use the constructed
`$_configuration` property is a shame.

## Changes

* We use `protected $_configuration` instead of `private $_configuration`. This
  way we can easily override the `$_configuration` property in the `Configuration` class
  by using a new `Configuration` object (extending the default one).

## Example

```php
class NewConfiguration extends \PrivateBin\Configuration
{
  public function __construct()
  {
    parent::__construct();
    $this->_configuration['main']['name'] = 'Awesome PrivateBin'; // This is now possible
  }
}

new \PrivateBin\Controller(new NewConfiguration()); // We use our new Configuration instance
```

## Usecases

This way we could perform something like this: (you get the idea)

```php
class EnvConfiguration extends \PrivateBin\Configuration
{
  public function __construct()
  {
    parent::__construct();
    $this->_configuration['main']['name'] = getenv('PRIVATEBIN_CONFIG_MAIN_NAME');
    // … with other envs
  }
}

new \PrivateBin\Controller(new EnvConfiguration());
```