### PR TITLE
Handle malformed configuration files cleanly

### DIFF
--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -145,7 +145,10 @@ class Configuration
         foreach ($basePaths as $basePath) {
             $configFile = $basePath . DIRECTORY_SEPARATOR . 'conf.php';
             if (is_readable($configFile)) {
-                $config = parse_ini_file($configFile, true);
+                $config = @parse_ini_file($configFile, true);
+                if ($config === false) {
+                    throw new TranslatedException('Unable to parse configuration file.', 5);
+                }
                 foreach (['main', 'model', 'model_options'] as $section) {
                     if (!array_key_exists($section, $config)) {
                         $name = $config['main']['name'] ?? self::getDefaults()['main']['name'];

--- a/tst/ConfigurationTest.php
+++ b/tst/ConfigurationTest.php
@@ -2,6 +2,7 @@
 
 use PHPUnit\Framework\TestCase;
 use PrivateBin\Configuration;
+use PrivateBin\Exception\TranslatedException;
 
 class ConfigurationTest extends TestCase
 {
@@ -61,6 +62,15 @@ class ConfigurationTest extends TestCase
         file_put_contents(CONF, '');
         $this->expectException(Exception::class);
         $this->expectExceptionCode(2);
+        new Configuration;
+    }
+
+    public function testHandleMalformedConfigFile()
+    {
+        file_put_contents(CONF, '[main');
+        $this->expectException(TranslatedException::class);
+        $this->expectExceptionMessage('Unable to parse configuration file.');
+        $this->expectExceptionCode(5);
         new Configuration;
     }
 


### PR DESCRIPTION
## Summary

- turn malformed INI parser failures into a controlled `TranslatedException`
- suppress the raw PHP parser warning once the failure is handled
- preserve the existing behavior for missing files, blank files, and missing required sections
- add a regression test for malformed configuration syntax

## Reproduction

With a readable `cfg/conf.php` containing `[main`, `parse_ini_file()` emits a warning and returns `false`. The subsequent configuration handling never gets a chance to report a useful PrivateBin error (and under PHPUnit's error handler the warning becomes an exception immediately).

## Tests

- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit ConfigurationTest.php --testdox`
  - 12 tests, 17 assertions passed
- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit --filter '/^(?!.*ServerSaltTest)/'`
  - 267 tests, 6508 assertions passed
- `php -l lib/Configuration.php`
- `git diff --check`

The local full suite still has the pre-existing environment-sensitive `ServerSaltTest` assertion failures where PHPUnit displays identical expected and actual salt strings.

## Compatibility and security

Valid configurations are unaffected. Malformed configuration contents are not included in the exception, so this does not disclose secrets from `conf.php`.

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.