### PR TITLE
fix: render attachment preview when adding a file in preview mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * FIXED: Gracefully handle YOURLS replies with a 200 status code but no shorturl, instead of raising a TypeError
 * FIXED: Return "Invalid data." instead of HTTP 500 on malformed v2 JSON payloads (#1883)
 * FIXED: Dead PATH validation guard in Controller, the check for a missing trailing directory separator never ran (#1887)
+* FIXED: Render the attachment preview when adding a file while the editor is in preview mode (#1884)
 
 ## 2.0.5 (2026-07-11)
 * CHANGED: Show OS-specific copy hotkey hint (Cmd+c on Mac, Ctrl+c on others) (#1506)

--- a/js/privatebin.js
+++ b/js/privatebin.js
@@ -3230,11 +3230,15 @@ window.PrivateBin = (function () {
                         const dataURL = event.target.result;
                         if (dataURL) {
                             attachmentsData[index] = dataURL;
-                        }
 
-                        if (Editor.isPreview()) {
-                            me.handleAttachmentPreview(attachmentPreview, dataURL);
-                            attachmentPreview.classList.remove('hidden');
+                            if (Editor.isPreview()) {
+                                me.handleBlobAttachmentPreview(
+                                    attachmentPreview,
+                                    dataURL,
+                                    me.getAttachmentMimeType(dataURL)
+                                );
+                                attachmentPreview.classList.remove('hidden');
+                            }
                         }
 
                         TopNav.highlightFileupload();

--- a/js/test/AttachmentViewer.js
+++ b/js/test/AttachmentViewer.js
@@ -190,6 +190,68 @@ describe('AttachmentViewer', function () {
         )
     });
 
+    describe('readFileData()', function () {
+        afterEach(() => {
+            delete global.FileReader;
+        });
+
+        it('previews a newly added file while the editor is in preview mode',
+            async function() {
+                document.body.innerHTML = (
+                    '<div id="attachmentPreview" class="col-md-12 text-center hidden"></div>' +
+                    '<div id="attachment" class="hidden"></div>' +
+                    '<input type="file" id="file">' +
+                    '<div id="templates">' +
+                        '<div id="attachmenttemplate" role="alert" class="attachment hidden alert alert-info">' +
+                            '<span class="glyphicon glyphicon-download-alt" aria-hidden="true"></span>' +
+                            '<a class="alert-link">Download attachment</a>' +
+                        '</div>' +
+                    '</div>'
+                );
+                // jsdom-global does not expose FileReader as a global, but
+                // readFileData() checks for it before reading any file - the
+                // subclass additionally exposes each read as a promise, so the
+                // test can await the asynchronous read instead of guessing a
+                // delay ("loadend" fires after the "load" handler of the code
+                // under test has run)
+                const pendingReads = [];
+                global.FileReader = class extends window.FileReader {
+                    constructor() {
+                        super();
+                        pendingReads.push(new Promise(
+                            resolve => this.addEventListener('loadend', resolve)
+                        ));
+                    }
+                };
+
+                PrivateBin.AttachmentViewer.init();
+                PrivateBin.Model.init();
+
+                // pretend the editor is showing the preview tab
+                PrivateBin.Editor.isPreview = () => true;
+
+                const fileInput = document.getElementById('file');
+                Object.defineProperty(fileInput, 'files', {
+                    value: [new File(['GIF89a'], 'test.gif', {type: 'image/gif'})]
+                });
+                fileInput.dispatchEvent(new window.Event('change'));
+
+                // the file is read asynchronously
+                await Promise.all(pendingReads);
+
+                const attachmentPreview = document.getElementById('attachmentPreview');
+                assert.ok(
+                    attachmentPreview.querySelector('img'),
+                    'the image preview should have been rendered'
+                );
+                assert.ok(
+                    !attachmentPreview.classList.contains('hidden'),
+                    'the attachment preview should be visible'
+                );
+            }
+        )
+    });
+
     function mockCreateObjectUrl() {
         if (typeof window.URL.createObjectURL === 'undefined') {
             Object.defineProperty(


### PR DESCRIPTION
readFileData() called the non-existent me.handleAttachmentPreview(), left over from the data-URL to blob-URL refactor. Adding a file while the editor was in preview mode therefore threw
"TypeError: me.handleAttachmentPreview is not a function" and the preview never rendered (the upload data itself was unaffected).

Call the existing me.handleBlobAttachmentPreview() with the data URL and its mime type, mirroring the Editor.setPreview() code path which already previews attachments the same way. The preview is now also guarded by the dataURL check so getAttachmentMimeType() is never given an undefined value.

Fixes #1884

This PR fixes #1884

## Changes
* `js/privatebin.js`: in `AttachmentViewer.readFileData()`, replace the call to the non-existent `me.handleAttachmentPreview($attachmentPreview, dataURL)` with `me.handleBlobAttachmentPreview($attachmentPreview, dataURL, me.getAttachmentMimeType(dataURL))`, mirroring the `Editor.setPreview()` code path.
* Move the preview call inside the existing `if (dataURL)` guard, so `getAttachmentMimeType()` is never handed an undefined value.

## ToDo
* [x] Fix the undefined `handleAttachmentPreview` call so previews render when adding a file in preview mode
* [x] Guard the preview against a missing `dataURL`
* [x] Verify the JS syntax and confirm no regression in the existing mocha suite (pre-existing environment-only failure is unrelated)

## Disclosure
* [] I do have used an AI/LLM tool for the work in this PR.
* [x] I have **not** used an AI/LLM tool for the work in this PR.