### PR TITLE
Syncronize changelog with GitHub release doc (for CVE IDs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 ## 2.0.2 (2025-10-28)
 * CHANGED: Upgrading libraries to: DOMpurify 3.3.0
 * CHANGED: Refactored jQuery DOM element creation into plain JavaScript
-* FIXED: Sanitize file name in attachment size hint (CVE-2025-62796 / https://github.com/PrivateBin/PrivateBin/security/advisories/GHSA-867c-p784-5q6g)
+* FIXED: Sanitize file name in attachment size hint ([CVE-2025-62796](https://privatebin.info/reports/vulnerability-2025-10-28.html))
 * FIXED: PHP OPcache module is optional again (#1679)
 * FIXED: bootstrap template password peek input group display
 


### PR DESCRIPTION
Aka adding the CVE ID's. BTW GitHub will make the CVEs clickable automatically when published. As for the GitHub's own ID well yeah… I just kept it synchronous now. (Maybe it's not _that_ relevant to mention all that IDs.)
