### PR TITLE
Validate Format V2 scalar field types

### DIFF
--- a/lib/FormatV2.php
+++ b/lib/FormatV2.php
@@ -56,6 +56,14 @@ class FormatV2
             return false;
         }
 
+        if (!$isComment && (
+            !is_string($message['adata'][1] ?? null) ||
+            !is_int($message['adata'][2] ?? null) ||
+            !is_int($message['adata'][3] ?? null)
+        )) {
+            return false;
+        }
+
         $cipherParams = $isComment ? $message['adata'] : ($message['adata'][0] ?? null);
 
         // Make sure the cipher parameters are a properly sized array.

--- a/lib/FormatV2.php
+++ b/lib/FormatV2.php
@@ -89,15 +89,18 @@ class FormatV2
 
         // Make sure some fields are base64 data:
         // - initialization vector
-        if (!base64_decode($cipherParams[0], true)) {
+        $iv = base64_decode($cipherParams[0], true);
+        if ($iv === false || $iv === '') {
             return false;
         }
         // - salt
-        if (!base64_decode($cipherParams[1], true)) {
+        $salt = base64_decode($cipherParams[1], true);
+        if ($salt === false || $salt === '') {
             return false;
         }
         // - cipher text
-        if (!($ct = base64_decode($message['ct'], true))) {
+        $ct = base64_decode($message['ct'], true);
+        if ($ct === false || $ct === '') {
             return false;
         }
 

--- a/lib/FormatV2.php
+++ b/lib/FormatV2.php
@@ -51,6 +51,13 @@ class FormatV2
             }
         }
 
+        if ($isComment && (
+            !is_string($message['pasteid']) ||
+            !is_string($message['parentid'])
+        )) {
+            return false;
+        }
+
         // Make sure adata is an array.
         if (!is_array($message['adata'])) {
             return false;
@@ -144,6 +151,7 @@ class FormatV2
             !is_array($message['meta']) ||
             count($message['meta']) === 0 ||
             !array_key_exists('expire', $message['meta']) ||
+            !(is_string($message['meta']['expire']) || is_int($message['meta']['expire'])) ||
             count($message['meta']) > 1
         )) {
             return false;

--- a/tst/FormatV2Test.php
+++ b/tst/FormatV2Test.php
@@ -111,6 +111,10 @@ class FormatV2Test extends TestCase
             $this->assertFalse(FormatV2::isValid($paste), "invalid paste adata field $index");
         }
 
+        $paste                    = Helper::getPastePost();
+        $paste['meta']['expire'] = [];
+        $this->assertFalse(FormatV2::isValid($paste), 'array expiration');
+
         $paste                = Helper::getPastePost();
         $paste['adata'][0][0] = [];
         $this->assertFalse(FormatV2::isValid($paste), 'non-string iv');
@@ -118,5 +122,13 @@ class FormatV2Test extends TestCase
         $comment           = Helper::getCommentPost();
         $comment['ct']     = 42;
         $this->assertFalse(FormatV2::isValid($comment, true), 'non-string comment ciphertext');
+
+        $comment            = Helper::getCommentPost();
+        $comment['pasteid'] = [];
+        $this->assertFalse(FormatV2::isValid($comment, true), 'non-string paste ID');
+
+        $comment             = Helper::getCommentPost();
+        $comment['parentid'] = [];
+        $this->assertFalse(FormatV2::isValid($comment, true), 'non-string parent ID');
     }
 }

--- a/tst/FormatV2Test.php
+++ b/tst/FormatV2Test.php
@@ -23,6 +23,18 @@ class FormatV2Test extends TestCase
         $paste['ct'] = '$';
         $this->assertFalse(FormatV2::isValid($paste), 'invalid base64 encoding of ct');
 
