### PR TITLE
Skip corrupt filesystem comments

### DIFF
--- a/lib/Data/Filesystem.php
+++ b/lib/Data/Filesystem.php
@@ -214,8 +214,18 @@ class Filesystem extends AbstractData
                 // - commentid is the comment identifier itself.
                 // - parentid is the comment this comment replies to (It can be pasteid)
                 if ($file->isFile()) {
+                    $items = explode('.', $file->getBasename('.php'));
+                    if (count($items) !== 3) {
+                        continue;
+                    }
                     $comment = $this->_get($file->getPathname());
-                    $items   = explode('.', $file->getBasename('.php'));
+                    if (
+                        !is_array($comment) ||
+                        !isset($comment['meta']['created']) ||
+                        !(is_int($comment['meta']['created']) || is_string($comment['meta']['created']))
+                    ) {
+                        continue;
+                    }
                     // Add some meta information not contained in file.
                     $comment['id']       = $items[1];
                     $comment['parentid'] = $items[2];

--- a/lib/Data/Filesystem.php
+++ b/lib/Data/Filesystem.php
@@ -215,7 +215,13 @@ class Filesystem extends AbstractData
                 // - parentid is the comment this comment replies to (It can be pasteid)
                 if ($file->isFile()) {
                     $items = explode('.', $file->getBasename('.php'));
-                    if (count($items) !== 3) {
+                    if (
+                        $file->getExtension() !== 'php' ||
+                        count($items) !== 3 ||
+                        $items[0] !== $pasteid ||
+                        preg_match('/\A[a-f0-9]{16}\z/', $items[1]) !== 1 ||
+                        preg_match('/\A[a-f0-9]{16}\z/', $items[2]) !== 1
+                    ) {
                         continue;
                     }
                     $comment = $this->_get($file->getPathname());

--- a/tst/Data/FilesystemTest.php
+++ b/tst/Data/FilesystemTest.php
@@ -75,6 +75,29 @@ class FilesystemTest extends TestCase
         $this->assertEquals($original, $this->_model->read(Helper::getPasteId()));
     }
 
+    public function testCorruptCommentsAreIgnored()
+    {
+        $pasteid   = Helper::getPasteId();
+        $commentid = Helper::getCommentId();
+        $comment   = Helper::getComment();
+        $this->assertTrue($this->_model->createComment($pasteid, $pasteid, $commentid, $comment));
+
+        $discussionPath = $this->_path . DIRECTORY_SEPARATOR . substr($pasteid, 0, 2) .
+            DIRECTORY_SEPARATOR . substr($pasteid, 2, 2) . DIRECTORY_SEPARATOR .
+            $pasteid . '.discussion' . DIRECTORY_SEPARATOR;
+        file_put_contents(
+            $discussionPath . $pasteid . '.ffffffffffffffff.' . $pasteid . '.php',
+            Filesystem::PROTECTION_LINE . PHP_EOL . '{'
+        );
+
+        $errorLog = ini_get('error_log');
+        ini_set('error_log', '/dev/null');
+        $comments = $this->_model->readComments($pasteid);
+        ini_set('error_log', $errorLog);
+        $this->assertCount(1, $comments);
+        $this->assertSame($commentid, current($comments)['id']);
+    }
+
     /**
      * pastes a-g are expired and should get deleted, x never expires and y-z expire in an hour
      */

--- a/tst/Data/FilesystemTest.php
+++ b/tst/Data/FilesystemTest.php
@@ -89,6 +89,18 @@ class FilesystemTest extends TestCase
             $discussionPath . $pasteid . '.ffffffffffffffff.' . $pasteid . '.php',
             Filesystem::PROTECTION_LINE . PHP_EOL . '{'
         );
+        file_put_contents(
+            $discussionPath . $pasteid . '.invalid.invalid.php',
+            Filesystem::PROTECTION_LINE . PHP_EOL . json_encode($comment)
+        );
+        file_put_contents(
+            $discussionPath . 'ffffffffffffffff.eeeeeeeeeeeeeeee.' . $pasteid . '.php',
+            Filesystem::PROTECTION_LINE . PHP_EOL . json_encode($comment)
+        );
+        file_put_contents(
+            $discussionPath . $pasteid . '.dddddddddddddddd.' . $pasteid,
+            Filesystem::PROTECTION_LINE . PHP_EOL . json_encode($comment)
+        );
 
         $errorLog = ini_get('error_log');
         ini_set('error_log', '/dev/null');


### PR DESCRIPTION
## Summary

- require filesystem comment filenames to use the expected `.php` extension, paste ID, and valid comment and parent IDs
- skip comments whose stored JSON cannot be decoded or lacks a usable creation timestamp
- preserve and return the remaining valid comments
- add regression coverage for corrupt content, malformed IDs, mismatched paste IDs, and missing extensions

## Reproduction

If a discussion directory contains a comment file with truncated JSON, `_get()` returns `false` after logging the decoder error. `readComments()` then writes array offsets on that boolean and reads `meta.created`, producing a deprecation and an undefined-key error. A single damaged entry therefore prevents the whole discussion from loading.

Separately, any valid JSON file with three dot-separated basename components was returned as a comment. This allowed malformed comment or parent IDs, a paste ID that did not match the discussion directory, and files without the storage backend's `.php` protection extension to inject impossible identifiers into API output.

## Tests

- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit Data/FilesystemTest.php --testdox`
  - 8 tests, 160 assertions passed
- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit --filter '/^(?!.*ServerSaltTest)/'`
  - 267 tests, 6508 assertions passed
- `php -l lib/Data/Filesystem.php`
- `php -l tst/Data/FilesystemTest.php`
- `git diff --check`

The local full suite still has the pre-existing environment-sensitive `ServerSaltTest` assertion failures where PHPUnit displays identical expected and actual salt strings.

## Compatibility and privacy

Valid comment files produced by `createComment()` are unchanged. The filename checks use the same lowercase 16-character hexadecimal ID format enforced by the model. The existing decoder continues to log the storage path and parse error, but malformed content and untrusted filenames are never returned to the client and do not expose plaintext or encrypted payload data.

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.