### PR TITLE
Hide version by default

### DIFF
--- a/cfg/conf.sample.php
+++ b/cfg/conf.sample.php
@@ -139,6 +139,10 @@ languageselection = false
 ; Can be set to one these values: "none" / "zlib" (default).
 ; compression = "zlib"
 
+; Show the version in the templates. Defaults to false to prevent attackers from exploiting 0-days
+; or slow updaters.
+show_version = false
+
 [expire]
 ; expire value that is selected per default
 ; make sure the value exists in [expire_options]

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -69,6 +69,7 @@ class Configuration
             'cspheader'                => 'default-src \'none\'; base-uri \'self\'; form-action \'none\'; manifest-src \'self\'; connect-src * blob:; script-src \'self\' \'wasm-unsafe-eval\'; style-src \'self\'; font-src \'self\'; frame-ancestors \'none\'; frame-src blob:; img-src \'self\' data: blob:; media-src blob:; object-src blob:; sandbox allow-same-origin allow-scripts allow-forms allow-modals allow-downloads',
             'httpwarning'              => true,
             'compression'              => 'zlib',
+            'show_version'             => false,
         ),
         'expire' => array(
             'default' => '1week',

--- a/lib/Controller.php
+++ b/lib/Controller.php
@@ -463,7 +463,7 @@ class Controller
         $page->assign('BASEPATH', I18n::_($this->_conf->getKey('basepath')));
         $page->assign('STATUS', I18n::_($this->_status));
         $page->assign('ISDELETED', $this->_is_deleted);
-        $page->assign('VERSION', self::VERSION);
+        $page->assign('VERSION',$this->_conf->getKey('show_version') ? self::VERSION : "");
         $page->assign('DISCUSSION', $this->_conf->getKey('discussion'));
         $page->assign('OPENDISCUSSION', $this->_conf->getKey('opendiscussion'));
         $page->assign('MARKDOWN', array_key_exists('markdown', $formatters));


### PR DESCRIPTION
The Privatebin version was always displayed in the templates. While of course it is nice to see the version of the Privatebin running, it makes it easier and trivial for attackers to find outdated instances of it and exploit them. Especially if a 0-day is found in one of the versions and actively being exploited.

Of course, seeing the version gives the end user some assurance that the server admin does not host an outdated version, but this can be easily spoofed by the server administrator as well.

Hence I think the default of not showing the version is better. This changes a default, but for security reasons, I think it is warranted. Also this change should not be breaking unless I overlooked something.

<!-- This is a template for your Pull Request. This are just some suggestions for you. You do not have to use all of them. -->

<!-- If your PR fixes an issue, mention it here. You can also just copy the URL - GitHub will convert it for you.
If this PR fixes several issues, please prepend each issue url/number with the word "fix"/"fixes" or "close"/"closes" as this automatically closes the issues you mentioned when the PR is merged.
-->


## Changes
<!-- List all the changes you have done -->
* Better protect against attacks against known vulnerable versions by hiding it


## Disclosure
* [ ] I do have used an AI/LLM tool for the work in this PR.
* [x] I have **not** used an AI/LLM tool for the work in this PR.