### PR TITLE
Escape request paths in JSON-LD responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * FIXED: Return "Invalid data." instead of HTTP 500 on malformed v2 JSON payloads (#1883)
 * FIXED: Dead PATH validation guard in Controller, the check for a missing trailing directory separator never ran (#1887)
 * FIXED: Escape request paths interpolated into JSON-LD contexts
+* FIXED: Fall back to the root path when request URI parsing fails
 
 ## 2.0.5 (2026-07-11)
 * CHANGED: Show OS-specific copy hotkey hint (Cmd+c on Mac, Ctrl+c on others) (#1506)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * FIXED: Gracefully handle YOURLS replies with a 200 status code but no shorturl, instead of raising a TypeError
 * FIXED: Return "Invalid data." instead of HTTP 500 on malformed v2 JSON payloads (#1883)
 * FIXED: Dead PATH validation guard in Controller, the check for a missing trailing directory separator never ran (#1887)
+* FIXED: Escape request paths interpolated into JSON-LD contexts
 
 ## 2.0.5 (2026-07-11)
 * CHANGED: Show OS-specific copy hotkey hint (Cmd+c on Mac, Ctrl+c on others) (#1506)

--- a/lib/Controller.php
+++ b/lib/Controller.php
@@ -514,7 +514,7 @@ class Controller
             $urlBase        = $this->_urlBase;
             $encodedUrlBase = Json::encode($urlBase, JSON_UNESCAPED_SLASHES);
             $escapedUrlBase = substr($encodedUrlBase, 1, -1);
-            $content = str_replace(
+            $content        = str_replace(
                 '?jsonld=',
                 $escapedUrlBase . '?jsonld=',
                 file_get_contents($file)

--- a/lib/Controller.php
+++ b/lib/Controller.php
@@ -511,9 +511,12 @@ class Controller
         $content = '{}';
         $file    = PUBLIC_PATH . DIRECTORY_SEPARATOR . 'js' . DIRECTORY_SEPARATOR . $type . '.jsonld';
         if (is_readable($file)) {
+            $urlBase        = $this->_urlBase;
+            $encodedUrlBase = Json::encode($urlBase, JSON_UNESCAPED_SLASHES);
+            $escapedUrlBase = substr($encodedUrlBase, 1, -1);
             $content = str_replace(
                 '?jsonld=',
-                $this->_urlBase . '?jsonld=',
+                $escapedUrlBase . '?jsonld=',
                 file_get_contents($file)
             );
         }

--- a/lib/Json.php
+++ b/lib/Json.php
@@ -24,12 +24,13 @@ class Json
      * @access public
      * @static
      * @param  mixed $input
+     * @param  int $flags
      * @throws JsonException
      * @return string
      */
-    public static function encode(&$input)
+    public static function encode(&$input, $flags = 0)
     {
-        return json_encode($input, JSON_THROW_ON_ERROR);
+        return json_encode($input, $flags | JSON_THROW_ON_ERROR);
     }
 
     /**

--- a/lib/Request.php
+++ b/lib/Request.php
@@ -231,7 +231,11 @@ class Request
     public function getRequestUri()
     {
         $uri = array_key_exists('REQUEST_URI', $_SERVER) ? filter_var($_SERVER['REQUEST_URI'], FILTER_SANITIZE_URL) : '';
-        return empty($uri) ? '/' : parse_url($uri, PHP_URL_PATH);
+        if (empty($uri)) {
+            return '/';
+        }
+        $path = parse_url($uri, PHP_URL_PATH);
+        return is_string($path) && $path !== '' ? $path : '/';
     }
 
     /**

--- a/tst/JsonApiTest.php
+++ b/tst/JsonApiTest.php
@@ -207,6 +207,25 @@ class JsonApiTest extends TestCase
     /**
      * @runInSeparateProcess
      */
+    public function testJsonLdEscapesRequestPath()
+    {
+        $_GET['jsonld']             = 'paste';
+        $_SERVER['REQUEST_URI']     = '/"quoted\\path?jsonld=paste';
+        ob_start();
+        new Controller;
+        $content = ob_get_contents();
+        ob_end_clean();
+
+        $decoded = json_decode($content, true, 512, JSON_THROW_ON_ERROR);
+        $this->assertSame(
+            '/"quoted\\path?jsonld=types#',
+            $decoded['@context']['pb']
+        );
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
     public function testJsonLdComment()
     {
         $_GET['jsonld'] = 'comment';

--- a/tst/RequestTest.php
+++ b/tst/RequestTest.php
@@ -234,6 +234,15 @@ class RequestTest extends TestCase
         $this->assertEquals('read', $request->getOperation());
     }
 
+    public function testMalformedRequestUriFallsBackToRoot()
+    {
+        $this->reset();
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+        $_SERVER['REQUEST_URI']    = 'http://[';
+        $request                   = new Request;
+        $this->assertSame('/', $request->getRequestUri());
+    }
+
     public function testPasteIdExtraction()
     {
         $this->reset();


### PR DESCRIPTION
## Summary

- JSON-escape request paths before interpolating them into JSON-LD string values
- preserve byte-for-byte output for ordinary slash-delimited paths
- fall back to `/` when `parse_url()` cannot produce a path

## Reproduction

JSON-LD templates contain relative references such as `?jsonld=types#`. PrivateBin prefixes these with the current request path. A path containing a raw quote or backslash was inserted without JSON escaping, producing an invalid `application/ld+json` response.

Separately, malformed request URIs can make `parse_url(..., PHP_URL_PATH)` return `null`, despite `Request::getRequestUri()` being consumed as a string.

The controller regression requests JSON-LD through:

```text
/"quoted\path?jsonld=paste
```

and verifies that the emitted response decodes successfully and contains the original path value.

## Tests

- JSON-LD controller tests — 7 tests, 7 assertions passed
- Request tests — 16 tests, 57 assertions passed
- PHP syntax checks for all changed PHP files
- `composer validate --no-check-publish`

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.