### PR TITLE
fix(bootstrap5): left-align status alert text after handleNotification rerender

### DIFF
--- a/tpl/bootstrap5.php
+++ b/tpl/bootstrap5.php
@@ -378,7 +378,7 @@ if ($FILEUPLOAD) :
 <?php
 endif;
 ?>
-				<div id="status" role="alert" class="d-flex justify-content-between align-items-center alert alert-<?php echo $ISDELETED ? 'success' : 'info'; echo empty($STATUS) ? ' hidden' : '' ?>">
+				<div id="status" role="alert" class="d-flex align-items-center alert alert-<?php echo $ISDELETED ? 'success' : 'info'; echo empty($STATUS) ? ' hidden' : '' ?>">
 					<div>
 						<svg width="16" height="16" fill="currentColor" aria-hidden="true"><use href="img/bootstrap-icons.svg#info-circle" /></svg>
 						<?php echo I18n::encode($STATUS), PHP_EOL; ?>
@@ -386,7 +386,7 @@ endif;
 <?php
 if ($ISDELETED) :
 ?>
-					<button type="button" class="btn btn-secondary d-flex justify-content-center align-items-center gap-1" id="new-from-alert">
+					<button type="button" class="btn btn-secondary d-flex justify-content-center align-items-center gap-1 ms-auto" id="new-from-alert">
 						<svg width="16" height="16" fill="currentColor" aria-hidden="true"><use href="img/bootstrap-icons.svg#repeat" /></svg>
 						<?php echo I18n::_('Start over'), PHP_EOL; ?>
 					</button>

--- a/tpl/bootstrap5.php
+++ b/tpl/bootstrap5.php
@@ -378,7 +378,7 @@ if ($FILEUPLOAD) :
 <?php
 endif;
 ?>
-				<div id="status" role="alert" class="d-flex align-items-center alert alert-<?php echo $ISDELETED ? 'success' : 'info'; echo empty($STATUS) ? ' hidden' : '' ?>">
+				<div id="status" role="alert" class="d-flex align-items-center gap-2 alert alert-<?php echo $ISDELETED ? 'success' : 'info'; echo empty($STATUS) ? ' hidden' : '' ?>">
 					<div>
 						<svg width="16" height="16" fill="currentColor" aria-hidden="true"><use href="img/bootstrap-icons.svg#info-circle" /></svg>
 						<?php echo I18n::encode($STATUS), PHP_EOL; ?>


### PR DESCRIPTION
This PR fixes #1833

## Changes

* `tpl/bootstrap5.php`: drop `justify-content-between` from the `#status` alert's flex container so the icon and text stay together on the left after `Alert.showStatus()` rerenders the alert into two flex children.
* `tpl/bootstrap5.php`: add `ms-auto` to the `#new-from-alert` button so it remains right-aligned in the deleted-paste case (the only case that originally needed `justify-content-between`).

Before:
<img width="2308" height="906" alt="CleanShot 2026-05-02 at 12 51 43@2x" src="https://github.com/user-attachments/assets/d79b786c-9c44-4717-9161-5069511fd41f" />

After:
<img width="2236" height="858" alt="CleanShot 2026-05-02 at 12 59 56@2x" src="https://github.com/user-attachments/assets/ce9f4ebd-6305-4773-a29e-d348102759f5" />


## ToDo

* [x] Verify the cloned-attachment status message left-aligns
* [x] Verify the deleted-paste "Start over" button still right-aligns
* [x] Confirm `tpl/bootstrap.php` (Bootstrap 3) is unchanged

## Disclosure

* [x] I do have used an AI/LLM tool for the work in this PR.
* [ ] I have **not** used an AI/LLM tool for the work in this PR.

Used Claude (Anthropic) to help draft the patch and PR text. Verified the diff manually against the JS handleNotification flow before pushing.

## Why this works

`js/privatebin.js` `handleNotification` clears the alert and re-injects two siblings (`<div>` with the icon, then a `<span>` with the translated message). With the parent's `justify-content-between`, those two siblings get pushed to opposite ends — the issue exactly. Removing the parent's `justify-content-between` makes the icon + text flow naturally left-to-right. The deleted-paste UI still needs the "Start over" button anchored to the right; `ms-auto` on the button reproduces that anchor without requiring a rule on the parent.

The Bootstrap 3 template (`tpl/bootstrap.php`) doesn't apply `d-flex justify-content-between` to `#status`, so it isn't affected.