### PR TITLE
Validate and order Accept-Language preferences

### DIFF
--- a/lib/I18n.php
+++ b/lib/I18n.php
@@ -415,7 +415,7 @@ class I18n
                 }
                 foreach ($availableLanguages as $availableValue) {
                     $availableQuality = 1.0;
-                    $matchingGrade = self::_matchLanguage($acceptedValue, $availableValue);
+                    $matchingGrade    = self::_matchLanguage($acceptedValue, $availableValue);
                     if ($matchingGrade > 0) {
                         $q = (string) ($acceptedQuality * $availableQuality * $matchingGrade);
                         if (!isset($matches[$q])) {

--- a/lib/I18n.php
+++ b/lib/I18n.php
@@ -409,12 +409,12 @@ class I18n
             if ($acceptedQuality === 0.0) {
                 continue;
             }
-            foreach ($availableLanguages as $availableValue) {
-                $availableQuality = 1.0;
-                foreach ($acceptedValues as $acceptedValue) {
-                    if ($acceptedValue === '*') {
-                        $any = true;
-                    }
+            foreach ($acceptedValues as $acceptedValue) {
+                if ($acceptedValue === '*') {
+                    $any = true;
+                }
+                foreach ($availableLanguages as $availableValue) {
+                    $availableQuality = 1.0;
                     $matchingGrade = self::_matchLanguage($acceptedValue, $availableValue);
                     if ($matchingGrade > 0) {
                         $q = (string) ($acceptedQuality * $availableQuality * $matchingGrade);

--- a/lib/I18n.php
+++ b/lib/I18n.php
@@ -230,7 +230,7 @@ class I18n
             $languageRanges = explode(',', trim($_SERVER['HTTP_ACCEPT_LANGUAGE']));
             foreach ($languageRanges as $languageRange) {
                 if (preg_match(
-                    '/(\*|[a-zA-Z0-9]{1,8}(?:-[a-zA-Z0-9]{1,8})*)(?:\s*;\s*q\s*=\s*(0(?:\.\d{0,3})|1(?:\.0{0,3})))?/',
+                    '/^(\*|[a-zA-Z0-9]{1,8}(?:-[a-zA-Z0-9]{1,8})*)(?:\s*;\s*q\s*=\s*(0(?:\.\d{0,3})|1(?:\.0{0,3})))?$/',
                     trim($languageRange), $match
                 )) {
                     if (!isset($match[2])) {

--- a/tst/I18nTest.php
+++ b/tst/I18nTest.php
@@ -80,6 +80,14 @@ class I18nTest extends TestCase
         $this->assertEquals('2 heures', I18n::_('%d hours', 2), '2 hours in French');
     }
 
+    public function testEqualQualityPreservesBrowserOrder()
+    {
+        $_SERVER['HTTP_ACCEPT_LANGUAGE'] = 'fr;q=0.8,de;q=0.8';
+        I18n::loadTranslations();
+
+        $this->assertEquals('fr', I18n::getLanguage());
+    }
+
     public function testBrowserLanguageNoDetection()
     {
         $_SERVER['HTTP_ACCEPT_LANGUAGE'] = 'no;q=0.8,en-GB;q=0.6,en-US;q=0.4,en;q=0.2';

--- a/tst/I18nTest.php
+++ b/tst/I18nTest.php
@@ -162,6 +162,12 @@ class I18nTest extends TestCase
         $this->assertEquals('14 minut',  I18n::_('%d minutes', 14), '14 minutes in Czech');
     }
 
+    public function testInvalidBrowserLanguageQualityIsIgnored()
+    {
+        $_SERVER['HTTP_ACCEPT_LANGUAGE'] = 'de;q=2,en;q=0.8';
+        $this->assertSame(['0.8' => ['en']], I18n::getBrowserLanguages());
+    }
+
     public function testBrowserLanguageAnyDetection()
     {
         $_SERVER['HTTP_ACCEPT_LANGUAGE'] = '*';


### PR DESCRIPTION
## Summary

- require each `Accept-Language` range to match the parser grammar in full
- ignore malformed quality values instead of treating them as quality `1.0`
- preserve browser order when languages have equal quality and specificity

## Reproductions

For `Accept-Language: de;q=2,en;q=0.8`, the previous unanchored regular expression matched only the `de` prefix. Since the invalid quality was not captured, German received the default quality `1.0` and outranked the valid English preference.

For `Accept-Language: fr;q=0.8,de;q=0.8`, the parser correctly grouped both languages at equal quality, but matching iterated installed languages before browser preferences. Because installed translation files are ordered with German first, PrivateBin selected `de` even though the browser listed French first.

The matcher now iterates browser values before installed languages. Computed quality and specificity still determine the winning score; header order only breaks equal-score ties.

## Tests

- focused malformed-quality and equal-quality ordering regressions
- complete `I18nTest`
  - 20 tests, 5,504 assertions passed
- broad PHP suite excluding environment-sensitive `ServerSaltTest`
  - 268 tests, 6,507 assertions passed
- PHP syntax checks for both changed files
- `git diff --check`

## Compatibility

Valid quality values and language-specificity matching are unchanged. Invalid trailing syntax is discarded, and equally preferred matches now respect the order sent by the browser.

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.