### PR TITLE
Support three-letter forced default languages

### DIFF
--- a/lib/Controller.php
+++ b/lib/Controller.php
@@ -203,7 +203,10 @@ class Controller
         $lang = $this->_conf->getKey('languagedefault');
         I18n::setLanguageFallback($lang);
         // force default language, if language selection is disabled and a default is set
-        if (!$this->_conf->getKey('languageselection') && strlen($lang) === 2) {
+        if (
+            !$this->_conf->getKey('languageselection') &&
+            in_array($lang, I18n::getAvailableLanguages(), true)
+        ) {
             $_COOKIE['lang'] = $lang;
             setcookie('lang', $lang, ['SameSite' => 'Lax', 'Secure' => true]);
         }

--- a/tst/ControllerTest.php
+++ b/tst/ControllerTest.php
@@ -4,6 +4,7 @@ use PHPUnit\Framework\TestCase;
 use PrivateBin\Configuration;
 use PrivateBin\Controller;
 use PrivateBin\Data\Filesystem;
+use PrivateBin\I18n;
 use PrivateBin\Persistence\ServerSalt;
 use PrivateBin\Persistence\TrafficLimiter;
 use PrivateBin\Request;
@@ -113,6 +114,23 @@ class ControllerTest extends TestCase
             $content,
             'outputs title correctly'
         );
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testViewForceThreeLetterLanguageDefault()
+    {
+        $options                              = parse_ini_file(CONF, true);
+        $options['main']['languageselection'] = false;
+        $options['main']['languagedefault']   = 'jbo';
+        Helper::createIniFile(CONF, $options);
+        $_COOKIE['lang'] = 'de';
+        ob_start();
+        new Controller;
+        ob_end_clean();
+        $this->assertSame('jbo', I18n::getLanguage());
+        $this->assertSame('jbo', $_COOKIE['lang']);
     }
 
     /**


### PR DESCRIPTION
## Summary

- validate a forced default language against PrivateBin's available locales
- support the shipped three-letter `jbo` language when language selection is disabled
- avoid writing unsupported two-letter values into the language cookie
- add an end-to-end controller regression with a conflicting existing cookie

## Reproduction

Set:

```ini
languageselection = false
languagedefault = "jbo"
```

and visit with an existing `lang=de` cookie. `_setDefaultLanguage()` only forces defaults whose string length is exactly two, so the German cookie remains active and the configured Lojban-only policy is ignored.

## Tests

- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit ControllerTest.php --testdox`
  - 37 tests, 106 assertions passed
- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit --filter '/^(?!.*ServerSaltTest)/'`
  - 269 tests, 6511 assertions passed
- `php -l lib/Controller.php`
- `git diff --check`

The local full suite still has the pre-existing environment-sensitive `ServerSaltTest` assertion failures where PHPUnit displays identical expected and actual salt strings.

## Compatibility

All currently shipped two-letter locales remain accepted. The check now follows the authoritative locale list, so unsupported values are ignored and the existing validated fallback behavior remains in effect.

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.