### PR TITLE
Fix: Focus modals when opened for accessibility

### DIFF
--- a/js/privatebin.js
+++ b/js/privatebin.js
@@ -2316,6 +2316,10 @@ jQuery.PrivateBin = (function($) {
             $loadconfirmClose.off('click.close');
             $loadconfirmClose.on('click.close', Controller.newPaste);
 
+            $loadconfirmmodal.on('shown.bs.modal', () => {
+                $loadconfirmOpenNow.trigger('focus');
+            });
+
             if (typeof bootstrap !== 'undefined' && bootstrap.Tooltip.VERSION) {
                 (new bootstrap.Modal($loadconfirmmodal[0])).show();
             } else {
@@ -4196,6 +4200,10 @@ jQuery.PrivateBin = (function($) {
                     localeConfiguration.timeZone = 'UTC';
                     sendEmailAndHideModal();
                 });
+                $emailconfirmmodal.on('shown.bs.modal', () => {
+                    $emailconfirmTimezoneCurrent.trigger('focus');
+                });
+
                 if (bootstrap5EmailConfirmModal) {
                     bootstrap5EmailConfirmModal.show();
                 } else {

--- a/js/privatebin.js
+++ b/js/privatebin.js
@@ -2317,6 +2317,10 @@ jQuery.PrivateBin = (function($) {
             $loadconfirmClose.off('click.close');
             $loadconfirmClose.on('click.close', Controller.newPaste);
 
+            $loadconfirmmodal.on('shown.bs.modal', () => {
+                $loadconfirmOpenNow.trigger('focus');
+            });
+
             if (typeof bootstrap !== 'undefined' && bootstrap.Tooltip.VERSION) {
                 (new bootstrap.Modal($loadconfirmmodal[0])).show();
             } else {
@@ -4192,6 +4196,10 @@ jQuery.PrivateBin = (function($) {
                     }
                     triggerEmailSend(emailBody);
                 }
+
+                $emailconfirmmodal.on('shown.bs.modal', () => {
+                    $emailconfirmTimezoneUtc.trigger('focus');
+                });
 
                 $emailconfirmTimezoneCurrent.off('click.sendEmailCurrentTimezone');
                 $emailconfirmTimezoneCurrent.on('click.sendEmailCurrentTimezone', sendEmailAndHideModal);

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -122,7 +122,7 @@ class Configuration
             'js/kjua-0.10.0.js'      => 'sha512-BYj4xggowR7QD150VLSTRlzH62YPfhpIM+b/1EUEr7RQpdWAGKulxWnOvjFx1FUlba4m6ihpNYuQab51H6XlYg==',
             'js/legacy.js'           => 'sha512-RQEo1hxpNc37i+jz/D9/JiAZhG8GFx3+SNxjYnI7jUgirDIqrCSj6QPAAZeaidditcWzsJ3jxfEj5lVm7ZwTRQ==',
             'js/prettify.js'         => 'sha512-puO0Ogy++IoA2Pb9IjSxV1n4+kQkKXYAEUtVzfZpQepyDPyXk8hokiYDS7ybMogYlyyEIwMLpZqVhCkARQWLMg==',
-            'js/privatebin.js'       => 'sha512-/IEJKCrmYXO6DJF1/vjiwl/bJTykFJQvYy7FlAJRwf3vhaeI6C0T60w8gIDBBYsfDK54PSKSU3zDN6fU33flPg==',
+            'js/privatebin.js'       => 'sha512-U52jFm7xsPJsJ7M/sFF6GoEBLTQ4pcvNDN5z3JcH0P2xHokiV3YrhfSi6XgTnBANdnjAXmg9GfJf3Bs2yKAiug==',
             'js/purify-3.4.1.js'     => 'sha512-280a/Vb6fVFsYaeRrkuDp4EDmdYlt2XS+dlDEO/U9qljPrAraA2bIzHTNmP+9dpwPDDwTML+RS+h5iaagPwTzA==',
             'js/showdown-2.1.0.js'   => 'sha512-WYXZgkTR0u/Y9SVIA4nTTOih0kXMEd8RRV6MLFdL6YU8ymhR528NLlYQt1nlJQbYz4EW+ZsS0fx1awhiQJme1Q==',
             'js/zlib-1.3.2.js'       => 'sha512-RAhJgxg9siMIA8ky4c10Rc2zUgnK80olHB8Tt1IOYWY4Eh1WmrviQkDn+sgBlb38ZHq3tzufGC41kP360gmosQ==',


### PR DESCRIPTION
## Summary

When the load confirmation and email confirmation modals open, focus was not set on any interactive element. Users had to press Tab once before they could interact with the modal, which is an accessibility issue for keyboard and screen reader users.

## Changes

Added `shown.bs.modal` event handlers to focus the primary action button when each modal becomes visible:

- **Load confirmation modal**: focuses the "Open now" button
- **Email confirmation modal**: focuses the "Current timezone" button

This matches the existing pattern used by the password modal, which already focuses the password input field on `shown.bs.modal`.

## Note

The issue also mentions restoring focus to the invoking button after modal close. Bootstrap's default behavior already handles this for modals created via data attributes, but for programmatically triggered modals, this may need additional work. Happy to add that in a follow-up if needed.

Fixes #1801