### PR TITLE
Harden cloud comment reads

### DIFF
--- a/lib/Data/GoogleCloudStorage.php
+++ b/lib/Data/GoogleCloudStorage.php
@@ -219,6 +219,14 @@ class GoogleCloudStorage extends AbstractData
         $prefix   = $this->_getKey($pasteid) . '/discussion/';
         try {
             foreach ($this->_bucket->objects(['prefix' => $prefix]) as $key) {
+                $items = explode('/', substr($key->name(), strlen($prefix)));
+                if (
+                    count($items) !== 2 ||
+                    preg_match('/\A[a-f0-9]{16}\z/', $items[0]) !== 1 ||
+                    preg_match('/\A[a-f0-9]{16}\z/', $items[1]) !== 1
+                ) {
+                    continue;
+                }
                 try {
                     $data = $this->_bucket->object($key->name())->downloadAsString();
                 } catch (NotFoundException $e) {
@@ -237,9 +245,10 @@ class GoogleCloudStorage extends AbstractData
                 ) {
                     continue;
                 }
-                $comment['id']   = basename($key->name());
-                $slot            = $this->getOpenSlot($comments, (int) $comment['meta']['created']);
-                $comments[$slot] = $comment;
+                $comment['id']       = $items[1];
+                $comment['parentid'] = $items[0];
+                $slot                = $this->getOpenSlot($comments, (int) $comment['meta']['created']);
+                $comments[$slot]     = $comment;
             }
         } catch (NotFoundException $e) {
             // no comments found

--- a/lib/Data/GoogleCloudStorage.php
+++ b/lib/Data/GoogleCloudStorage.php
@@ -219,7 +219,11 @@ class GoogleCloudStorage extends AbstractData
         $prefix   = $this->_getKey($pasteid) . '/discussion/';
         try {
             foreach ($this->_bucket->objects(['prefix' => $prefix]) as $key) {
-                $data            = $this->_bucket->object($key->name())->downloadAsString();
+                try {
+                    $data = $this->_bucket->object($key->name())->downloadAsString();
+                } catch (NotFoundException $e) {
+                    continue;
+                }
                 try {
                     $comment = Json::decode($data);
                 } catch (JsonException $e) {

--- a/lib/Data/GoogleCloudStorage.php
+++ b/lib/Data/GoogleCloudStorage.php
@@ -224,7 +224,14 @@ class GoogleCloudStorage extends AbstractData
                     $comment = Json::decode($data);
                 } catch (JsonException $e) {
                     error_log('failed to read comment from ' . $key->name() . ', ' . $e->getMessage());
-                    $comment = [];
+                    continue;
+                }
+                if (
+                    !is_array($comment) ||
+                    !isset($comment['meta']['created']) ||
+                    !(is_int($comment['meta']['created']) || is_string($comment['meta']['created']))
+                ) {
+                    continue;
                 }
                 $comment['id']   = basename($key->name());
                 $slot            = $this->getOpenSlot($comments, (int) $comment['meta']['created']);

--- a/lib/Data/S3Storage.php
+++ b/lib/Data/S3Storage.php
@@ -284,11 +284,15 @@ class S3Storage extends AbstractData
         try {
             $entries = $this->_listAllObjects($prefix);
             foreach ($entries as $entry) {
-                $object = $this->_client->getObject([
-                    'Bucket' => $this->_bucket,
-                    'Key'    => $entry['Key'],
-                ]);
-                $data = $object['Body']->getContents();
+                try {
+                    $object = $this->_client->getObject([
+                        'Bucket' => $this->_bucket,
+                        'Key'    => $entry['Key'],
+                    ]);
+                    $data = $object['Body']->getContents();
+                } catch (S3Exception $e) {
+                    continue;
+                }
                 try {
                     $body = Json::decode($data);
                 } catch (JsonException $e) {

--- a/lib/Data/S3Storage.php
+++ b/lib/Data/S3Storage.php
@@ -288,12 +288,20 @@ class S3Storage extends AbstractData
                     'Bucket' => $this->_bucket,
                     'Key'    => $entry['Key'],
                 ]);
-                $data             = $object['Body']->getContents();
-                $body             = JSON::decode($data);
-                $items            = explode('/', $entry['Key']);
-                $body['id']       = $items[3];
-                $body['parentid'] = $items[2];
-                $slot             = $this->getOpenSlot($comments, (int) $object['Metadata']['created']);
+                $data = $object['Body']->getContents();
+                try {
+                    $body = Json::decode($data);
+                } catch (JsonException $e) {
+                    error_log('failed to read comment from ' . $entry['Key'] . ', ' . $e->getMessage());
+                    continue;
+                }
+                $created = $object['Metadata']['created'] ?? null;
+                if (!is_array($body) || !is_numeric($created)) {
+                    continue;
+                }
+                $body['id']       = basename($entry['Key']);
+                $body['parentid'] = basename(dirname($entry['Key']));
+                $slot             = $this->getOpenSlot($comments, (int) $created);
                 $comments[$slot]  = $body;
             }
         } catch (S3Exception $e) {

--- a/lib/Data/S3Storage.php
+++ b/lib/Data/S3Storage.php
@@ -284,6 +284,14 @@ class S3Storage extends AbstractData
         try {
             $entries = $this->_listAllObjects($prefix);
             foreach ($entries as $entry) {
+                $items = explode('/', substr($entry['Key'], strlen($prefix)));
+                if (
+                    count($items) !== 2 ||
+                    preg_match('/\A[a-f0-9]{16}\z/', $items[0]) !== 1 ||
+                    preg_match('/\A[a-f0-9]{16}\z/', $items[1]) !== 1
+                ) {
+                    continue;
+                }
                 try {
                     $object = $this->_client->getObject([
                         'Bucket' => $this->_bucket,
@@ -300,11 +308,16 @@ class S3Storage extends AbstractData
                     continue;
                 }
                 $created = $object['Metadata']['created'] ?? null;
-                if (!is_array($body) || !is_numeric($created)) {
+                if (
+                    !is_array($body) ||
+                    !isset($body['meta']) ||
+                    !is_array($body['meta']) ||
+                    !is_numeric($created)
+                ) {
                     continue;
                 }
-                $body['id']       = basename($entry['Key']);
-                $body['parentid'] = basename(dirname($entry['Key']));
+                $body['id']       = $items[1];
+                $body['parentid'] = $items[0];
                 $slot             = $this->getOpenSlot($comments, (int) $created);
                 $comments[$slot]  = $body;
             }

--- a/tst/Data/GoogleCloudStorageTest.php
+++ b/tst/Data/GoogleCloudStorageTest.php
@@ -158,8 +158,8 @@ class GoogleCloudStorageTest extends TestCase
 
     public function testMissingCommentsAreIgnored()
     {
-        $pasteid = Helper::getPasteId();
-        $name    = 'pastes/' . $pasteid . '/discussion/' . $pasteid . '/ffffffffffffffff';
+        $pasteid                        = Helper::getPasteId();
+        $name                           = 'pastes/' . $pasteid . '/discussion/' . $pasteid . '/ffffffffffffffff';
         self::$_bucket->_objects[$name] = new MissingStorageObjectStub(
             new ConnectionInterfaceStub,
             $name,

--- a/tst/Data/GoogleCloudStorageTest.php
+++ b/tst/Data/GoogleCloudStorageTest.php
@@ -150,6 +150,12 @@ class GoogleCloudStorageTest extends TestCase
         self::$_bucket->upload('{', [
             'name' => 'pastes/' . $pasteid . '/discussion/' . $pasteid . '/ffffffffffffffff',
         ]);
+        self::$_bucket->upload(json_encode($comment), [
+            'name' => 'pastes/' . $pasteid . '/discussion/' . $pasteid . '/invalid',
+        ]);
+        self::$_bucket->upload(json_encode($comment), [
+            'name' => 'pastes/' . $pasteid . '/discussion/invalid/eeeeeeeeeeeeeeee',
+        ]);
 
         $comments = $this->_model->readComments($pasteid);
         $this->assertCount(1, $comments);
@@ -173,6 +179,19 @@ class GoogleCloudStorageTest extends TestCase
         $comments = $this->_model->readComments($pasteid);
         $this->assertCount(1, $comments);
         $this->assertSame($commentid, current($comments)['id']);
+    }
+
+    public function testCommentParentComesFromObjectName()
+    {
+        $pasteid  = Helper::getPasteId();
+        $parentid = 'eeeeeeeeeeeeeeee';
+        $comment  = Helper::getComment();
+        self::$_bucket->upload(json_encode($comment), [
+            'name' => 'pastes/' . $pasteid . '/discussion/' . $parentid . '/' . Helper::getCommentId(),
+        ]);
+
+        $storedComment = current($this->_model->readComments($pasteid));
+        $this->assertSame($parentid, $storedComment['parentid']);
     }
 
     /**

--- a/tst/Data/GoogleCloudStorageTest.php
+++ b/tst/Data/GoogleCloudStorageTest.php
@@ -133,6 +133,21 @@ class GoogleCloudStorageTest extends TestCase
         $this->assertFalse($this->_model->existsComment(Helper::getPasteId(), Helper::getPasteId(), Helper::getCommentId()), 'comment does still not exist');
     }
 
+    public function testCorruptCommentsAreIgnored()
+    {
+        $pasteid   = Helper::getPasteId();
+        $commentid = Helper::getCommentId();
+        $comment   = Helper::getComment();
+        $this->assertTrue($this->_model->createComment($pasteid, $pasteid, $commentid, $comment));
+        self::$_bucket->upload('{', [
+            'name' => 'pastes/' . $pasteid . '/discussion/' . $pasteid . '/ffffffffffffffff',
+        ]);
+
+        $comments = $this->_model->readComments($pasteid);
+        $this->assertCount(1, $comments);
+        $this->assertSame($commentid, current($comments)['id']);
+    }
+
     /**
      * @throws Exception
      */

--- a/tst/Data/GoogleCloudStorageTest.php
+++ b/tst/Data/GoogleCloudStorageTest.php
@@ -5,6 +5,14 @@ use GuzzleHttp\Client;
 use PHPUnit\Framework\TestCase;
 use PrivateBin\Data\GoogleCloudStorage;
 
+class MissingStorageObjectStub extends StorageObjectStub
+{
+    public function downloadAsString(array $options = [])
+    {
+        throw new Google\Cloud\Core\Exception\NotFoundException('object disappeared');
+    }
+}
+
 class GoogleCloudStorageTest extends TestCase
 {
     private static $_client;
@@ -142,6 +150,25 @@ class GoogleCloudStorageTest extends TestCase
         self::$_bucket->upload('{', [
             'name' => 'pastes/' . $pasteid . '/discussion/' . $pasteid . '/ffffffffffffffff',
         ]);
+
+        $comments = $this->_model->readComments($pasteid);
+        $this->assertCount(1, $comments);
+        $this->assertSame($commentid, current($comments)['id']);
+    }
+
+    public function testMissingCommentsAreIgnored()
+    {
+        $pasteid = Helper::getPasteId();
+        $name    = 'pastes/' . $pasteid . '/discussion/' . $pasteid . '/ffffffffffffffff';
+        self::$_bucket->_objects[$name] = new MissingStorageObjectStub(
+            new ConnectionInterfaceStub,
+            $name,
+            self::$_bucket,
+            '1'
+        );
+        $comment   = Helper::getComment();
+        $commentid = Helper::getCommentId();
+        $this->assertTrue($this->_model->createComment($pasteid, $pasteid, $commentid, $comment));
 
         $comments = $this->_model->readComments($pasteid);
         $this->assertCount(1, $comments);

--- a/tst/Data/S3StorageTest.php
+++ b/tst/Data/S3StorageTest.php
@@ -32,7 +32,7 @@ class S3CommentClientStub
         if ($includeCorrupt) {
             $this->_objects[$prefix . 'ffffffffffffffff'] = '{';
             $this->_objects[$prefix . 'eeeeeeeeeeeeeeee'] = json_encode(['meta' => true]);
-            $this->_objects[$prefix . 'invalid'] = json_encode($comment);
+            $this->_objects[$prefix . 'invalid']          = json_encode($comment);
         }
     }
 

--- a/tst/Data/S3StorageTest.php
+++ b/tst/Data/S3StorageTest.php
@@ -25,7 +25,7 @@ class S3CommentClientStub
     public function __construct($pasteid, $parentid, $commentid, $comment, $prefix = '', $includeCorrupt = true)
     {
         $prefix         = empty($prefix) ? '' : $prefix . '/';
-        $prefix        .= $pasteid . '/discussion/' . $parentid . '/';
+        $prefix .= $pasteid . '/discussion/' . $parentid . '/';
         $this->_objects = [
             $prefix . $commentid => json_encode($comment),
         ];
@@ -86,7 +86,7 @@ class S3StorageTest extends TestCase
         $commentid = Helper::getCommentId();
         $client    = new S3CommentClientStub($pasteid, $pasteid, $commentid, Helper::getComment());
         $storage   = $this->getStorage($client);
-        $comments = $storage->readComments($pasteid);
+        $comments  = $storage->readComments($pasteid);
         $this->assertCount(1, $comments);
         $this->assertSame($commentid, current($comments)['id']);
     }

--- a/tst/Data/S3StorageTest.php
+++ b/tst/Data/S3StorageTest.php
@@ -31,6 +31,8 @@ class S3CommentClientStub
         ];
         if ($includeCorrupt) {
             $this->_objects[$prefix . 'ffffffffffffffff'] = '{';
+            $this->_objects[$prefix . 'eeeeeeeeeeeeeeee'] = json_encode(['meta' => true]);
+            $this->_objects[$prefix . 'invalid'] = json_encode($comment);
         }
     }
 
@@ -100,5 +102,37 @@ class S3StorageTest extends TestCase
         $comment   = current($storage->readComments($pasteid));
         $this->assertSame($commentid, $comment['id']);
         $this->assertSame($pasteid, $comment['parentid']);
+    }
+
+    public function testInvalidCommentParentIsIgnored()
+    {
+        $pasteid = Helper::getPasteId();
+        $client  = new S3CommentClientStub(
+            $pasteid,
+            'invalid',
+            Helper::getCommentId(),
+            Helper::getComment(),
+            '',
+            false
+        );
+        $storage = $this->getStorage($client);
+        $this->assertSame([], $storage->readComments($pasteid));
+    }
+
+    public function testCommentParentComesFromObjectKey()
+    {
+        $pasteid = Helper::getPasteId();
+        $parent  = 'eeeeeeeeeeeeeeee';
+        $client  = new S3CommentClientStub(
+            $pasteid,
+            $parent,
+            Helper::getCommentId(),
+            Helper::getComment(),
+            '',
+            false
+        );
+        $storage = $this->getStorage($client);
+        $comment = current($storage->readComments($pasteid));
+        $this->assertSame($parent, $comment['parentid']);
     }
 }

--- a/tst/Data/S3StorageTest.php
+++ b/tst/Data/S3StorageTest.php
@@ -1,0 +1,104 @@
+<?php declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use PrivateBin\Data\S3Storage;
+
+class S3CommentBodyStub
+{
+    private $_data;
+
+    public function __construct($data)
+    {
+        $this->_data = $data;
+    }
+
+    public function getContents()
+    {
+        return $this->_data;
+    }
+}
+
+class S3CommentClientStub
+{
+    private $_objects;
+
+    public function __construct($pasteid, $parentid, $commentid, $comment, $prefix = '', $includeCorrupt = true)
+    {
+        $prefix         = empty($prefix) ? '' : $prefix . '/';
+        $prefix        .= $pasteid . '/discussion/' . $parentid . '/';
+        $this->_objects = [
+            $prefix . $commentid => json_encode($comment),
+        ];
+        if ($includeCorrupt) {
+            $this->_objects[$prefix . 'ffffffffffffffff'] = '{';
+        }
+    }
+
+    public function listObjects($options)
+    {
+        return [
+            'Contents' => array_map(
+                function ($key) {
+                    return ['Key' => $key];
+                },
+                array_keys($this->_objects)
+            ),
+            'IsTruncated' => false,
+        ];
+    }
+
+    public function getObject($options)
+    {
+        return [
+            'Body'     => new S3CommentBodyStub($this->_objects[$options['Key']]),
+            'Metadata' => ['created' => '1'],
+        ];
+    }
+}
+
+class S3StorageTest extends TestCase
+{
+    public function setUp(): void
+    {
+        ini_set('error_log', stream_get_meta_data(tmpfile())['uri']);
+    }
+
+    private function getStorage($client, $prefix = '')
+    {
+        $reflection = new ReflectionClass(S3Storage::class);
+        $storage    = $reflection->newInstanceWithoutConstructor();
+
+        foreach ([
+            '_client' => $client,
+            '_bucket' => 'bucket',
+            '_prefix' => $prefix,
+        ] as $name => $value) {
+            $property = $reflection->getProperty($name);
+            $property->setAccessible(true);
+            $property->setValue($storage, $value);
+        }
+        return $storage;
+    }
+
+    public function testCorruptCommentsAreIgnored()
+    {
+        $pasteid   = Helper::getPasteId();
+        $commentid = Helper::getCommentId();
+        $client    = new S3CommentClientStub($pasteid, $pasteid, $commentid, Helper::getComment());
+        $storage   = $this->getStorage($client);
+        $comments = $storage->readComments($pasteid);
+        $this->assertCount(1, $comments);
+        $this->assertSame($commentid, current($comments)['id']);
+    }
+
+    public function testCommentIdentifiersHonorStoragePrefix()
+    {
+        $pasteid   = Helper::getPasteId();
+        $commentid = Helper::getCommentId();
+        $client    = new S3CommentClientStub($pasteid, $pasteid, $commentid, Helper::getComment(), 'pastes', false);
+        $storage   = $this->getStorage($client, 'pastes');
+        $comment   = current($storage->readComments($pasteid));
+        $this->assertSame($commentid, $comment['id']);
+        $this->assertSame($pasteid, $comment['parentid']);
+    }
+}


### PR DESCRIPTION
## Summary

- skip corrupt or structurally unusable comments in Google Cloud Storage and S3 discussions
- reject malformed parent/comment path components and extra nested key segments
- require S3 comment bodies to contain array metadata
- keep returning valid comments after per-object JSON failures or concurrent deletions
- derive both backends' comment and parent IDs from validated object-key components
- add GCS corruption coverage and a lightweight S3 client stub covering both regressions
- add a GCS regression for an object deleted between listing and download

## Reproductions

### Corrupt cloud comment

GCS catches `JsonException` but replaces the comment with an empty array and immediately reads `meta.created`, causing an undefined-key error. S3 does not catch the decode exception in `readComments()`, so one truncated object aborts the full discussion.

### S3 prefix

For a key such as `pastes/<paste>/discussion/<parent>/<comment>`, fixed indices `[2]` and `[3]` produce `discussion` as the parent ID and `<parent>` as the comment ID. Reading the final two path components works with or without a prefix.

### Object-key and metadata integrity

Both cloud readers accepted arbitrary path components as comment identifiers. GCS also trusted the parent ID embedded in the JSON body instead of the object's authoritative parent path, while S3 accepted array-shaped bodies with scalar `meta`; the latter reaches `array_key_exists()` in the paste model and raises `TypeError` when discussion dates are hidden. The readers now require exactly two valid 16-character lowercase hexadecimal path components, use those components for both IDs, and require usable metadata.

### Concurrent deletion

Both cloud implementations catch not-found errors around the entire comment loop. If an object disappears after listing but before download, iteration stops and later valid comments are omitted. Handling that race per object isolates the missing comment.

## Tests

- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit Data/GoogleCloudStorageTest.php --testdox`
  - 9 tests, 80 assertions passed
- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit Data/S3StorageTest.php --testdox`
  - 4 tests, 6 assertions passed
- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit --filter '/^(?!.*ServerSaltTest)/'`
  - 273 tests, 6518 assertions passed
- `php -l lib/Data/GoogleCloudStorage.php`
- `php -l lib/Data/S3Storage.php`
- `php -l tst/Data/GoogleCloudStorageTest.php`
- `php -l tst/Data/S3StorageTest.php`
- `git diff --check`

The local full suite still has the pre-existing environment-sensitive `ServerSaltTest` assertion failures where PHPUnit displays identical expected and actual salt strings.

## Compatibility and privacy

Valid objects and metadata retain their existing response shape. Parent and comment IDs now consistently come from the storage key, matching the filesystem and database backends. Invalid encrypted objects are logged by key and skipped; structurally invalid keys and metadata are skipped without logging payload contents. Concurrently deleted objects are silently ignored as already missing.

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.