### PR TITLE
fix: handle YOURLS 200 response without shorturl gracefully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # PrivateBin version history
 
 ## 2.0.6 (not yet released)
+* FIXED: Gracefully handle YOURLS replies with a 200 status code but no shorturl, instead of raising a TypeError
 
 ## 2.0.5 (2026-07-11)
 * CHANGED: Show OS-specific copy hotkey hint (Cmd+c on Mac, Ctrl+c on others) (#1506)

--- a/lib/Proxy/YourlsProxy.php
+++ b/lib/Proxy/YourlsProxy.php
@@ -66,7 +66,7 @@ class YourlsProxy extends AbstractProxy
     protected function _extractShortUrl(array $data): ?string
     {
         if ((int) ($data['statusCode'] ?? 0) === 200) {
-            return $data['shorturl'] ?? 0;
+            return $data['shorturl'] ?? null;
         }
         return null;
     }

--- a/tst/YourlsProxyTest.php
+++ b/tst/YourlsProxyTest.php
@@ -139,8 +139,9 @@ class YourlsProxyTest extends TestCase
     {
         // YOURLS may reply with statusCode 200 but without a shorturl field;
         // this must be handled gracefully as an error instead of raising a
-        // TypeError (the method is declared to return ?string)
-        file_put_contents($this->_mock_yourls_service, '{"statusCode":200}');
+        // TypeError (the method is declared to return ?string). YOURLS returns
+        // the status code as a string, so mirror that here.
+        file_put_contents($this->_mock_yourls_service, '{"statusCode":"200"}');
 
         $yourls = new YourlsProxy($this->_conf, 'https://example.com/?foo#bar');
         $this->assertTrue($yourls->isError());

--- a/tst/YourlsProxyTest.php
+++ b/tst/YourlsProxyTest.php
@@ -135,6 +135,18 @@ class YourlsProxyTest extends TestCase
         $this->assertEquals($yourls->getError(), 'Proxy error: Error parsing proxy response. This can be a configuration issue, like wrong or missing config keys.');
     }
 
+    public function testYourlsSuccessWithoutShortUrl()
+    {
+        // YOURLS may reply with statusCode 200 but without a shorturl field;
+        // this must be handled gracefully as an error instead of raising a
+        // TypeError (the method is declared to return ?string)
+        file_put_contents($this->_mock_yourls_service, '{"statusCode":200}');
+
+        $yourls = new YourlsProxy($this->_conf, 'https://example.com/?foo#bar');
+        $this->assertTrue($yourls->isError());
+        $this->assertEquals($yourls->getError(), 'Proxy error: Error parsing proxy response. This can be a configuration issue, like wrong or missing config keys.');
+    }
+
     public function testServerError()
     {
         // simulate some other server error that results in a non-JSON reply


### PR DESCRIPTION
This PR fixes a latent `TypeError` in the YOURLS URL-shortener proxy.

## Changes

* `YourlsProxy::_extractShortUrl()` fell back to int `0` when a YOURLS reply had `statusCode` 200 but no `shorturl` field. The method is declared to return `?string`, and the file uses `declare(strict_types=1)`, so returning `0` raises an uncaught `TypeError` that aborts paste creation instead of surfacing the intended "Error parsing proxy response" message. It now falls back to `null`, matching `ShlinkProxy`, so the existing graceful error path is taken.
* Added a regression test (`testYourlsSuccessWithoutShortUrl`) covering a `{"statusCode":200}` reply with no `shorturl`.
* Added a CHANGELOG entry.

## Disclosure

* [x] I do have used an AI/LLM tool for the work in this PR.
* [ ] I have **not** used an AI/LLM tool for the work in this PR.

I used Claude (Anthropic) as an assistant. I reviewed the one-line change, confirmed it matches the sibling `ShlinkProxy` behaviour, and verified the before/after against the real class under `declare(strict_types=1)` on PHP: returning `0` raises `TypeError: Return value must be of type ?string, int returned`, while `null` returns cleanly and takes the graceful error path. A CI/PHPUnit run is of course welcome.
