### PR TITLE
Use LONGBLOB for MySQL paste data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * FIXED: Gracefully handle YOURLS replies with a 200 status code but no shorturl, instead of raising a TypeError
 * FIXED: Return "Invalid data." instead of HTTP 500 on malformed v2 JSON payloads (#1883)
 * FIXED: Dead PATH validation guard in Controller, the check for a missing trailing directory separator never ran (#1887)
+* FIXED: MySQL/MariaDB paste data columns limited encrypted documents to 16 MiB (#1398)
 
 ## 2.0.5 (2026-07-11)
 * CHANGED: Show OS-specific copy hotkey hint (Cmd+c on Mac, Ctrl+c on others) (#1506)

--- a/doc/Installation.md
+++ b/doc/Installation.md
@@ -186,7 +186,7 @@ client):
 ```sql
 CREATE TABLE prefix_paste (
     dataid CHAR(16) NOT NULL,
-    data MEDIUMBLOB,
+    data LONGBLOB,
     expiredate INT,
     meta TEXT,
     PRIMARY KEY (dataid)
@@ -209,12 +209,15 @@ CREATE TABLE prefix_config (
 INSERT INTO prefix_config VALUES('VERSION', '2.0.5');
 ```
 
+The configured `sizelimit` and the MariaDB/MySQL `max_allowed_packet` setting
+may impose lower limits than the `LONGBLOB` column.
+
 In **PostgreSQL**, the `data`, `attachment`, `nickname` and `vizhash` columns
-need to be `TEXT` and not `BLOB` or `MEDIUMBLOB`. The key names in brackets,
+need to be `TEXT` and not `BLOB` or `LONGBLOB`. The key names in brackets,
 after `PRIMARY KEY`, need to be removed.
 
 In **Oracle**, the `data`, `attachment`, `nickname` and `vizhash` columns need
-to be `CLOB` and not `BLOB` or `MEDIUMBLOB`, the `id` column in the `config`
+to be `CLOB` and not `BLOB` or `LONGBLOB`, the `id` column in the `config`
 table needs to be `VARCHAR2(16)` and the `meta` column in the `paste` table
 and the `value` column in the `config` table need to be `VARCHAR2(4000)`.
 

--- a/lib/Data/Database.php
+++ b/lib/Data/Database.php
@@ -642,6 +642,8 @@ class Database extends AbstractData
                 return 'CLOB';
             case 'pgsql':
                 return 'TEXT';
+            case 'mysql':
+                return 'LONGBLOB';
             default:
                 return 'MEDIUMBLOB';
         }
@@ -866,6 +868,16 @@ class Database extends AbstractData
                     "\" MODIFY COLUMN \"data\" $attachmentType"
                 );
             }
+        }
+        if (
+            $this->_type === 'mysql' &&
+            version_compare($oldversion, '1.3', '>') &&
+            version_compare($oldversion, '2.0.5', '<=')
+        ) {
+            $this->_db->exec(
+                'ALTER TABLE "' . $this->_sanitizeIdentifier('paste') .
+                "\" MODIFY COLUMN \"data\" $attachmentType"
+            );
         }
         if (version_compare($oldversion, '1.7.1', '<=')) {
             if ($this->_supportsDropColumn()) {

--- a/tst/Data/DatabaseTest.php
+++ b/tst/Data/DatabaseTest.php
@@ -271,6 +271,28 @@ class DatabaseTest extends TestCase
         new Database($options);
     }
 
+    public function testPasteDataTypes()
+    {
+        $reflection     = new ReflectionClass(Database::class);
+        $database       = $reflection->newInstanceWithoutConstructor();
+        $type           = $reflection->getProperty('_type');
+        $attachmentType = $reflection->getMethod('_getAttachmentType');
+        $type->setAccessible(true);
+        $attachmentType->setAccessible(true);
+
+        foreach (
+            [
+                'mysql'  => 'LONGBLOB',
+                'oci'    => 'CLOB',
+                'pgsql'  => 'TEXT',
+                'sqlite' => 'MEDIUMBLOB',
+            ] as $driver => $expected
+        ) {
+            $type->setValue($database, $driver);
+            $this->assertSame($expected, $attachmentType->invoke($database));
+        }
+    }
+
     public function testTableUpgrade()
     {
         mkdir($this->_path);


### PR DESCRIPTION
Fixes #1398.

## What changed

- use `LONGBLOB` for the paste payload column on the PDO MySQL driver, which also covers MariaDB
- migrate existing MySQL/MariaDB schemas that have already passed the earlier 1.3 attachment migration
- keep the existing SQLite, PostgreSQL, Oracle, and fallback mappings unchanged
- update the manual schema and document that `sizelimit` and `max_allowed_packet` may remain lower limits
- add regression coverage for every driver-specific paste payload type

## Root cause

PrivateBin created the MySQL/MariaDB paste payload column as `MEDIUMBLOB`, whose 16 MiB capacity could reject otherwise permitted encrypted documents after an administrator raised both PrivateBin's size limit and the database packet limit.

## Compatibility and operational impact

The schema change is restricted to the PDO `mysql` driver. Existing releases at schema versions after 1.3 through 2.0.5 are upgraded with `ALTER TABLE ... MODIFY COLUMN`; older schemas already pass through the existing attachment migration, which now selects `LONGBLOB`. As with other MySQL schema migrations, administrators should account for possible table locking on large installations.

This does not change encryption, document contents, privacy behavior, or the configured application size limit.

## Validation

- PHPUnit: 267 tests, 6509 assertions
- PHP syntax checks passed for `lib/Data/Database.php` and `tst/Data/DatabaseTest.php`
- `composer validate --no-check-publish` passed with only the repository's existing exact-version warnings
- `git diff --check` passed

## AI assistance

OpenAI Codex was used to investigate the issue, implement the change, add tests, run validation, and prepare this pull request under the contributor's direction. The complete AI-assisted workflow is recorded in the associated Codex conversation.

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.