### PR TITLE
Fix JSON Accept header quality handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * FIXED: Gracefully handle YOURLS replies with a 200 status code but no shorturl, instead of raising a TypeError
 * FIXED: Return "Invalid data." instead of HTTP 500 on malformed v2 JSON payloads (#1883)
 * FIXED: Dead PATH validation guard in Controller, the check for a missing trailing directory separator never ran (#1887)
+* FIXED: Honor exact media types and quality values during JSON content negotiation
 
 ## 2.0.5 (2026-07-11)
 * CHANGED: Show OS-specific copy hotkey hint (Cmd+c on Mac, Ctrl+c on others) (#1506)

--- a/lib/Request.php
+++ b/lib/Request.php
@@ -267,15 +267,8 @@ class Request
     {
         $acceptHeader = $_SERVER['HTTP_ACCEPT'] ?? '';
 
-        // simple cases
-        if (
-            ($_SERVER['HTTP_X_REQUESTED_WITH'] ?? '') === 'JSONHttpRequest' ||
-            (
-                str_contains($acceptHeader, self::MIME_JSON) &&
-                !str_contains($acceptHeader, self::MIME_HTML) &&
-                !str_contains($acceptHeader, self::MIME_XHTML)
-            )
-        ) {
+        // explicit API request
+        if (($_SERVER['HTTP_X_REQUESTED_WITH'] ?? '') === 'JSONHttpRequest') {
             return true;
         }
 
@@ -284,7 +277,7 @@ class Request
             $mediaTypes = [];
             foreach (explode(',', trim($acceptHeader)) as $mediaTypeRange) {
                 if (preg_match(
-                    '#(\*/\*|[a-z\-]+/[a-z\-+*]+(?:\s*;\s*[^q]\S*)*)(?:\s*;\s*q\s*=\s*(0(?:\.\d{0,3})|1(?:\.0{0,3})))?#',
+                    '#^(\*/\*|[a-z\-]+/[a-z\-+*]+(?:\s*;\s*[^q]\S*)*)(?:\s*;\s*q\s*=\s*(0(?:\.\d{0,3})|1(?:\.0{0,3})))?$#i',
                     trim($mediaTypeRange), $match
                 )) {
                     if (!isset($match[2])) {
@@ -304,12 +297,13 @@ class Request
             krsort($mediaTypes);
             foreach ($mediaTypes as $acceptedQuality => $acceptedValues) {
                 foreach ($acceptedValues as $acceptedValue) {
+                    $acceptedMediaType = trim(explode(';', $acceptedValue, 2)[0]);
                     if (
-                        str_starts_with($acceptedValue, self::MIME_HTML) ||
-                        str_starts_with($acceptedValue, self::MIME_XHTML)
+                        $acceptedMediaType === self::MIME_HTML ||
+                        $acceptedMediaType === self::MIME_XHTML
                     ) {
                         return false;
-                    } elseif (str_starts_with($acceptedValue, self::MIME_JSON)) {
+                    } elseif ($acceptedMediaType === self::MIME_JSON) {
                         return true;
                     }
                 }

--- a/tst/RequestTest.php
+++ b/tst/RequestTest.php
@@ -220,6 +220,23 @@ class RequestTest extends TestCase
         $this->assertEquals('read', $request->getOperation());
     }
 
+    public function testJsonNegotiationHonorsExactMediaTypeAndQuality()
+    {
+        $cases = [
+            'application/json;q=0, text/plain' => false,
+            'application/jsonp' => false,
+            'application/json; charset=UTF-8' => true,
+            'APPLICATION/JSON' => true,
+        ];
+        foreach ($cases as $accept => $expected) {
+            $this->reset();
+            $_SERVER['REQUEST_METHOD'] = 'GET';
+            $_SERVER['HTTP_ACCEPT']    = $accept;
+            $request                   = new Request;
+            $this->assertSame($expected, $request->isJsonApiCall(), $accept);
+        }
+    }
+
     public function testReadWithFailedNegotiation()
     {
         $this->reset();

--- a/tst/RequestTest.php
+++ b/tst/RequestTest.php
@@ -224,9 +224,9 @@ class RequestTest extends TestCase
     {
         $cases = [
             'application/json;q=0, text/plain' => false,
-            'application/jsonp' => false,
-            'application/json; charset=UTF-8' => true,
-            'APPLICATION/JSON' => true,
+            'application/jsonp'                => false,
+            'application/json; charset=UTF-8'  => true,
+            'APPLICATION/JSON'                 => true,
         ];
         foreach ($cases as $accept => $expected) {
             $this->reset();


### PR DESCRIPTION
## Summary

- honor `q=0` when negotiating `application/json`
- require exact HTML, XHTML, and JSON media types instead of prefix matches
- parse media types case-insensitively and retain support for parameters such as `charset`

## Reproduction

Before this change, `Accept: application/json;q=0, text/plain` was treated as a JSON API request because the early substring shortcut ignored the quality value. `Accept: application/jsonp` was also classified as JSON.

The added regression covers:

- rejected JSON (`application/json;q=0`)
- a lookalike media type (`application/jsonp`)
- parameterized JSON (`application/json; charset=UTF-8`)
- case-insensitive JSON (`APPLICATION/JSON`)

## Tests

- `phpunit --filter testJsonNegotiationHonorsExactMediaTypeAndQuality RequestTest.php` — 1 test, 4 assertions passed
- `phpunit RequestTest.php` — 16 tests, 60 assertions passed
- `php -l lib/Request.php`
- `php -l tst/RequestTest.php`
- `composer validate --no-check-publish`

The full local PHP run passed 268 of 272 tests; four unrelated `ServerSaltTest` isolation assertions failed while displaying identical expected and actual values.

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.