### PR TITLE
fix: preview dropped attachments

### DIFF
--- a/js/privatebin.js
+++ b/js/privatebin.js
@@ -3283,7 +3283,11 @@ jQuery.PrivateBin = (function($) {
                         }
 
                         if (Editor.isPreview()) {
-                            me.handleAttachmentPreview($attachmentPreview, dataURL);
+                            me.handleBlobAttachmentPreview(
+                                $attachmentPreview,
+                                dataURL,
+                                me.getAttachmentMimeType(dataURL)
+                            );
                             $attachmentPreview.removeClass('hidden');
                         }
 

--- a/js/test/AttachmentViewer.js
+++ b/js/test/AttachmentViewer.js
@@ -176,66 +176,70 @@ describe('AttachmentViewer', function () {
                 const clean = jsdom(),
                     originalFileReader = global.FileReader;
 
-                $('body').html(
-                    '<nav><div id="navbar"><ul><li id="attach" class="' +
-                    'dropdown"><a href="#" class="dropdown-toggle" ' +
-                    'aria-expanded="false">Attach a file</a><ul ' +
-                    'class="dropdown-menu"><li id="filewrap"><div><input ' +
-                    'type="file" id="file" name="file" /></div></li><li ' +
-                    'id="customattachment" class="hidden"></li><li><a ' +
-                    'id="fileremovebutton" href="#">Remove attachment</a>' +
-                    '</li></ul></li></ul></div></nav><ul id="editorTabs" ' +
-                    'class="nav nav-tabs hidden"><li role="presentation" ' +
-                    'class="active"><a id="messageedit" href="#">Editor</a>' +
-                    '</li><li role="presentation"><a id="messagepreview" ' +
-                    'href="#">Preview</a></li></ul><div id="placeholder" ' +
-                    'class="hidden">+++ no document text +++</div><div ' +
-                    'id="prettymessage" class="hidden"><pre id="prettyprint" ' +
-                    'class="prettyprint linenums:1"></pre></div><div ' +
-                    'id="plaintext" class="hidden"></div><p><textarea ' +
-                    'id="message" name="message" cols="80" rows="25" ' +
-                    'class="form-control hidden"></textarea></p><div ' +
-                    'id="attachmentPreview" class="col-md-12 text-center hidden">' +
-                    '</div><div id="attachment" class="hidden"></div><div ' +
-                    'id="dragAndDropFileName"></div><div id="dropzone" ' +
-                    'class="hidden"></div><div id="templates"><div ' +
-                    'id="attachmenttemplate" role="alert" class="attachment ' +
-                    'hidden alert alert-info"><span class="glyphicon ' +
-                    'glyphicon-download-alt" aria-hidden="true"></span><a ' +
-                    'class="alert-link">Download attachment</a></div></div>'
-                );
+                try {
+                    $('body').html(
+                        '<nav><div id="navbar"><ul><li id="attach" class="' +
+                        'dropdown"><a href="#" class="dropdown-toggle" ' +
+                        'aria-expanded="false">Attach a file</a><ul ' +
+                        'class="dropdown-menu"><li id="filewrap"><div><input ' +
+                        'type="file" id="file" name="file" /></div></li><li ' +
+                        'id="customattachment" class="hidden"></li><li><a ' +
+                        'id="fileremovebutton" href="#">Remove attachment</a>' +
+                        '</li></ul></li></ul></div></nav><ul id="editorTabs" ' +
+                        'class="nav nav-tabs hidden"><li role="presentation" ' +
+                        'class="active"><a id="messageedit" href="#">Editor</a>' +
+                        '</li><li role="presentation"><a id="messagepreview" ' +
+                        'href="#">Preview</a></li></ul><div id="placeholder" ' +
+                        'class="hidden">+++ no document text +++</div><div ' +
+                        'id="prettymessage" class="hidden"><pre id="prettyprint" ' +
+                        'class="prettyprint linenums:1"></pre></div><div ' +
+                        'id="plaintext" class="hidden"></div><p><textarea ' +
+                        'id="message" name="message" cols="80" rows="25" ' +
+                        'class="form-control hidden"></textarea></p><div ' +
+                        'id="attachmentPreview" class="col-md-12 text-center hidden">' +
+                        '</div><div id="attachment" class="hidden"></div><div ' +
+                        'id="dragAndDropFileName"></div><div id="dropzone" ' +
+                        'class="hidden"></div><div id="templates"><div ' +
+                        'id="attachmenttemplate" role="alert" class="attachment ' +
+                        'hidden alert alert-info"><span class="glyphicon ' +
+                        'glyphicon-download-alt" aria-hidden="true"></span><a ' +
+                        'class="alert-link">Download attachment</a></div></div>'
+                    );
 
-                global.FileReader = function() {
-                    this.readAsDataURL = function() {
-                        this.onload({
-                            target: {
-                                result: 'data:application/pdf;base64,JVBERi0x'
-                            }
-                        });
+                    global.FileReader = function() {
+                        this.readAsDataURL = function() {
+                            this.onload({
+                                target: {
+                                    result: 'data:application/pdf;base64,JVBERi0x'
+                                }
+                            });
+                        };
                     };
-                };
 
-                $.PrivateBin.Model.init();
-                $.PrivateBin.PasteViewer.init();
-                $.PrivateBin.Editor.init();
-                $.PrivateBin.TopNav.init();
-                $.PrivateBin.AttachmentViewer.init();
+                    $.PrivateBin.Model.init();
+                    $.PrivateBin.PasteViewer.init();
+                    $.PrivateBin.Editor.init();
+                    $.PrivateBin.TopNav.init();
+                    $.PrivateBin.AttachmentViewer.init();
 
-                $('#messagepreview').trigger('click');
-                Object.defineProperty($('#file')[0], 'files', {
-                    value: [{name: 'preview.pdf'}],
-                    configurable: true
-                });
-                $('#file').trigger('change');
+                    $('#messagepreview').trigger('click');
+                    Object.defineProperty($('#file')[0], 'files', {
+                        value: [{name: 'preview.pdf'}],
+                        configurable: true
+                    });
+                    $('#file').trigger('change');
 
-                const result =
-                    !$('#attachmentPreview').hasClass('hidden') &&
-                    $('#attachmentPreview embed.pdfPreview').attr('src') ===
-                        'data:application/pdf;base64,JVBERi0x';
+                    const result =
+                        !$('#attachmentPreview').hasClass('hidden') &&
+                        $('#attachmentPreview embed.pdfPreview').attr('src') ===
+                            'data:application/pdf;base64,JVBERi0x';
 
-                global.FileReader = originalFileReader;
-                clean();
-                assert.ok(result);
+                    assert.ok(result);
+                } finally {
+                    $('#messageedit').trigger('click');
+                    global.FileReader = originalFileReader;
+                    clean();
+                }
             }
         );
 

--- a/js/test/AttachmentViewer.js
+++ b/js/test/AttachmentViewer.js
@@ -170,5 +170,74 @@ describe('AttachmentViewer', function () {
             }
         );
 
+        it(
+            'previews file input attachments while editing markdown preview',
+            function() {
+                const clean = jsdom(),
+                    originalFileReader = global.FileReader;
+
+                $('body').html(
+                    '<nav><div id="navbar"><ul><li id="attach" class="' +
+                    'dropdown"><a href="#" class="dropdown-toggle" ' +
+                    'aria-expanded="false">Attach a file</a><ul ' +
+                    'class="dropdown-menu"><li id="filewrap"><div><input ' +
+                    'type="file" id="file" name="file" /></div></li><li ' +
+                    'id="customattachment" class="hidden"></li><li><a ' +
+                    'id="fileremovebutton" href="#">Remove attachment</a>' +
+                    '</li></ul></li></ul></div></nav><ul id="editorTabs" ' +
+                    'class="nav nav-tabs hidden"><li role="presentation" ' +
+                    'class="active"><a id="messageedit" href="#">Editor</a>' +
+                    '</li><li role="presentation"><a id="messagepreview" ' +
+                    'href="#">Preview</a></li></ul><div id="placeholder" ' +
+                    'class="hidden">+++ no document text +++</div><div ' +
+                    'id="prettymessage" class="hidden"><pre id="prettyprint" ' +
+                    'class="prettyprint linenums:1"></pre></div><div ' +
+                    'id="plaintext" class="hidden"></div><p><textarea ' +
+                    'id="message" name="message" cols="80" rows="25" ' +
+                    'class="form-control hidden"></textarea></p><div ' +
+                    'id="attachmentPreview" class="col-md-12 text-center hidden">' +
+                    '</div><div id="attachment" class="hidden"></div><div ' +
+                    'id="dragAndDropFileName"></div><div id="dropzone" ' +
+                    'class="hidden"></div><div id="templates"><div ' +
+                    'id="attachmenttemplate" role="alert" class="attachment ' +
+                    'hidden alert alert-info"><span class="glyphicon ' +
+                    'glyphicon-download-alt" aria-hidden="true"></span><a ' +
+                    'class="alert-link">Download attachment</a></div></div>'
+                );
+
+                global.FileReader = function() {
+                    this.readAsDataURL = function() {
+                        this.onload({
+                            target: {
+                                result: 'data:application/pdf;base64,JVBERi0x'
+                            }
+                        });
+                    };
+                };
+
+                $.PrivateBin.Model.init();
+                $.PrivateBin.PasteViewer.init();
+                $.PrivateBin.Editor.init();
+                $.PrivateBin.TopNav.init();
+                $.PrivateBin.AttachmentViewer.init();
+
+                $('#messagepreview').trigger('click');
+                Object.defineProperty($('#file')[0], 'files', {
+                    value: [{name: 'preview.pdf'}],
+                    configurable: true
+                });
+                $('#file').trigger('change');
+
+                const result =
+                    !$('#attachmentPreview').hasClass('hidden') &&
+                    $('#attachmentPreview embed.pdfPreview').attr('src') ===
+                        'data:application/pdf;base64,JVBERi0x';
+
+                global.FileReader = originalFileReader;
+                clean();
+                assert.ok(result);
+            }
+        );
+
     });
 });


### PR DESCRIPTION
## Summary
- Fix dropped/file-input attachments while the editor is in preview mode by routing the data URL through the existing attachment preview helper.
- Add regression coverage for previewing a PDF data URL from the file input while markdown preview is active.

Fixes #1863.

## Verification
- `cd js && npx eslint privatebin.js test/AttachmentViewer.js`
- Rebased onto current `master` on 2026-06-21.

No visual styling changes; this only restores the existing attachment preview behavior.

## AI disclosure
This pull request was prepared with assistance from OpenAI Codex (GPT-5) in the user's local development environment. I reviewed the scoped diff and verification output before opening the PR.
