### PR TITLE
harden github actions

### DIFF
--- a/.github/workflows/codacy-analysis.yml
+++ b/.github/workflows/codacy-analysis.yml
@@ -17,18 +17,20 @@ on:
   schedule:
     - cron: '45 16 * * 1'
 
-permissions:
-  contents: read
-  security-events: write
+permissions: {}
 
 jobs:
   codacy-security-scan:
     name: Codacy Security Scan
+    permissions:
+      security-events: write
     runs-on: ubuntu-latest
     steps:
       # Checkout the repository to the GitHub Actions runner
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Remove folders causing errors in report
         run: rm -rf doc img *.md

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -18,13 +18,13 @@ on:
   schedule:
     - cron: '28 22 * * 5'
 
-permissions:
-  contents: read
-  security-events: write
+permissions: {}
 
 jobs:
   analyze:
     name: Analyze
+    permissions:
+      security-events: write
     runs-on: ubuntu-latest
 
     strategy:
@@ -38,6 +38,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v6
+      with:
+        persist-credentials: false
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -12,8 +12,7 @@ on:
       - 'js/package-lock.json'
       - .github/workflows/eslint.yml
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   eslint:
@@ -21,6 +20,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Set up Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ jobs:
       - name: Fetch changelog from tag
         uses: actions/checkout@v6
         with:
+          persist-credentials: false
           sparse-checkout: CHANGELOG.md
           sparse-checkout-cone-mode: false
 
@@ -32,8 +33,8 @@ jobs:
     steps:
       - name: Collect artifacts
         run: |
-          wget -q https://github.com/PrivateBin/PrivateBin/archive/refs/tags/${GITHUB_REF_NAME}.tar.gz
-          wget -q https://github.com/PrivateBin/PrivateBin/archive/refs/tags/${GITHUB_REF_NAME}.zip
+          wget -q "https://github.com/PrivateBin/PrivateBin/archive/refs/tags/${GITHUB_REF_NAME}.tar.gz"
+          wget -q "https://github.com/PrivateBin/PrivateBin/archive/refs/tags/${GITHUB_REF_NAME}.zip"
 
       - name: Generate hashes
         shell: bash

--- a/.github/workflows/snyk-scan.yml
+++ b/.github/workflows/snyk-scan.yml
@@ -9,13 +9,13 @@ on:
   pull_request:
     branches: [ master ]
 
-permissions:
-  contents: read
-  security-events: write
+permissions: {}
 
 jobs:
   # https://github.com/snyk/actions/tree/master/php
   snyk-php:
+    permissions:
+      security-events: write
     runs-on: ubuntu-latest
     if: |
       github.repository == 'PrivateBin/PrivateBin' && (
@@ -25,6 +25,8 @@ jobs:
       github.event.pull_request.author_association == 'OWNER' )
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Run Snyk to check for vulnerabilities
         uses: snyk/actions/php@master
         continue-on-error: true # To make sure that SARIF upload gets called

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v6
+      with:
+        persist-credentials: false
     - name: Validate composer.json and composer.lock
       run: composer validate
     - name: Install dependencies
@@ -42,6 +44,8 @@ jobs:
     # let's get started!
     - name: Checkout
       uses: actions/checkout@v6
+      with:
+        persist-credentials: false
 
     # cache PHP extensions
     - name: Setup cache environment
@@ -121,7 +125,7 @@ jobs:
     name: PHP configuration combination unit tests
     runs-on: ubuntu-latest
     env:
-      php-version: '8.4'
+      php-version: '8.5'
       extensions: gd, sqlite3
       extensions-cache-key-name: phpextensions
 
@@ -130,6 +134,8 @@ jobs:
     # let's get started!
     - name: Checkout
       uses: actions/checkout@v6
+      with:
+        persist-credentials: false
 
     # cache PHP extensions
     - name: Setup cache environment
@@ -214,11 +220,13 @@ jobs:
 
     - name: Checkout
       uses: actions/checkout@v6
+      with:
+        persist-credentials: false
 
     - name: Setup Node
       uses: actions/setup-node@v6
       with:
-        node-version: '18'
+        node-version: '20'
         cache: 'npm'
         cache-dependency-path: 'js/package-lock.json'
 


### PR DESCRIPTION
## Changes
- restrict all default permissions
- content: read is not necessary for public repos
- security-events: write is needed for CodeQL uploads of SARIF reports
- persist-credentials: false prevents any github token to remain configured in the checked out repo (not necessary when not intending to push from the action)

## Disclosure
* [x] I have **not** used an AI/LLM tool for the work in this PR.
