### PR TITLE
Workflows for collaborators

### DIFF
--- a/.github/workflows/snyk-scan.yml
+++ b/.github/workflows/snyk-scan.yml
@@ -12,7 +12,7 @@ jobs:
   # https://github.com/snyk/actions/tree/master/php
   snyk-php:
     runs-on: ubuntu-latest
-    if: ${{ github.repository == 'PrivateBin/PrivateBin' }}
+    if: ${{ github.repository == 'PrivateBin/PrivateBin' && (github.event.pull_request.author_association == 'COLLABORATOR' || github.event.pull_request.author_association == 'OWNER') }}
     steps:
       - uses: actions/checkout@v5
       - name: Install Google Cloud Storage

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,8 @@
 name: Tests
 on:
   push:
+  pull_request:
+    branches: [ master ]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
It is annoying that snyk gets executed in PRs for this repo, but fails because the contributor has no access to our secret. Likewise there is no reason not to run the regular unit tests on contributors PRs as they don't use secrets.

## Changes
* disable running snyk if the triggering user doesn't have the permissions to access the snyk secret
* enable running our regular unit tests on PRs (the push occurs in a different repo, so doesn't trigger the pipeline in ours)
