### PR TITLE
Allow work at exact limiter boundaries

### DIFF
--- a/lib/Persistence/PurgeLimiter.php
+++ b/lib/Persistence/PurgeLimiter.php
@@ -69,7 +69,7 @@ class PurgeLimiter extends AbstractPersistence
 
         $now  = time();
         $pl   = (int) self::$_store->getValue('purge_limiter');
-        if ($pl + self::$_limit >= $now) {
+        if ($pl + self::$_limit > $now) {
             return false;
         }
         $hasStored = self::$_store->setValue((string) $now, 'purge_limiter');

--- a/lib/Persistence/TrafficLimiter.php
+++ b/lib/Persistence/TrafficLimiter.php
@@ -203,7 +203,7 @@ class TrafficLimiter extends AbstractPersistence
         $now  = time();
         $tl   = (int) self::$_store->getValue('traffic_limiter', $hash);
         self::$_store->purgeValues('traffic_limiter', $now - self::$_limit);
-        if ($tl === 0 || ($tl + self::$_limit) < $now) {
+        if ($tl === 0 || ($tl + self::$_limit) <= $now) {
             if (!self::$_store->setValue((string) $now, 'traffic_limiter', $hash)) {
                 error_log('failed to store the traffic limiter, it probably contains outdated information');
             }

--- a/tst/Persistence/PurgeLimiterTest.php
+++ b/tst/Persistence/PurgeLimiterTest.php
@@ -8,6 +8,8 @@ class PurgeLimiterTest extends TestCase
 {
     private $_path;
 
+    private $_store;
+
     public function setUp(): void
     {
         /* Setup Routine */
@@ -15,9 +17,8 @@ class PurgeLimiterTest extends TestCase
         if (!is_dir($this->_path)) {
             mkdir($this->_path);
         }
-        PurgeLimiter::setStore(
-            new Filesystem(['dir' => $this->_path])
-        );
+        $this->_store = new Filesystem(['dir' => $this->_path]);
+        PurgeLimiter::setStore($this->_store);
     }
 
     public function tearDown(): void
@@ -41,5 +42,12 @@ class PurgeLimiterTest extends TestCase
         PurgeLimiter::setLimit(0);
         PurgeLimiter::canPurge();
         $this->assertEquals(true, PurgeLimiter::canPurge());
+    }
+
+    public function testPurgePassesAtExactLimitBoundary()
+    {
+        PurgeLimiter::setLimit(10);
+        $this->_store->setValue((string) (time() - 10), 'purge_limiter');
+        $this->assertTrue(PurgeLimiter::canPurge());
     }
 }

--- a/tst/Persistence/TrafficLimiterTest.php
+++ b/tst/Persistence/TrafficLimiterTest.php
@@ -64,7 +64,7 @@ class TrafficLimiterTest extends TestCase
     public function testTrafficPassesAtExactLimitBoundary()
     {
         TrafficLimiter::setLimit(10);
-        $_SERVER['REMOTE_ADDR'] = '127.0.0.1';
+        $_SERVER['REMOTE_ADDR']  = '127.0.0.1';
         $hash                    = TrafficLimiter::getHash('sha256');
         $this->_store->setValue((string) (time() - 10), 'traffic_limiter', $hash);
         $this->assertTrue(TrafficLimiter::canPass());

--- a/tst/Persistence/TrafficLimiterTest.php
+++ b/tst/Persistence/TrafficLimiterTest.php
@@ -9,13 +9,18 @@ class TrafficLimiterTest extends TestCase
 {
     private $_path;
 
+    private $_store;
+
     public function setUp(): void
     {
         /* Setup Routine */
-        $this->_path = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'trafficlimit';
-        $store       = new Filesystem(['dir' => $this->_path]);
-        ServerSalt::setStore($store);
-        TrafficLimiter::setStore($store);
+        $this->_path  = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'trafficlimit';
+        $this->_store = new Filesystem(['dir' => $this->_path]);
+        ServerSalt::setStore($this->_store);
+        TrafficLimiter::setStore($this->_store);
+        TrafficLimiter::setCreators(null);
+        TrafficLimiter::setExempted(null);
+        TrafficLimiter::setLimit(4);
     }
 
     public function tearDown(): void
@@ -54,6 +59,15 @@ class TrafficLimiterTest extends TestCase
         } catch (Exception $e) {
             $this->assertEquals($e->getMessage(), 'Please wait 4 seconds between each post.', 'fifth request is to fast, may not pass');
         }
+    }
+
+    public function testTrafficPassesAtExactLimitBoundary()
+    {
+        TrafficLimiter::setLimit(10);
+        $_SERVER['REMOTE_ADDR'] = '127.0.0.1';
+        $hash                    = TrafficLimiter::getHash('sha256');
+        $this->_store->setValue((string) (time() - 10), 'traffic_limiter', $hash);
+        $this->assertTrue(TrafficLimiter::canPass());
     }
 
     public function testTrafficLimitExempted()


### PR DESCRIPTION
## Summary

- allow a new submission and purge when exactly the configured interval has elapsed
- add stored-timestamp regressions for both limiters
- reset static limiter settings in test setup to remove test-order coupling

## Reproduction

With a 10-second limit, a last-submission timestamp of `now - 10` is rejected because the traffic comparison requires `last + limit < now`. The purge limiter has the equivalent `last + limit >= now` check. Since timestamps have one-second resolution, both effectively require an extra second.

## Tests

- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit Persistence/TrafficLimiterTest.php --testdox`
  - 5 tests, 25 assertions passed
- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit Persistence/PurgeLimiterTest.php --testdox`
  - 2 tests, 4 assertions passed
- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit --filter '/^(?!.*ServerSaltTest)/'`
  - 268 tests, 6507 assertions passed
- PHP syntax checks for both limiter classes
- `git diff --check`

The local full suite still has the pre-existing environment-sensitive `ServerSaltTest` assertion failures where PHPUnit displays identical expected and actual salt strings.

## Compatibility

Submissions and purge cycles attempted before their configured intervals are still rejected. Only the exact boundaries change from rejected to allowed.

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.