### PR TITLE
Show the encrypted document size limit before upload

### DIFF
--- a/lib/Controller.php
+++ b/lib/Controller.php
@@ -474,6 +474,7 @@ class Controller
         $page->assign('BURNAFTERREADINGSELECTED', $this->_conf->getKey('burnafterreadingselected'));
         $page->assign('PASSWORD', $this->_conf->getKey('password'));
         $page->assign('FILEUPLOAD', $this->_conf->getKey('fileupload'));
+        $page->assign('SIZELIMIT', Filter::formatHumanReadableSize($this->_conf->getKey('sizelimit')));
         $page->assign('LANGUAGESELECTION', $languageselection);
         $page->assign('LANGUAGES', I18n::getLanguageLabels(I18n::getAvailableLanguages()));
         $page->assign('TEMPLATESELECTION', $templateselection);

--- a/tpl/bootstrap5.php
+++ b/tpl/bootstrap5.php
@@ -265,7 +265,10 @@ if ($FILEUPLOAD) :
 							<ul class="dropdown-menu px-2">
 								<li id="filewrap">
 									<div>
-										<input type="file" id="file" name="file" class="form-control" multiple />
+										<input type="file" id="file" name="file" class="form-control" aria-describedby="file-size-limit" multiple />
+									</div>
+									<div id="file-size-limit" class="form-text">
+										<?php echo I18n::_('Document is limited to %s of encrypted data.', $SIZELIMIT); ?>
 									</div>
 									<div id="dragAndDropFileName" class="dragAndDropFile"><?php echo I18n::_('alternatively drag & drop a file or paste an image from the clipboard'); ?></div>
 								</li>

--- a/tst/ControllerTest.php
+++ b/tst/ControllerTest.php
@@ -77,6 +77,31 @@ class ControllerTest extends TestCase
     /**
      * @runInSeparateProcess
      */
+    public function testViewDisplaysEncryptedDocumentSizeLimitForFileUploads()
+    {
+        $options                       = parse_ini_file(CONF, true);
+        $options['main']['fileupload'] = true;
+        $options['main']['sizelimit']  = 1234000;
+        Helper::createIniFile(CONF, $options);
+        ob_start();
+        new Controller;
+        $content = ob_get_contents();
+        ob_end_clean();
+        $this->assertStringContainsString(
+            'Document is limited to 1.23 MB of encrypted data.',
+            $content,
+            'outputs configured encrypted document size limit'
+        );
+        $this->assertMatchesRegularExpression(
+            '#<input[^>]+id="file"[^>]+aria-describedby="file-size-limit"[^>]*>#',
+            $content,
+            'associates the encrypted document size limit with the file input'
+        );
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
     public function testViewLanguageSelection()
     {
         $options                              = parse_ini_file(CONF, true);

--- a/tst/ViewTest.php
+++ b/tst/ViewTest.php
@@ -52,6 +52,7 @@ class ViewTest extends TestCase
         $page->assign('BURNAFTERREADINGSELECTED', false);
         $page->assign('PASSWORD', true);
         $page->assign('FILEUPLOAD', false);
+        $page->assign('SIZELIMIT', '10.00 MB');
         $page->assign('INFO', 'example');
         $page->assign('NOTICE', 'example');
         $page->assign('LANGUAGESELECTION', '');


### PR DESCRIPTION
Closes #95

## Changes

* Display the configured encrypted-document size limit in the attachment menu.
* Associate the explanatory text with the file input through `aria-describedby`.
* Add controller and rendered-view regression coverage.

## Impact

Users can see the server's encrypted payload limit before selecting an attachment. The wording intentionally describes encrypted data because paste text, attachment metadata, and encryption overhead share the same configured limit. No upload validation, paste format, encryption, or storage behavior changes.

## Screenshot

![Attachment menu showing the encrypted document size limit](https://raw.githubusercontent.com/Jose-Tejera/PrivateBin/pr-assets/.github/pr-assets/95-size-limit.png)

## Validation

* JavaScript: 126 tests passing
* PHP: 269 tests passing, 6,511 assertions
* Focused controller/view coverage: 6 tests, 16 assertions
* ESLint: passed
* Composer manifest: valid; existing exact-version warnings remain
* Manual Chromium check at desktop width: attachment dropdown opens and exposes the limit text to the file input

## Disclosure

* [x] I have used an AI/LLM tool for the work in this PR.
* OpenAI Codex was used to investigate the issue, implement the change, add tests, capture UI evidence, and run validation under the contributor's direction. The complete AI-assisted workflow is recorded in the associated Codex conversation.

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.