### PR TITLE
Fix copy button visibility for markdown format

### DIFF
--- a/js/privatebin.js
+++ b/js/privatebin.js
@@ -2762,9 +2762,13 @@ jQuery.PrivateBin = (function($) {
 
             if (format === 'markdown') {
                 $plainText.removeClass('hidden');
+                // Show copy button for markdown format
+                $('#prettyMessageCopyBtn').removeClass('hidden');
                 $prettyMessage.addClass('hidden');
             } else {
                 $plainText.addClass('hidden');
+                // Show copy button for non-markdown formats
+                $('#prettyMessageCopyBtn').removeClass('hidden');
                 $prettyMessage.removeClass('hidden');
             }
         }
@@ -2881,6 +2885,8 @@ jQuery.PrivateBin = (function($) {
 
             $plainText.addClass('hidden');
             $prettyMessage.addClass('hidden');
+            // Also hide the copy button when hiding the view
+            $('#prettyMessageCopyBtn').addClass('hidden');
             $placeholder.addClass('hidden');
             AttachmentViewer.hideAttachmentPreview();
 

--- a/tpl/bootstrap.php
+++ b/tpl/bootstrap.php
@@ -619,11 +619,11 @@ endif;
 					<div id="placeholder" class="col-md-12 hidden"><?php echo I18n::_('+++ no document text +++'); ?></div>
 					<div id="attachmentPreview" class="col-md-12 text-center hidden"></div>
 					<h5 id="copyShortcutHint" class="col-md-12"><small id="copyShortcutHintText"></small></h5>
+					<button id="prettyMessageCopyBtn" class="col-md-12 hidden">
+						<span id="copyIcon" class="glyphicon glyphicon-duplicate" aria-hidden="true"></span>
+						<span id="copySuccessIcon" class="glyphicon glyphicon-ok text-success" aria-hidden="true"></span>
+					</button>
 					<div id="prettymessage" class="col-md-12 hidden">
-						<button id="prettyMessageCopyBtn">
-							<span id="copyIcon" class="glyphicon glyphicon-duplicate" aria-hidden="true"></span>
-							<span id="copySuccessIcon" class="glyphicon glyphicon-ok text-success" aria-hidden="true"></span>
-						</button>
 						<pre id="prettyprint" class="col-md-12 prettyprint linenums:1"></pre>
 					</div>
 					<div id="plaintext" class="col-md-12 hidden"></div>

--- a/tpl/bootstrap5.php
+++ b/tpl/bootstrap5.php
@@ -477,11 +477,11 @@ endif;
 					<div id="placeholder" class="col-md-12 hidden"><?php echo I18n::_('+++ no document text +++'); ?></div>
 					<div id="attachmentPreview" class="col-md-12 text-center hidden"></div>
 					<h6 id="copyShortcutHint" class="col-md-12"><small id="copyShortcutHintText"></small></h6>
+					<button type="button" id="prettyMessageCopyBtn" class="text-secondary opacity-05-1-hover col-md-12 hidden">
+						<svg id="copyIcon" fill="currentColor" aria-hidden="true"><use href="img/bootstrap-icons.svg#copy" /></svg>
+						<svg id="copySuccessIcon" class="text-success" fill="currentColor" aria-hidden="true"><use href="img/bootstrap-icons.svg#check" /></svg>
+					</button>
 					<div id="prettymessage" class="card col-md-12 hidden">
-						<button type="button" id="prettyMessageCopyBtn" class="text-secondary opacity-05-1-hover">
-							<svg id="copyIcon" fill="currentColor" aria-hidden="true"><use href="img/bootstrap-icons.svg#copy" /></svg>
-							<svg id="copySuccessIcon" class="text-success" fill="currentColor" aria-hidden="true"><use href="img/bootstrap-icons.svg#check" /></svg>
-						</button>
 						<pre id="prettyprint" class="card-body col-md-12 prettyprint linenums:1"></pre>
 					</div>
 					<div id="plaintext" class="col-md-12 hidden"></div>


### PR DESCRIPTION
## Problem
The copy button was hidden when viewing pastes in markdown format because it was located inside the `prettymessage` div, which gets hidden when the format is markdown.

## Solution
- Moved the copy button (`#prettyMessageCopyBtn`) outside the `prettymessage` div in both `bootstrap.php` and `bootstrap5.php` templates
- Added the `hidden` class to the button for consistent styling
- Updated the JavaScript in `privatebin.js` to explicitly control the button visibility independently of the `prettymessage` div

## Changes Made
1. **tpl/bootstrap.php**: Moved copy button outside `prettymessage` div
2. **tpl/bootstrap5.php**: Moved copy button outside `prettymessage` div  
3. **js/privatebin.js**: Updated `showPaste()` and `hide()` functions to control button visibility independently

## Testing
The copy button now remains visible and functional for both markdown and non-markdown paste formats.

Fixes #1703