### PR TITLE
Reject malformed stored paste records

### DIFF
--- a/lib/Model/Paste.php
+++ b/lib/Model/Paste.php
@@ -53,7 +53,11 @@ class Paste extends AbstractModel
     public function get()
     {
         $data = $this->_store->read($this->getId());
-        if ($data === false) {
+        if (
+            !is_array($data) ||
+            !isset($data['meta']) ||
+            !is_array($data['meta'])
+        ) {
             throw new TranslatedException(Controller::GENERIC_ERROR, 64);
         }
 

--- a/lib/Model/Paste.php
+++ b/lib/Model/Paste.php
@@ -63,13 +63,21 @@ class Paste extends AbstractModel
 
         // check if paste has expired and delete it if necessary.
         if (array_key_exists('expire_date', $data['meta'])) {
-            $now = time();
-            if ($data['meta']['expire_date'] < $now) {
+            $expireDate = $data['meta']['expire_date'];
+            if (
+                !is_int($expireDate) &&
+                !(is_string($expireDate) && preg_match('/\A[+-]?\d+\z/', $expireDate) === 1)
+            ) {
+                throw new TranslatedException(Controller::GENERIC_ERROR, 64);
+            }
+            $expireDate = (int) $expireDate;
+            $now        = time();
+            if ($expireDate < $now) {
                 $this->delete();
                 throw new TranslatedException(Controller::GENERIC_ERROR, 63);
             }
             // We kindly provide the remaining time before expiration (in seconds)
-            $data['meta']['time_to_live'] = $data['meta']['expire_date'] - $now;
+            $data['meta']['time_to_live'] = $expireDate - $now;
             unset($data['meta']['expire_date']);
         }
         if (array_key_exists('created', $data['meta'])) {

--- a/lib/Model/Paste.php
+++ b/lib/Model/Paste.php
@@ -191,10 +191,18 @@ class Paste extends AbstractModel
      */
     public function getDeleteToken()
     {
-        if (!array_key_exists('salt', $this->_data['meta'])) {
+        if (
+            !isset($this->_data['meta']) ||
+            !is_array($this->_data['meta']) ||
+            !array_key_exists('salt', $this->_data['meta'])
+        ) {
             $this->get();
         }
-        return hash_hmac('sha256', $this->getId(), $this->_data['meta']['salt']);
+        $salt = $this->_data['meta']['salt'] ?? null;
+        if (!is_string($salt) || $salt === '') {
+            throw new TranslatedException(Controller::GENERIC_ERROR, 64);
+        }
+        return hash_hmac('sha256', $this->getId(), $salt);
     }
 
     /**

--- a/tst/ModelTest.php
+++ b/tst/ModelTest.php
@@ -4,6 +4,7 @@ use Jdenticon\Identicon;
 use PHPUnit\Framework\TestCase;
 use PrivateBin\Configuration;
 use PrivateBin\Data\Database;
+use PrivateBin\Data\Filesystem;
 use PrivateBin\Model;
 use PrivateBin\Model\Comment;
 use PrivateBin\Model\Paste;
@@ -285,6 +286,25 @@ class ModelTest extends TestCase
     {
         $this->_model->getPaste(Helper::getPasteId())->delete();
         $paste = $this->_model->getPaste(Helper::getPasteId());
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(64);
+        $paste->get();
+    }
+
+    public function testMalformedStoredPaste()
+    {
+        $pasteid = Helper::getPasteId();
+        $path    = $this->_path . DIRECTORY_SEPARATOR . substr($pasteid, 0, 2) .
+            DIRECTORY_SEPARATOR . substr($pasteid, 2, 2) . DIRECTORY_SEPARATOR;
+        if (!is_dir($path)) {
+            mkdir($path, 0700, true);
+        }
+        file_put_contents(
+            $path . $pasteid . '.php',
+            Filesystem::PROTECTION_LINE . PHP_EOL . 'true'
+        );
+        $paste = new Paste($this->_conf, new Filesystem(['dir' => $this->_path]));
+        $paste->setId($pasteid);
         $this->expectException(Exception::class);
         $this->expectExceptionCode(64);
         $paste->get();

--- a/tst/ModelTest.php
+++ b/tst/ModelTest.php
@@ -310,6 +310,25 @@ class ModelTest extends TestCase
         $paste->get();
     }
 
+    public function testMalformedStoredPasteSalt()
+    {
+        $pasteid                 = Helper::getPasteId();
+        $paste                   = Helper::getPaste();
+        $paste['meta']['salt']   = [];
+        $store                   = $this->_model->getStore();
+        $store->delete($pasteid);
+        $this->assertTrue($store->create($pasteid, $paste));
+
+        try {
+            $this->_model->getPaste($pasteid)->getDeleteToken();
+            $this->fail('corrupt salt was accepted');
+        } catch (Exception $e) {
+            $this->assertSame(64, $e->getCode());
+        } finally {
+            $store->delete($pasteid);
+        }
+    }
+
     public function testInvalidPasteFormat()
     {
         $pasteData             = Helper::getPastePost();

--- a/tst/ModelTest.php
+++ b/tst/ModelTest.php
@@ -329,6 +329,34 @@ class ModelTest extends TestCase
         }
     }
 
+    public function testMalformedStoredPasteExpiration()
+    {
+        $pasteid = Helper::getPasteId();
+        $store   = new Filesystem(['dir' => $this->_path]);
+        foreach ([[], 'invalid'] as $expireDate) {
+            $paste = Helper::getPaste(['expire_date' => $expireDate]);
+            $store->delete($pasteid);
+            $this->assertTrue($store->create($pasteid, $paste));
+            try {
+                $storedPaste = new Paste($this->_conf, $store);
+                $storedPaste->setId($pasteid);
+                $storedPaste->get();
+                $this->fail('corrupt expiration date was accepted');
+            } catch (Exception $e) {
+                $this->assertSame(64, $e->getCode());
+            } finally {
+                $store->delete($pasteid);
+            }
+        }
+
+        $paste = Helper::getPaste(['expire_date' => (string) (time() + 60)]);
+        $this->assertTrue($store->create($pasteid, $paste));
+        $storedPaste = new Paste($this->_conf, $store);
+        $storedPaste->setId($pasteid);
+        $this->assertIsInt($storedPaste->get()['meta']['time_to_live']);
+        $store->delete($pasteid);
+    }
+
     public function testInvalidPasteFormat()
     {
         $pasteData             = Helper::getPastePost();


### PR DESCRIPTION
## Summary

- validate the minimum stored-paste shape before reading metadata
- return PrivateBin's existing generic document error for scalar or metadata-less records
- require a non-empty string salt before generating a deletion token
- validate stored expiration timestamps before comparison or subtraction
- protect every storage backend at the shared model boundary
- add regressions for valid scalar JSON, malformed salt, and malformed expiration dates

## Reproduction

A paste file containing the protected payload `true` is valid JSON, so the filesystem backend returns boolean `true` rather than `false`. `Paste::get()` then indexes `true['meta']`, producing a PHP error instead of the generic missing/expired document response. Other backends can return the same shape when stored data is corrupted but still valid JSON.

A stored paste whose `meta.salt` is an array passes the minimum shape check and loads normally. Deletion then passes that array to `hash_hmac()`, causing an uncaught `TypeError`. Missing, empty, or non-string salts now use the same generic code-64 document error.

An array or nonnumeric string in `meta.expire_date` similarly reaches timestamp subtraction and raises `TypeError`. Stored integer timestamps and legacy signed integer strings remain supported and are normalized before comparison.

## Tests

- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit ModelTest.php --testdox`
  - 22 tests, 112 assertions passed
- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit --filter '/^(?!.*ServerSaltTest)/'`
  - 269 tests, 6515 assertions passed
- `php -l lib/Model/Paste.php`
- `php -l tst/ModelTest.php`
- `git diff --check`

The local full suite still has the pre-existing environment-sensitive `ServerSaltTest` assertion failures where PHPUnit displays identical expected and actual salt strings.

## Compatibility and privacy

Valid and legacy paste arrays with usable string salts and integer-form expiration timestamps remain supported. Invalid stored shapes, salts, or timestamps use the same generic error as an unreadable record, avoiding internal PHP error disclosure, accidental exposure of malformed stored content, and deletion-token generation with an empty key.

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.