### PR TITLE
Fix cloud purge limits and storage prefixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * FIXED: Gracefully handle YOURLS replies with a 200 status code but no shorturl, instead of raising a TypeError
 * FIXED: Return "Invalid data." instead of HTTP 500 on malformed v2 JSON payloads (#1883)
 * FIXED: Dead PATH validation guard in Controller, the check for a missing trailing directory separator never ran (#1887)
+* FIXED: Honor purge batch limits and S3 prefixes when deleting expired cloud pastes
 
 ## 2.0.5 (2026-07-11)
 * CHANGED: Show OS-specific copy hotkey hint (Cmd+c on Mac, Ctrl+c on others) (#1506)

--- a/lib/Data/GoogleCloudStorage.php
+++ b/lib/Data/GoogleCloudStorage.php
@@ -357,7 +357,7 @@ class GoogleCloudStorage extends AbstractData
         try {
             foreach ($this->_bucket->objects(['prefix' => $prefix]) as $object) {
                 $candidate = substr($object->name(), strlen($prefix));
-                if (str_contains($candidate, '/')) {
+                if (preg_match('/\A[a-f0-9]{16}\z/', $candidate) !== 1) {
                     continue;
                 }
                 $expire_at = $object->info()['metadata']['expire_date'] ?? '';
@@ -389,7 +389,7 @@ class GoogleCloudStorage extends AbstractData
         try {
             foreach ($this->_bucket->objects(['prefix' => $prefix]) as $object) {
                 $candidate = substr($object->name(), strlen($prefix));
-                if (!str_contains($candidate, '/')) {
+                if (preg_match('/\A[a-f0-9]{16}\z/', $candidate) === 1) {
                     $pastes[] = $candidate;
                 }
             }

--- a/lib/Data/GoogleCloudStorage.php
+++ b/lib/Data/GoogleCloudStorage.php
@@ -342,12 +342,16 @@ class GoogleCloudStorage extends AbstractData
         }
         try {
             foreach ($this->_bucket->objects(['prefix' => $prefix]) as $object) {
+                $candidate = substr($object->name(), strlen($prefix));
+                if (str_contains($candidate, '/')) {
+                    continue;
+                }
                 $expire_at = $object->info()['metadata']['expire_date'] ?? '';
                 if (is_numeric($expire_at) && intval($expire_at) < $now) {
-                    array_push($expired, basename($object->name()));
+                    array_push($expired, $candidate);
                 }
 
-                if (count($expired) > $batchsize) {
+                if (count($expired) >= $batchsize) {
                     break;
                 }
             }

--- a/lib/Data/GoogleCloudStorage.php
+++ b/lib/Data/GoogleCloudStorage.php
@@ -251,7 +251,7 @@ class GoogleCloudStorage extends AbstractData
      */
     public function purgeValues($namespace, $time)
     {
-        $path = 'config/' . $namespace;
+        $path = $this->_getKey('config/' . $namespace);
         try {
             foreach ($this->_bucket->objects(['prefix' => $path]) as $object) {
                 $name = $object->name();
@@ -284,6 +284,7 @@ class GoogleCloudStorage extends AbstractData
         } else {
             $key = 'config/' . $namespace . '/' . $key;
         }
+        $key = $this->_getKey($key);
 
         $metadata = ['namespace' => $namespace];
         if ($namespace !== 'salt') {
@@ -315,14 +316,27 @@ class GoogleCloudStorage extends AbstractData
      */
     public function getValue($namespace, $key = '')
     {
+        $valueKey = $key;
         if ($key === '') {
             $key = 'config/' . $namespace;
         } else {
             $key = 'config/' . $namespace . '/' . $key;
         }
+        $legacyKey = $key;
+        $key       = $this->_getKey($key);
         try {
             $o = $this->_bucket->object($key);
             return $o->downloadAsString();
+        } catch (NotFoundException $e) {
+            if ($legacyKey === $key) {
+                return '';
+            }
+        }
+        try {
+            $o     = $this->_bucket->object($legacyKey);
+            $value = $o->downloadAsString();
+            $this->setValue($value, $namespace, $valueKey);
+            return $value;
         } catch (NotFoundException $e) {
             return '';
         }

--- a/lib/Data/S3Storage.php
+++ b/lib/Data/S3Storage.php
@@ -429,7 +429,7 @@ class S3Storage extends AbstractData
         try {
             foreach ($this->_listAllObjects($prefix) as $object) {
                 $candidate = substr($object['Key'], strlen($prefix));
-                if (str_contains($candidate, '/')) {
+                if (preg_match('/\A[a-f0-9]{16}\z/', $candidate) !== 1) {
                     continue;
                 }
                 $head = $this->_client->headObject([
@@ -465,7 +465,7 @@ class S3Storage extends AbstractData
         try {
             foreach ($this->_listAllObjects($prefix) as $object) {
                 $candidate = substr($object['Key'], strlen($prefix));
-                if (!str_contains($candidate, '/')) {
+                if (preg_match('/\A[a-f0-9]{16}\z/', $candidate) === 1) {
                     $pastes[] = $candidate;
                 }
             }

--- a/lib/Data/S3Storage.php
+++ b/lib/Data/S3Storage.php
@@ -428,16 +428,20 @@ class S3Storage extends AbstractData
 
         try {
             foreach ($this->_listAllObjects($prefix) as $object) {
+                $candidate = substr($object['Key'], strlen($prefix));
+                if (str_contains($candidate, '/')) {
+                    continue;
+                }
                 $head = $this->_client->headObject([
                     'Bucket' => $this->_bucket,
                     'Key'    => $object['Key'],
                 ]);
                 $expire_at = $head->get('Metadata')['expire_date'] ?? '';
                 if (is_numeric($expire_at) && intval($expire_at) < $now) {
-                    array_push($expired, $object['Key']);
+                    array_push($expired, $candidate);
                 }
 
-                if (count($expired) > $batchsize) {
+                if (count($expired) >= $batchsize) {
                     break;
                 }
             }

--- a/tst/Data/GoogleCloudStorageTest.php
+++ b/tst/Data/GoogleCloudStorageTest.php
@@ -111,6 +111,26 @@ class GoogleCloudStorageTest extends TestCase
         }
     }
 
+    public function testPurgeHonorsBatchSize()
+    {
+        $expired = Helper::getPaste(['expire_date' => 1344803344]);
+        $ids     = [
+            'aaaaaaaaaaaaaaaa',
+            'bbbbbbbbbbbbbbbb',
+            'cccccccccccccccc',
+        ];
+        foreach ($ids as $id) {
+            $this->assertTrue($this->_model->create($id, $expired));
+        }
+
+        $this->_model->purge(2);
+
+        $remaining = array_filter($ids, function ($id) {
+            return $this->_model->exists($id);
+        });
+        $this->assertCount(1, $remaining);
+    }
+
     public function testErrorDetection()
     {
         $this->_model->delete(Helper::getPasteId());

--- a/tst/Data/GoogleCloudStorageTest.php
+++ b/tst/Data/GoogleCloudStorageTest.php
@@ -122,6 +122,13 @@ class GoogleCloudStorageTest extends TestCase
         foreach ($ids as $id) {
             $this->assertTrue($this->_model->create($id, $expired));
         }
+        foreach (['not-a-paste', 'aaaaaaaaaaaaaaaa.backup'] as $name) {
+            self::$_bucket->upload('{}', [
+                'name'     => 'pastes/' . $name,
+                'metadata' => ['metadata' => ['expire_date' => '1']],
+            ]);
+        }
+        $this->assertSame($ids, $this->_model->getAllPastes());
 
         $this->_model->purge(2);
 

--- a/tst/Data/GoogleCloudStorageTest.php
+++ b/tst/Data/GoogleCloudStorageTest.php
@@ -203,4 +203,32 @@ class GoogleCloudStorageTest extends TestCase
         $this->_model->purgeValues('traffic_limiter', time() + 60);
         $this->assertEquals('', $this->_model->getValue('traffic_limiter', $client));
     }
+
+    public function testKeyValueStoreHonorsPrefix()
+    {
+        $other = new GoogleCloudStorage([
+            'bucket' => self::$_bucket->name(),
+            'prefix' => 'other',
+        ]);
+
+        $this->assertTrue($this->_model->setValue('first salt', 'salt'));
+        $this->assertTrue($other->setValue('second salt', 'salt'));
+        $this->assertSame('first salt', $this->_model->getValue('salt'));
+        $this->assertSame('second salt', $other->getValue('salt'));
+
+        $this->assertTrue($this->_model->setValue('1', 'traffic_limiter', 'client'));
+        $this->assertTrue($other->setValue('2', 'traffic_limiter', 'client'));
+        $this->_model->purgeValues('traffic_limiter', 2);
+        $this->assertSame('', $this->_model->getValue('traffic_limiter', 'client'));
+        $this->assertSame('2', $other->getValue('traffic_limiter', 'client'));
+    }
+
+    public function testKeyValueStoreMigratesLegacyConfig()
+    {
+        self::$_bucket->upload('legacy salt', ['name' => 'config/salt']);
+
+        $this->assertSame('legacy salt', $this->_model->getValue('salt'));
+        self::$_bucket->object('config/salt')->delete();
+        $this->assertSame('legacy salt', $this->_model->getValue('salt'));
+    }
 }

--- a/tst/Data/S3StorageTest.php
+++ b/tst/Data/S3StorageTest.php
@@ -1,0 +1,70 @@
+<?php declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use PrivateBin\Data\S3Storage;
+
+class S3HeadResultStub
+{
+    public function get($name)
+    {
+        return $name === 'Metadata' ? ['expire_date' => '1'] : null;
+    }
+}
+
+class S3PurgeClientStub
+{
+    public $deletedKeys = [];
+
+    public function listObjects($options)
+    {
+        $contents = [];
+        if ($options['Prefix'] === 'pastes/') {
+            $contents = [
+                ['Key' => 'pastes/aaaaaaaaaaaaaaaa'],
+                ['Key' => 'pastes/bbbbbbbbbbbbbbbb'],
+                ['Key' => 'pastes/cccccccccccccccc'],
+            ];
+        }
+        return [
+            'Contents'    => $contents,
+            'IsTruncated' => false,
+        ];
+    }
+
+    public function headObject($options)
+    {
+        return new S3HeadResultStub;
+    }
+
+    public function deleteObject($options)
+    {
+        $this->deletedKeys[] = $options['Key'];
+    }
+}
+
+class S3StorageTest extends TestCase
+{
+    public function testPurgeHonorsBatchSizeAndDoesNotDuplicatePrefix()
+    {
+        $reflection = new ReflectionClass(S3Storage::class);
+        $storage    = $reflection->newInstanceWithoutConstructor();
+        $client     = new S3PurgeClientStub;
+
+        foreach ([
+            '_client' => $client,
+            '_bucket' => 'bucket',
+            '_prefix' => 'pastes',
+        ] as $name => $value) {
+            $property = $reflection->getProperty($name);
+            $property->setAccessible(true);
+            $property->setValue($storage, $value);
+        }
+
+        $storage->purge(2);
+
+        $this->assertSame([
+            'pastes/aaaaaaaaaaaaaaaa',
+            'pastes/bbbbbbbbbbbbbbbb',
+        ], $client->deletedKeys);
+    }
+}

--- a/tst/Data/S3StorageTest.php
+++ b/tst/Data/S3StorageTest.php
@@ -20,6 +20,9 @@ class S3PurgeClientStub
         $contents = [];
         if ($options['Prefix'] === 'pastes/') {
             $contents = [
+                ['Key' => 'pastes/not-a-paste'],
+                ['Key' => 'pastes/aaaaaaaaaaaaaaaa.backup'],
+                ['Key' => 'pastes/config/salt'],
                 ['Key' => 'pastes/aaaaaaaaaaaaaaaa'],
                 ['Key' => 'pastes/bbbbbbbbbbbbbbbb'],
                 ['Key' => 'pastes/cccccccccccccccc'],
@@ -59,6 +62,12 @@ class S3StorageTest extends TestCase
             $property->setAccessible(true);
             $property->setValue($storage, $value);
         }
+
+        $this->assertSame([
+            'aaaaaaaaaaaaaaaa',
+            'bbbbbbbbbbbbbbbb',
+            'cccccccccccccccc',
+        ], $storage->getAllPastes());
 
         $storage->purge(2);
 


### PR DESCRIPTION
## Summary

- return bare S3 paste IDs from expiration scans so configured prefixes are applied exactly once during deletion
- stop S3 and Google Cloud scans at the documented batch size instead of one item later
- ignore nested discussion/config objects when selecting expired top-level pastes
- require enumerated and purge-candidate cloud paste IDs to match the model's 16-hex format
- store Google Cloud salt and limiter objects beneath the configured prefix
- copy legacy unprefixed Google Cloud config into the prefix on first access

## Reproduction

With the default non-empty S3 prefix, an expired object named `pastes/<id>` was returned as the paste ID. `delete()` then applied the prefix again and targeted `pastes/pastes/<id>`, leaving the expired paste in storage.

Both cloud implementations also used `count($expired) > $batchsize`, allowing a purge configured for two items to return and delete three.

Google Cloud applied its configured prefix to paste objects but always stored salts and limiter state under the shared `config/` path. Two PrivateBin instances using different prefixes in one bucket therefore overwrote each other's server salt, traffic limiter, and purge limiter.

Both cloud backends also treated any top-level object beneath the prefix as a paste. Names such as `not-a-paste` and `<id>.backup` appeared in administration/migration enumeration and could consume the purge batch before real expired pastes were selected.

The new S3 regression starts with three expired `pastes/<id>` objects and verifies that `purge(2)` deletes exactly:

```text
pastes/aaaaaaaaaaaaaaaa
pastes/bbbbbbbbbbbbbbbb
```

## Tests

- `phpunit Data/S3StorageTest.php` — 1 test, 2 assertions passed
- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit Data/GoogleCloudStorageTest.php`
  - 9 tests, 88 assertions passed
- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit --filter '/^(?!.*ServerSaltTest)/'`
  - 270 tests, 6522 assertions passed
- PHP syntax checks for both implementations and test files
- `composer validate --no-check-publish`

## Compatibility and privacy

Fresh Google Cloud installations keep configuration state isolated by prefix. On upgrade, a missing prefixed value falls back to the legacy unprefixed object and copies it into the prefix before returning it, preserving existing deletion tokens. The shared legacy object is not removed because another configured prefix may not have migrated yet. Enumeration and purge now operate only on IDs that normal model methods can address. No paste ciphertext or metadata is moved.

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.