### PR TITLE
Fix browser history when opening the raw text view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * FIXED: Gracefully handle YOURLS replies with a 200 status code but no shorturl, instead of raising a TypeError
 * FIXED: Return "Invalid data." instead of HTTP 500 on malformed v2 JSON payloads (#1883)
 * FIXED: Dead PATH validation guard in Controller, the check for a missing trailing directory separator never ran (#1887)
+* FIXED: Returning from the raw text view no longer loses the document history entry (#503)
 
 ## 2.0.5 (2026-07-11)
 * CHANGED: Show OS-specific copy hotkey hint (Cmd+c on Mac, Ctrl+c on others) (#1506)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 * FIXED: Gracefully handle YOURLS replies with a 200 status code but no shorturl, instead of raising a TypeError
 * FIXED: Return "Invalid data." instead of HTTP 500 on malformed v2 JSON payloads (#1883)
 * FIXED: Dead PATH validation guard in Controller, the check for a missing trailing directory separator never ran (#1887)
-* FIXED: Returning from the raw text view no longer loses the document history entry (#503)
+* FIXED: Raw, Back, Clone and New navigation no longer loses or duplicates browser history entries (#503)
 
 ## 2.0.5 (2026-07-11)
 * CHANGED: Show OS-specific copy hotkey hint (Cmd+c on Mac, Ctrl+c on others) (#1506)

--- a/js/privatebin.js
+++ b/js/privatebin.js
@@ -5883,7 +5883,7 @@ window.PrivateBin = (function () {
 
             Alert.hideLoading();
             // only push new state if we are coming from a different one
-            if (Helper.baseUri() !== window.location) {
+            if (Helper.baseUri() !== window.location.href) {
                 history.pushState({ type: 'create' }, document.title, Helper.baseUri());
             }
 

--- a/js/privatebin.js
+++ b/js/privatebin.js
@@ -40,6 +40,7 @@ function draghover(element) {
     });
 }
 
+
 window.PrivateBin = (function () {
 
     /**
@@ -3966,24 +3967,19 @@ window.PrivateBin = (function () {
                 CryptTool.base58encode(Model.getPasteKey())
             );
 
-            // we use text/html instead of text/plain to avoid a bug when
-            // reloading the raw text view (it reverts to type text/html)
+            // Replace the document contents without document.open(), which
+            // replaces the active history entry and removes window listeners.
             const headElements = document.head.querySelectorAll(':not(noscript):not(script):not(link[type="text/css"])');
-
-            const newDoc = document.open('text/html', 'replace');
-            newDoc.write('<!DOCTYPE html><html><head>');
+            const newHead = document.createElement('head');
             for (let i = 0; i < headElements.length; ++i) {
-                newDoc.write(headElements[i].outerHTML);
+                newHead.appendChild(headElements[i].cloneNode(true));
             }
-            newDoc.write(
-                '</head><body><pre>' +
-                DOMPurify.sanitize(
-                    Helper.htmlEntities(paste),
-                    purifyHtmlConfig
-                ) +
-                '</pre></body></html>'
-            );
-            newDoc.close();
+            const newBody = document.createElement('body');
+            const rawPaste = document.createElement('pre');
+            rawPaste.textContent = paste;
+            newBody.appendChild(rawPaste);
+            document.head.replaceWith(newHead);
+            document.body.replaceWith(newBody);
         }
 
         /**

--- a/js/privatebin.js
+++ b/js/privatebin.js
@@ -1596,13 +1596,12 @@ window.PrivateBin = (function () {
          * @name   UiHelper.historyChange
          * @private
          * @function
-         * @param  {Event} event
+         * @param  {PopStateEvent} event
          */
         function historyChange(event) {
             let currentLocation = Helper.baseUri();
-            if (event.originalEvent.state === null && // no state object passed
-                event.target.location.href === currentLocation && // target location is home page
-                window.location.href === currentLocation // and we are not already on the home page
+            if (event.state === null && // no state object passed
+                window.location.href === currentLocation // target location is home page
             ) {
                 // redirect to home page
                 window.location.href = currentLocation;
@@ -1635,7 +1634,7 @@ window.PrivateBin = (function () {
             if (typeof state === 'undefined') {
                 state = null;
             }
-            historyChange({ originalEvent: new PopStateEvent('popstate', { state: state }), target: window });
+            historyChange(new PopStateEvent('popstate', { state: state }));
         };
 
         /**
@@ -6150,5 +6149,3 @@ if (typeof module === 'undefined' || !module.exports) {
         window.PrivateBin.Controller.init();
     });
 }
-
-

--- a/js/test/Controller.js
+++ b/js/test/Controller.js
@@ -1,0 +1,61 @@
+'use strict';
+require('../common');
+
+describe('Controller', function () {
+    describe('newPaste', function () {
+        function stubViewUpdates() {
+            const methods = {
+                TopNav: [
+                    'hideAllButtons',
+                    'resetInput',
+                    'setFormat',
+                    'showCreateButtons',
+                    'hideCustomAttachment'
+                ],
+                Alert: ['showLoading', 'hideLoading'],
+                PasteStatus: ['hideMessages'],
+                PasteViewer: ['hide', 'setFormat'],
+                Editor: ['resetInput', 'show', 'focusInput'],
+                AttachmentViewer: [
+                    'removeAttachment',
+                    'clearDragAndDrop',
+                    'removeAttachmentData'
+                ],
+                DiscussionViewer: ['prepareNewDiscussion']
+            };
+
+            Object.entries(methods).forEach(([module, names]) => {
+                names.forEach(name => {
+                    PrivateBin[module][name] = function () {};
+                });
+            });
+        }
+
+        it('does not add another history entry on the new document URL', function () {
+            const clean = globalThis.cleanup('', {url: 'https://example.com/path/'});
+            stubViewUpdates();
+            const initialHistoryLength = history.length;
+
+            PrivateBin.Controller.newPaste();
+
+            assert.strictEqual(history.length, initialHistoryLength);
+            assert.strictEqual(window.location.href, 'https://example.com/path/');
+            clean();
+        });
+
+        it('adds a history entry when leaving a viewed document', function () {
+            const clean = globalThis.cleanup('', {
+                url: 'https://example.com/path/?0123456789abcdef#key'
+            });
+            stubViewUpdates();
+            const initialHistoryLength = history.length;
+
+            PrivateBin.Controller.newPaste();
+
+            assert.strictEqual(history.length, initialHistoryLength + 1);
+            assert.strictEqual(window.location.href, 'https://example.com/path/');
+            assert.deepStrictEqual(history.state, {type: 'create'});
+            clean();
+        });
+    });
+});

--- a/js/test/TopNav.js
+++ b/js/test/TopNav.js
@@ -781,19 +781,32 @@ describe('TopNav', function () {
 
         // TODO triggers error messages in jsDOM since version 12, but passes
         it(
-            'displays raw text view correctly',
+            'displays raw text without replacing the history document',
             function () {
                 const clean = globalThis.cleanup('', {url: 'https://privatebin.net/?0123456789abcdef#1'});
                 document.documentElement.innerHTML = `
+                <head><title>PrivateBin</title></head>
+                <body>
                 <li id="loadingindicator" class="hidden"></li>
-                <button id="rawtextbutton"></button>`;
+                <button id="rawtextbutton"></button>
+                </body>`;
                 const sample = 'example';
                 PrivateBin.Alert.init(); // required because of locading indiator being used
                 PrivateBin.TopNav.init();
                 PrivateBin.PasteViewer.setText(sample);
                 PrivateBin.Helper.reset();
-                query('#rawtextbutton').click();
-                assert.strictEqual(document.querySelector('pre').textContent, sample);
+                const originalOpen = document.open;
+                document.open = () => {
+                    throw new Error('document.open() replaces the history entry');
+                };
+                try {
+                    query('#rawtextbutton').click();
+                    assert.strictEqual(document.querySelector('pre').textContent, sample);
+                    assert.strictEqual(document.title, 'PrivateBin');
+                    assert.deepStrictEqual(history.state, {type: 'raw'});
+                } finally {
+                    document.open = originalOpen;
+                }
                 clean();
             }
         );

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -120,7 +120,7 @@ class Configuration
             'js/kjua-0.10.0.js'      => 'sha512-BYj4xggowR7QD150VLSTRlzH62YPfhpIM+b/1EUEr7RQpdWAGKulxWnOvjFx1FUlba4m6ihpNYuQab51H6XlYg==',
             'js/legacy.js'           => 'sha512-pRofxsrf5UItjiP22Dcjh3FAcBjF/n7h8U9/W5xqJk17U0N2U1oajhXypq/omo9jhwS1iVGOhWrRepoPeFns+w==',
             'js/prettify.js'         => 'sha512-puO0Ogy++IoA2Pb9IjSxV1n4+kQkKXYAEUtVzfZpQepyDPyXk8hokiYDS7ybMogYlyyEIwMLpZqVhCkARQWLMg==',
-            'js/privatebin.js'       => 'sha512-usQ6D7M+PH52q76aypdtVOculQnQMxY9v49yPdIC4O1YOPYBmAGO2xCTvEserpBCBPXyBqqq/4lL5VndE36WPQ==',
+            'js/privatebin.js'       => 'sha512-qGQV02J5qeq3s45pWiDnfBx4k4w65uNgIIpOk5GZey19ivRj7uywwfkdkH8yybH2pVAr2VTnOcskNjcVPV4WxQ==',
             'js/purify-3.4.12.js'    => 'sha512-Akf6HnAJZm0sWWWI4gp2GYff0NDnHUB02XJE5S7Hdq/Z5xtMjkuFacsDA8ZtViv1gi+onBxMhEMIaGyQeGxBng==',
             'js/showdown-2.1.0.js'   => 'sha512-WYXZgkTR0u/Y9SVIA4nTTOih0kXMEd8RRV6MLFdL6YU8ymhR528NLlYQt1nlJQbYz4EW+ZsS0fx1awhiQJme1Q==',
             'js/zlib-1.3.2.js'       => 'sha512-RAhJgxg9siMIA8ky4c10Rc2zUgnK80olHB8Tt1IOYWY4Eh1WmrviQkDn+sgBlb38ZHq3tzufGC41kP360gmosQ==',

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -120,7 +120,7 @@ class Configuration
             'js/kjua-0.10.0.js'      => 'sha512-BYj4xggowR7QD150VLSTRlzH62YPfhpIM+b/1EUEr7RQpdWAGKulxWnOvjFx1FUlba4m6ihpNYuQab51H6XlYg==',
             'js/legacy.js'           => 'sha512-pRofxsrf5UItjiP22Dcjh3FAcBjF/n7h8U9/W5xqJk17U0N2U1oajhXypq/omo9jhwS1iVGOhWrRepoPeFns+w==',
             'js/prettify.js'         => 'sha512-puO0Ogy++IoA2Pb9IjSxV1n4+kQkKXYAEUtVzfZpQepyDPyXk8hokiYDS7ybMogYlyyEIwMLpZqVhCkARQWLMg==',
-            'js/privatebin.js'       => 'sha512-ah/QdETig/ovH1QPl9Ne+T3VvaP7Bj4Rd9Or9wqQgo5BHge9o02MxAlRGXUZpKviy/27OSzHgz2PwpnH/B2RZg==',
+            'js/privatebin.js'       => 'sha512-aKLe6zry+hfzx7IhXxGF4ri+I9js5yCdXaRs/MAsomw0H8QOcSwl0mPC5xTcWPVb6rPo6t+YXpa9wUwZTXjXcw==',
             'js/purify-3.4.12.js'    => 'sha512-Akf6HnAJZm0sWWWI4gp2GYff0NDnHUB02XJE5S7Hdq/Z5xtMjkuFacsDA8ZtViv1gi+onBxMhEMIaGyQeGxBng==',
             'js/showdown-2.1.0.js'   => 'sha512-WYXZgkTR0u/Y9SVIA4nTTOih0kXMEd8RRV6MLFdL6YU8ymhR528NLlYQt1nlJQbYz4EW+ZsS0fx1awhiQJme1Q==',
             'js/zlib-1.3.2.js'       => 'sha512-RAhJgxg9siMIA8ky4c10Rc2zUgnK80olHB8Tt1IOYWY4Eh1WmrviQkDn+sgBlb38ZHq3tzufGC41kP360gmosQ==',

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -120,7 +120,7 @@ class Configuration
             'js/kjua-0.10.0.js'      => 'sha512-BYj4xggowR7QD150VLSTRlzH62YPfhpIM+b/1EUEr7RQpdWAGKulxWnOvjFx1FUlba4m6ihpNYuQab51H6XlYg==',
             'js/legacy.js'           => 'sha512-pRofxsrf5UItjiP22Dcjh3FAcBjF/n7h8U9/W5xqJk17U0N2U1oajhXypq/omo9jhwS1iVGOhWrRepoPeFns+w==',
             'js/prettify.js'         => 'sha512-puO0Ogy++IoA2Pb9IjSxV1n4+kQkKXYAEUtVzfZpQepyDPyXk8hokiYDS7ybMogYlyyEIwMLpZqVhCkARQWLMg==',
-            'js/privatebin.js'       => 'sha512-aKLe6zry+hfzx7IhXxGF4ri+I9js5yCdXaRs/MAsomw0H8QOcSwl0mPC5xTcWPVb6rPo6t+YXpa9wUwZTXjXcw==',
+            'js/privatebin.js'       => 'sha512-usQ6D7M+PH52q76aypdtVOculQnQMxY9v49yPdIC4O1YOPYBmAGO2xCTvEserpBCBPXyBqqq/4lL5VndE36WPQ==',
             'js/purify-3.4.12.js'    => 'sha512-Akf6HnAJZm0sWWWI4gp2GYff0NDnHUB02XJE5S7Hdq/Z5xtMjkuFacsDA8ZtViv1gi+onBxMhEMIaGyQeGxBng==',
             'js/showdown-2.1.0.js'   => 'sha512-WYXZgkTR0u/Y9SVIA4nTTOih0kXMEd8RRV6MLFdL6YU8ymhR528NLlYQt1nlJQbYz4EW+ZsS0fx1awhiQJme1Q==',
             'js/zlib-1.3.2.js'       => 'sha512-RAhJgxg9siMIA8ky4c10Rc2zUgnK80olHB8Tt1IOYWY4Eh1WmrviQkDn+sgBlb38ZHq3tzufGC41kP360gmosQ==',


### PR DESCRIPTION
Closes #503.

## Summary

- replace the document contents without calling `document.open()`, which replaces the active history entry and removes window listeners
- preserve the existing `<head>` metadata and render the raw paste via `textContent`
- add a regression test proving the raw view does not call `document.open()` and records the expected history state
- handle native `popstate` events through `event.state` after the frontend's jQuery removal
- compare the base URL with `window.location.href` so New does not add a duplicate history entry after Clone
- update the JavaScript SRI hash and unreleased changelog

## Validation

- `npm test -- --grep 'displays raw text without replacing the history document'` (1 passing)
- `npm test -- --grep 'historyChange|raw text without replacing'` (3 passing)
- `npm test -- --grep 'UiHelper|TopNav'` (21 passing)
- `npm test -- --grep 'Controller|historyChange|raw text without replacing'` (5 passing)
- `npm run lint -- privatebin.js test/TopNav.js`
- full JavaScript suite: 126 passing (run before the changelog-only follow-up)
- full PHP suite: 266 tests, 6505 assertions (run before the changelog-only follow-up)
- Chromium E2E: create → reload → raw text → Back → clone → New, with no page errors, failed requests, content loss, or duplicate history entries
- `git diff --check`

## Security and compatibility

Raw paste content is assigned with `textContent`, so it remains inert text. The implementation avoids `document.open()` while retaining the existing same-document raw-view URL/history behavior.

## AI disclosure

This change was developed with assistance from OpenAI Codex. The implementation and tests were reviewed and run locally before submission.

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.