### PR TITLE
Fix plural expiration units in email dates

### DIFF
--- a/js/privatebin.js
+++ b/js/privatebin.js
@@ -373,6 +373,9 @@ window.PrivateBin = (function () {
             let pieces = duration.split(/(\D+)/),
                 factor = pieces[0] || 0,
                 timespan = pieces[1] || pieces[0];
+            if (typeof timespan === 'string' && timespan.endsWith('s')) {
+                timespan = timespan.slice(0, -1);
+            }
             switch (timespan) {
                 case 'min':
                     return factor * minute;
@@ -6154,5 +6157,4 @@ if (typeof module === 'undefined' || !module.exports) {
         window.PrivateBin.Controller.init();
     });
 }
-
 

--- a/js/test/Helper.js
+++ b/js/test/Helper.js
@@ -3,6 +3,23 @@ const common = require('../common');
 const fc = require('fast-check');
 
 describe('Helper', function () {
+    describe('durationToSeconds', function () {
+        it('accepts plural expiration units used by server configuration', function () {
+            assert.strictEqual(PrivateBin.Helper.durationToSeconds('3days'), 259200);
+            assert.strictEqual(PrivateBin.Helper.durationToSeconds('6months'), 15552000);
+        });
+
+        it('calculates expiration dates from plural expiration units', function () {
+            const initialDate = new Date('2026-01-01T00:00:00Z');
+            const expirationDate = PrivateBin.Helper.calculateExpirationDate(initialDate, '3days');
+
+            assert.strictEqual(
+                new Date(expirationDate).toISOString(),
+                '2026-01-04T00:00:00.000Z'
+            );
+        });
+    });
+
     describe('secondsToHuman', function () {
         it('returns an array with a number and a word', () => {
             fc.assert(fc.property(fc.integer(), function (number) {

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -120,7 +120,7 @@ class Configuration
             'js/kjua-0.10.0.js'      => 'sha512-BYj4xggowR7QD150VLSTRlzH62YPfhpIM+b/1EUEr7RQpdWAGKulxWnOvjFx1FUlba4m6ihpNYuQab51H6XlYg==',
             'js/legacy.js'           => 'sha512-pRofxsrf5UItjiP22Dcjh3FAcBjF/n7h8U9/W5xqJk17U0N2U1oajhXypq/omo9jhwS1iVGOhWrRepoPeFns+w==',
             'js/prettify.js'         => 'sha512-puO0Ogy++IoA2Pb9IjSxV1n4+kQkKXYAEUtVzfZpQepyDPyXk8hokiYDS7ybMogYlyyEIwMLpZqVhCkARQWLMg==',
-            'js/privatebin.js'       => 'sha512-ah/QdETig/ovH1QPl9Ne+T3VvaP7Bj4Rd9Or9wqQgo5BHge9o02MxAlRGXUZpKviy/27OSzHgz2PwpnH/B2RZg==',
+            'js/privatebin.js'       => 'sha512-KhNbpdqJ0tleAUCSxVVUqBuYbAVeNyxIjs97MBxlyuvEkCPssS+DBlJRNA/yNSswyip64zcSWNEMyzLDx7B0GA==',
             'js/purify-3.4.12.js'    => 'sha512-Akf6HnAJZm0sWWWI4gp2GYff0NDnHUB02XJE5S7Hdq/Z5xtMjkuFacsDA8ZtViv1gi+onBxMhEMIaGyQeGxBng==',
             'js/showdown-2.1.0.js'   => 'sha512-WYXZgkTR0u/Y9SVIA4nTTOih0kXMEd8RRV6MLFdL6YU8ymhR528NLlYQt1nlJQbYz4EW+ZsS0fx1awhiQJme1Q==',
             'js/zlib-1.3.2.js'       => 'sha512-RAhJgxg9siMIA8ky4c10Rc2zUgnK80olHB8Tt1IOYWY4Eh1WmrviQkDn+sgBlb38ZHq3tzufGC41kP360gmosQ==',


### PR DESCRIPTION
Fixes #815

## Changes

* Normalize plural expiration-unit suffixes before converting configured durations to seconds.
* Add regression coverage for both direct conversion and email expiration-date calculation.
* Regenerate the JavaScript SRI hash for this isolated branch.

## Impact

Custom expiration options such as `3days` and `6months` now behave consistently in the PHP-rendered UI and JavaScript email flow. Existing singular values and the paste format are unchanged. This does not alter encryption, server-side storage, or privacy behavior.

## Validation

* JavaScript: 128 tests passing
* PHP: 266 tests passing, 6,505 assertions (the root-incompatible `ServerSaltTest` was excluded locally)
* ESLint: passed
* Composer manifest: valid; existing exact-version warnings remain
* SRI: independently verified with OpenSSL

## Disclosure

* [x] I have used an AI/LLM tool for the work in this PR.
* OpenAI Codex was used to investigate the issue, implement the change, add tests, and run validation under the contributor's direction. The complete AI-assisted workflow is recorded in the associated Codex conversation.

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.