### PR TITLE
docs: fix broken README references in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [![PrivateBin](https://cdn.rawgit.com/PrivateBin/assets/master/images/preview/logoSmall.png)](https://privatebin.info/)
+# [![PrivateBin](https://raw.githubusercontent.com/PrivateBin/assets/master/images/preview/logoSmall.png)](https://privatebin.info/)
 
 *Current version: 2.0.3*
 


### PR DESCRIPTION
## Summary
- Automated README maintenance for `PrivateBin/PrivateBin` focused on dead links and stale API references.

## Changed files
- `README.md`: 1 edit(s)

## Validation
- Reviewed README Markdown files only.
- Kept edits minimal and localized to broken references or outdated API endpoints.

Automated README maintenance pass focused on dead links and stale API references. If this saved you time, coffee on Base is always appreciated: 0x85a7d7eefac69d5f90615cf72a4dcc5657370e2c