### PR TITLE
fix: sandbox PDF attachment previews

### DIFF
--- a/js/privatebin.js
+++ b/js/privatebin.js
@@ -3335,13 +3335,13 @@ jQuery.PrivateBin = (function($) {
                     audio.appendChild(source);
                     $targetElement[0].appendChild(audio);
                 } else if (mimeType.toLowerCase().endsWith('/pdf')) {
-                    const embed = document.createElement('embed');
-                    embed.setAttribute('src', blobUrl);
-                    embed.setAttribute('type', 'application/pdf');
-                    embed.setAttribute('class', 'pdfPreview');
+                    const iframe = document.createElement('iframe');
+                    iframe.setAttribute('src', blobUrl);
+                    iframe.setAttribute('sandbox', 'allow-scripts allow-downloads allow-top-navigation-by-user-activation');
+                    iframe.setAttribute('class', 'pdfPreview');
                     // Fallback for browsers, that don't support the vh unit
-                    embed.style.height = window.innerHeight + 'px';
-                    $targetElement[0].appendChild(embed);
+                    iframe.style.height = window.innerHeight + 'px';
+                    $targetElement[0].appendChild(iframe);
                 }
             }
         };

--- a/js/test/AttachmentViewer.js
+++ b/js/test/AttachmentViewer.js
@@ -170,5 +170,41 @@ describe('AttachmentViewer', function () {
             }
         );
 
+        it(
+            'previews PDFs in a sandboxed iframe',
+            function() {
+                const clean = jsdom();
+                $('body').html(
+                    '<div id="attachmentPreview" class="col-md-12 text-center hidden"></div>' +
+                    '<div id="attachment" class="hidden"></div>' +
+                    '<div id="templates">' +
+                        '<div id="attachmenttemplate" role="alert" class="attachment hidden alert alert-info">' +
+                            '<span class="glyphicon glyphicon-download-alt" aria-hidden="true"></span>' +
+                            '<a class="alert-link">Download attachment</a>' +
+                        '</div>' +
+                    '</div>'
+                );
+                $.PrivateBin.AttachmentViewer.init();
+                $.PrivateBin.AttachmentViewer.handleBlobAttachmentPreview(
+                    $('#attachmentPreview'),
+                    'blob:https://example.com/document.pdf',
+                    'application/pdf'
+                );
+
+                const $preview = $('#attachmentPreview iframe.pdfPreview');
+                assert.strictEqual($preview.length, 1);
+                assert.strictEqual(
+                    $preview.attr('src'),
+                    'blob:https://example.com/document.pdf'
+                );
+                assert.strictEqual(
+                    $preview.attr('sandbox'),
+                    'allow-scripts allow-downloads allow-top-navigation-by-user-activation'
+                );
+                assert.strictEqual($('#attachmentPreview embed').length, 0);
+                clean();
+            }
+        );
+
     });
 });


### PR DESCRIPTION
## Summary
- render PDF attachment previews in a sandboxed iframe instead of embed
- allow only scripts, downloads, and user-activated top navigation for PDF preview iframes
- add a focused test covering the iframe, sandbox attribute, source URL, and absence of embed

Fixes #1864.

## Test
- `node -e "const fs=require('fs'); const {Readable}=require('stream'); const orig=fs.createReadStream; fs.createReadStream=function(path,...args){ if(path==='/etc/mime.types') return Readable.from(['application/pdf\\tpdf\\nimage/png\\tpng\\naudio/mpeg\\tmp3\\nvideo/mp4\\tmp4\\napplication/octet-stream\\tbin\\n']); return orig.call(this,path,...args); }; process.argv=['node','mocha','--reporter','xunit','--reporter-option','output=mocha-results.xml']; require('./node_modules/mocha/bin/mocha.js');"`

Note: the local macOS host lacks `/etc/mime.types`, so the command above supplies the same file stream the test harness expects on CI-like Linux hosts.