### PR TITLE
fix: cast statusCode to int before strict comparison in YourlsProxy

### DIFF
--- a/lib/Proxy/YourlsProxy.php
+++ b/lib/Proxy/YourlsProxy.php
@@ -65,7 +65,7 @@ class YourlsProxy extends AbstractProxy
      */
     protected function _extractShortUrl(array $data): ?string
     {
-        if (($data['statusCode'] ?? 0) === 200) {
+        if ((int) ($data['statusCode'] ?? 0) === 200) {
             return $data['shorturl'] ?? 0;
         }
         return null;

--- a/tst/YourlsProxyTest.php
+++ b/tst/YourlsProxyTest.php
@@ -51,6 +51,16 @@ class YourlsProxyTest extends TestCase
         $this->assertEquals($yourls->getUrl(), 'https://example.com/1');
     }
 
+    public function testYourlsProxyWithStringStatusCode(): void
+    {
+        // YOURLS API returns statusCode as a string "200", not integer 200
+        file_put_contents($this->_mock_yourls_service, '{"shorturl":"https:\/\/example.com\/1","statusCode":"200"}');
+
+        $yourls = new YourlsProxy($this->_conf, 'https://example.com/?foo#bar');
+        $this->assertFalse($yourls->isError());
+        $this->assertEquals($yourls->getUrl(), 'https://example.com/1');
+    }
+
     /**
      * @dataProvider providerInvalidUrl
      */


### PR DESCRIPTION
This PR fixes #1844

## Changes
* Cast `statusCode` to `int` before strict comparison in `YourlsProxy::_extractShortUrl()` — YOURLS API returns `statusCode` as a string `"200"`, which broke strict `===` comparison introduced in 2.0.4
* Add `testYourlsProxyWithStringStatusCode` test case covering string `statusCode` responses

## Disclosure
* [x] I do have used an AI/LLM tool for the work in this PR.
* [ ] I have **not** used an AI/LLM tool for the work in this PR.