### PR TITLE
Remove history change test helper

### DIFF
--- a/js/privatebin.js
+++ b/js/privatebin.js
@@ -1727,23 +1727,6 @@ jQuery.PrivateBin = (function($) {
         };
 
         /**
-         * trigger a history (pop) state change
-         *
-         * used to test the UiHelper.historyChange private function
-         *
-         * @name   UiHelper.mockHistoryChange
-         * @function
-         * @param  {string} state   (optional) state to mock
-         */
-        me.mockHistoryChange = function(state)
-        {
-            if (typeof state === 'undefined') {
-                state = null;
-            }
-            historyChange($.Event('popstate', {originalEvent: new PopStateEvent('popstate', {state: state}), target: window}));
-        };
-
-        /**
          * initialize
          *
          * @name   UiHelper.init

--- a/js/test/UiHelper.js
+++ b/js/test/UiHelper.js
@@ -2,50 +2,6 @@
 var common = require('../common');
 
 describe('UiHelper', function () {
-    // TODO: As per https://github.com/tmpvar/jsdom/issues/1565 there is no navigation support in jsdom, yet.
-    // for now we use a mock function to trigger the event
-    describe('historyChange', function () {
-        this.timeout(30000);
-        beforeEach(function () {
-            $.PrivateBin.Helper.reset();
-            cleanup();
-        });
-
-        jsc.property(
-            'redirects to home, when the state is null',
-            common.jscUrl(false, false),
-            function (url) {
-                const expected = common.urlToString(url),
-                    clean = jsdom('', {url: expected});
-
-                $.PrivateBin.UiHelper.mockHistoryChange();
-                $.PrivateBin.Helper.reset();
-                var result = window.location.href;
-                clean();
-                return expected === result;
-            }
-        );
-
-        jsc.property(
-            'does not redirect to home, when a new document is created',
-            common.jscUrl(false),
-            jsc.nearray(common.jscBase64String()),
-            function (url, fragment) {
-                url.fragment = fragment.join('');
-                const expected = common.urlToString(url),
-                    clean = jsdom('', {url: expected});
-
-                $.PrivateBin.UiHelper.mockHistoryChange([
-                    {type: 'newpaste'}, '', expected
-                ]);
-                $.PrivateBin.Helper.reset();
-                var result = window.location.href;
-                clean();
-                return expected === result;
-            }
-        );
-    });
-
     describe('reloadHome', function () {
         // TODO triggers error messages in jsDOM since version 11
         /*
@@ -103,4 +59,3 @@ describe('UiHelper', function () {
         // TODO Did not find a way to test that, see isVisible test above
     });
 });
-


### PR DESCRIPTION
## Summary
- remove the UiHelper.mockHistoryChange helper that existed only for tests
- drop the historyChange tests that depended on the custom mock

Fixes #1841

## Tests
- `node --require <mime.types shim> ./node_modules/mocha/bin/mocha` from `js/` -> 116 passing

Note: this host does not provide `/etc/mime.types`, so the verification command preloaded a temporary fs.createReadStream shim for that exact file path.