+        $paste                = Helper::getPastePost();
+        $paste['adata'][0][0] = 'MA==';
+        $this->assertTrue(FormatV2::isValid($paste), 'valid base64 iv decoding to zero');
+
+        $paste                = Helper::getPastePost();
+        $paste['adata'][0][1] = 'MA==';
+        $this->assertTrue(FormatV2::isValid($paste), 'valid base64 salt decoding to zero');
+
+        $paste       = Helper::getPastePost();
+        $paste['ct'] = 'MA==';
+        $this->assertTrue(FormatV2::isValid($paste), 'valid base64 ct decoding to zero');
+
         $paste       = Helper::getPastePost();
         $paste['ct'] = 'bm9kYXRhbm9kYXRhbm9kYXRhbm9kYXRhbm9kYXRhCg==';
         $this->assertFalse(FormatV2::isValid($paste), 'low ct entropy');

--- a/tst/FormatV2Test.php
+++ b/tst/FormatV2Test.php
@@ -101,6 +101,16 @@ class FormatV2Test extends TestCase
         $paste['adata'][0] = [];
         $this->assertFalse(FormatV2::isValid($paste), 'empty cipher parameters');
 
+        foreach ([
+            1 => ['plaintext'],
+            2 => '1',
+            3 => false,
+        ] as $index => $value) {
+            $paste                   = Helper::getPastePost();
+            $paste['adata'][$index] = $value;
+            $this->assertFalse(FormatV2::isValid($paste), "invalid paste adata field $index");
+        }
+
         $paste                = Helper::getPastePost();
         $paste['adata'][0][0] = [];
         $this->assertFalse(FormatV2::isValid($paste), 'non-string iv');

--- a/tst/FormatV2Test.php
+++ b/tst/FormatV2Test.php
@@ -107,12 +107,12 @@ class FormatV2Test extends TestCase
             3 => false,
         ] as $index => $value) {
             $paste                   = Helper::getPastePost();
-            $paste['adata'][$index] = $value;
+            $paste['adata'][$index]  = $value;
             $this->assertFalse(FormatV2::isValid($paste), "invalid paste adata field $index");
         }
 
         $paste                    = Helper::getPastePost();
-        $paste['meta']['expire'] = [];
+        $paste['meta']['expire']  = [];
         $this->assertFalse(FormatV2::isValid($paste), 'array expiration');
 
         $paste                = Helper::getPastePost();


### PR DESCRIPTION
## Summary

- require the paste formatter authenticated-data field to be a string
- require open-discussion and burn-after-reading fields to be integers
- require comment paste/parent IDs to be strings
- reject array expiration selectors while preserving integer fallback behavior
- reject missing or malformed paste fields at the format boundary
- distinguish base64 decode failures from the valid non-empty decoded value `"0"`
- add regression coverage for array/string/boolean type confusion

## Reproduction

`FormatV2::isValid()` currently accepts a paste whose `adata[1]` formatter is an array. `Paste::_validate()` then passes that array to `array_key_exists()`, which raises a `TypeError` instead of returning the normal JSON “Invalid data” response. Missing or malformed flag slots likewise reach model code that assumes their presence.

The same boundary accepts array-valued comment IDs, causing array-to-string errors during ID validation, and an array-valued `meta.expire`, causing an illegal-offset `TypeError` during expiration lookup.

The base64 checks also use truthiness on decoded strings. `MA==` is valid base64 but decodes to PHP's falsey string `"0"`, so it is uniquely rejected for IV, salt, or ciphertext while other non-empty decoded values pass.

## Tests

- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit FormatV2Test.php --testdox`
  - 2 tests, 35 assertions passed
- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit --filter '/^(?!.*ServerSaltTest)/'`
  - 266 tests, 6514 assertions passed
- `php -l lib/FormatV2.php`
- `php -l tst/FormatV2Test.php`
- `git diff --check`

The local full suite still has the pre-existing environment-sensitive `ServerSaltTest` assertion failures where PHPUnit displays identical expected and actual salt strings.

## Compatibility and security

Valid version-2 pastes already use a formatter string, integer 0/1 flags, and string comment IDs. String and integer expiration selectors remain accepted, including the existing behavior where unknown integers fall back to the configured default. Malformed shapes are rejected before strict PHP operations can turn an untrusted request into a server error. Base64 policy is unchanged: decoding failures and empty results remain invalid, while all non-empty successfully decoded byte strings are handled consistently.

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.