### PR TITLE
Install PHP/composer unit testing dependencies globally for DevContainer

### DIFF
--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -8,8 +8,7 @@ ln -s ./conf.sample.php cfg/conf.php
 composer install --no-dev --optimize-autoloader
 
 # for PHP unit testing
-# composer require google/cloud-storage
-# composer install --optimize-autoloader
+composer require --global google/cloud-storage
 
 sudo chmod a+x "$(pwd)" && sudo rm -rf /var/www/html && sudo ln -s "$(pwd)" /var/www/html
 


### PR DESCRIPTION
Updated composer commands to require google/cloud-storage globally, so it does not end up in the git diff of `vendor`.

This helps with https://github.com/PrivateBin/PrivateBin/issues/1641 (but technically not solve it).
