### PR TITLE
Reject corrupt database records

### DIFF
--- a/lib/Data/Database.php
+++ b/lib/Data/Database.php
@@ -310,10 +310,15 @@ class Database extends AbstractData
      */
     public function readComments($pasteid)
     {
-        $rows = $this->_select(
-            'SELECT * FROM "' . $this->_sanitizeIdentifier('comment') .
-            '" WHERE "pasteid" = ?', [$pasteid]
-        );
+        try {
+            $rows = $this->_select(
+                'SELECT * FROM "' . $this->_sanitizeIdentifier('comment') .
+                '" WHERE "pasteid" = ?', [$pasteid]
+            );
+        } catch (PDOException $e) {
+            error_log('Error while reading comments from the database: ' . $e->getMessage());
+            return [];
+        }
 
         // create comment list
         $comments = [];

--- a/lib/Data/Database.php
+++ b/lib/Data/Database.php
@@ -342,6 +342,13 @@ class Database extends AbstractData
                     error_log('Error while reading a comment from the database: invalid data structure');
                     continue;
                 }
+                if (
+                    preg_match('/\A[a-f0-9]{16}\z/', (string) $row['dataid']) !== 1 ||
+                    preg_match('/\A[a-f0-9]{16}\z/', (string) $row['parentid']) !== 1
+                ) {
+                    error_log('Error while reading a comment from the database: invalid identifier');
+                    continue;
+                }
                 $i                          = $this->getOpenSlot($comments, (int) $row['postdate']);
                 $comments[$i]               = $data;
                 $comments[$i]['id']         = $row['dataid'];

--- a/lib/Data/Database.php
+++ b/lib/Data/Database.php
@@ -230,14 +230,22 @@ class Database extends AbstractData
      */
     public function delete($pasteid)
     {
-        $this->_exec(
-            'DELETE FROM "' . $this->_sanitizeIdentifier('paste') .
-            '" WHERE "dataid" = ?', [$pasteid]
-        );
-        $this->_exec(
-            'DELETE FROM "' . $this->_sanitizeIdentifier('comment') .
-            '" WHERE "pasteid" = ?', [$pasteid]
-        );
+        try {
+            $this->_exec(
+                'DELETE FROM "' . $this->_sanitizeIdentifier('paste') .
+                '" WHERE "dataid" = ?', [$pasteid]
+            );
+        } catch (PDOException $e) {
+            error_log('Error while deleting a paste from the database: ' . $e->getMessage());
+        }
+        try {
+            $this->_exec(
+                'DELETE FROM "' . $this->_sanitizeIdentifier('comment') .
+                '" WHERE "pasteid" = ?', [$pasteid]
+            );
+        } catch (PDOException $e) {
+            error_log('Error while deleting comments from the database: ' . $e->getMessage());
+        }
     }
 
     /**

--- a/lib/Data/Database.php
+++ b/lib/Data/Database.php
@@ -214,7 +214,7 @@ class Database extends AbstractData
             return false;
         }
         $paste['meta'] = $meta;
-        $expire_date = (int) $row['expiredate'];
+        $expire_date   = (int) $row['expiredate'];
         if ($expire_date > 0) {
             $paste['meta']['expire_date'] = $expire_date;
         }

--- a/lib/Data/Database.php
+++ b/lib/Data/Database.php
@@ -486,9 +486,17 @@ class Database extends AbstractData
      */
     public function getAllPastes()
     {
-        return $this->_db->query(
+        $ids = $this->_db->query(
             'SELECT "dataid" FROM "' . $this->_sanitizeIdentifier('paste') . '"'
         )->fetchAll(PDO::FETCH_COLUMN, 0);
+        $pastes = [];
+        foreach ($ids as $pasteid) {
+            $pasteid = (string) $pasteid;
+            if (preg_match('/\A[a-f0-9]{16}\z/', $pasteid) === 1) {
+                $pastes[] = $pasteid;
+            }
+        }
+        return $pastes;
     }
 
     /**

--- a/lib/Data/Database.php
+++ b/lib/Data/Database.php
@@ -196,15 +196,24 @@ class Database extends AbstractData
             $paste = Json::decode($row['data']);
         } catch (JsonException $e) {
             error_log('Error while reading a paste from the database: ' . $e->getMessage());
-            $paste = [];
+            return false;
+        }
+        if (!is_array($paste)) {
+            error_log('Error while reading a paste from the database: invalid data structure');
+            return false;
         }
 
         try {
-            $paste['meta'] = Json::decode($row['meta']);
+            $meta = Json::decode($row['meta']);
         } catch (JsonException $e) {
             error_log('Error while reading a paste from the database: ' . $e->getMessage());
-            $paste['meta'] = [];
+            return false;
         }
+        if (!is_array($meta)) {
+            error_log('Error while reading a paste from the database: invalid metadata structure');
+            return false;
+        }
+        $paste['meta'] = $meta;
         $expire_date = (int) $row['expiredate'];
         if ($expire_date > 0) {
             $paste['meta']['expire_date'] = $expire_date;
@@ -314,7 +323,11 @@ class Database extends AbstractData
                     $data = Json::decode($row['data']);
                 } catch (JsonException $e) {
                     error_log('Error while reading a comment from the database: ' . $e->getMessage());
-                    $data = [];
+                    continue;
+                }
+                if (!is_array($data)) {
+                    error_log('Error while reading a comment from the database: invalid data structure');
+                    continue;
                 }
                 $i                          = $this->getOpenSlot($comments, (int) $row['postdate']);
                 $comments[$i]               = $data;

--- a/tst/Data/DatabaseTest.php
+++ b/tst/Data/DatabaseTest.php
@@ -131,6 +131,19 @@ class DatabaseTest extends TestCase
         ini_set('error_log', $errorLog);
     }
 
+    public function testPasteEnumerationRejectsInvalidIdentifiers()
+    {
+        $this->_model->delete(Helper::getPasteId());
+        $database  = $this->getDatabaseConnection();
+        $statement = $database->prepare('INSERT INTO paste VALUES(?,?,?,?)');
+        $statement->execute(['invalid', '{}', 0, '{}']);
+        try {
+            $this->assertSame([], $this->_model->getAllPastes());
+        } finally {
+            $database->exec("DELETE FROM paste WHERE dataid = 'invalid'");
+        }
+    }
+
     public function testCorruptCommentsAreIgnored()
     {
         $this->_model->delete(Helper::getPasteId());

--- a/tst/Data/DatabaseTest.php
+++ b/tst/Data/DatabaseTest.php
@@ -154,6 +154,22 @@ class DatabaseTest extends TestCase
             null,
             time(),
         ]);
+        $statement->execute([
+            'invalid',
+            Helper::getPasteId(),
+            Helper::getPasteId(),
+            json_encode($comment),
+            null,
+            time(),
+        ]);
+        $statement->execute([
+            'eeeeeeeeeeeeeeee',
+            Helper::getPasteId(),
+            'invalid',
+            json_encode($comment),
+            null,
+            time(),
+        ]);
         $errorLog = ini_get('error_log');
         ini_set('error_log', '/dev/null');
         $comments = $this->_model->readComments(Helper::getPasteId());

--- a/tst/Data/DatabaseTest.php
+++ b/tst/Data/DatabaseTest.php
@@ -34,6 +34,13 @@ class DatabaseTest extends TestCase
         }
     }
 
+    private function getDatabaseConnection()
+    {
+        $property = new ReflectionProperty(Database::class, '_db');
+        $property->setAccessible(true);
+        return $property->getValue($this->_model);
+    }
+
     public function testSaltMigration()
     {
         ServerSalt::setStore(new Filesystem(['dir' => 'data']));
@@ -107,6 +114,52 @@ class DatabaseTest extends TestCase
         $this->assertFalse($this->_model->create(Helper::getPasteId(), $paste), 'unable to store the same paste twice');
         ini_set('error_log', $error_log_setting);
         $this->assertEquals($original, $this->_model->read(Helper::getPasteId()));
+    }
+
+    public function testCorruptPasteIsRejected()
+    {
+        $this->_model->delete(Helper::getPasteId());
+        $paste = Helper::getPaste();
+        $this->assertTrue($this->_model->create(Helper::getPasteId(), $paste));
+        $statement = $this->getDatabaseConnection()->prepare(
+            'UPDATE paste SET data = ? WHERE dataid = ?'
+        );
+        $statement->execute(['true', Helper::getPasteId()]);
+        $errorLog = ini_get('error_log');
+        ini_set('error_log', '/dev/null');
+        $this->assertFalse($this->_model->read(Helper::getPasteId()));
+        ini_set('error_log', $errorLog);
+    }
+
+    public function testCorruptCommentsAreIgnored()
+    {
+        $this->_model->delete(Helper::getPasteId());
+        $comment = Helper::getComment();
+        $this->assertTrue(
+            $this->_model->createComment(
+                Helper::getPasteId(),
+                Helper::getPasteId(),
+                Helper::getCommentId(),
+                $comment
+            )
+        );
+        $statement = $this->getDatabaseConnection()->prepare(
+            'INSERT INTO comment VALUES(?,?,?,?,?,?)'
+        );
+        $statement->execute([
+            'ffffffffffffffff',
+            Helper::getPasteId(),
+            Helper::getPasteId(),
+            'true',
+            null,
+            time(),
+        ]);
+        $errorLog = ini_get('error_log');
+        ini_set('error_log', '/dev/null');
+        $comments = $this->_model->readComments(Helper::getPasteId());
+        ini_set('error_log', $errorLog);
+        $this->assertCount(1, $comments);
+        $this->assertSame(Helper::getCommentId(), current($comments)['id']);
     }
 
     /**

--- a/tst/Data/DatabaseTest.php
+++ b/tst/Data/DatabaseTest.php
@@ -171,6 +171,49 @@ class DatabaseTest extends TestCase
         ini_set('error_log', $errorLog);
     }
 
+    public function testDeleteContinuesAfterPasteQueryFailure()
+    {
+        $comment = Helper::getComment();
+        $this->assertTrue(
+            $this->_model->createComment(
+                Helper::getPasteId(),
+                Helper::getPasteId(),
+                Helper::getCommentId(),
+                $comment
+            )
+        );
+        $this->getDatabaseConnection()->exec('DROP TABLE paste');
+        $errorLog = ini_get('error_log');
+        ini_set('error_log', '/dev/null');
+        try {
+            $this->_model->delete(Helper::getPasteId());
+        } finally {
+            ini_set('error_log', $errorLog);
+        }
+        $this->assertFalse(
+            $this->_model->existsComment(
+                Helper::getPasteId(),
+                Helper::getPasteId(),
+                Helper::getCommentId()
+            )
+        );
+    }
+
+    public function testDeleteHandlesCommentQueryFailure()
+    {
+        $paste = Helper::getPaste();
+        $this->assertTrue($this->_model->create(Helper::getPasteId(), $paste));
+        $this->getDatabaseConnection()->exec('DROP TABLE comment');
+        $errorLog = ini_get('error_log');
+        ini_set('error_log', '/dev/null');
+        try {
+            $this->_model->delete(Helper::getPasteId());
+        } finally {
+            ini_set('error_log', $errorLog);
+        }
+        $this->assertFalse($this->_model->exists(Helper::getPasteId()));
+    }
+
     /**
      * pastes a-g are expired and should get deleted, x never expires and y-z expire in an hour
      */

--- a/tst/Data/DatabaseTest.php
+++ b/tst/Data/DatabaseTest.php
@@ -162,6 +162,15 @@ class DatabaseTest extends TestCase
         $this->assertSame(Helper::getCommentId(), current($comments)['id']);
     }
 
+    public function testCommentQueryFailureReturnsEmptyList()
+    {
+        $this->getDatabaseConnection()->exec('DROP TABLE comment');
+        $errorLog = ini_get('error_log');
+        ini_set('error_log', '/dev/null');
+        $this->assertSame([], $this->_model->readComments(Helper::getPasteId()));
+        ini_set('error_log', $errorLog);
+    }
+
     /**
      * pastes a-g are expired and should get deleted, x never expires and y-z expire in an hour
      */


### PR DESCRIPTION
## Summary

- return `false` when database paste data or metadata cannot be decoded into arrays
- skip scalar comment rows and rows with malformed comment or parent IDs while preserving valid comments
- return an empty comment list when the comment query itself fails
- isolate paste and comment deletion failures so either cleanup can still succeed
- exclude malformed paste identifiers from database enumeration
- log structural failures without logging stored encrypted payloads
- add direct SQLite regressions for corrupt rows and failed read/delete queries

## Reproduction

JSON scalars such as `true` decode successfully. A paste row whose `data` column contains `true` therefore reaches `$paste['meta']` and raises `Cannot use a scalar value as an array`. A scalar comment row fails in the same way while adding its ID and metadata.

Array-shaped comment rows with malformed `dataid` or `parentid` values were also returned to clients. These now use the same lowercase 16-character hexadecimal identifier rule enforced by the model.

Malformed paste JSON was also converted into an empty partial record, unlike the other storage backends that report an unreadable paste.

`readComments()` also uniquely allowed its initial `PDOException` to escape. Dropping the SQLite comment table reproduced a request-ending exception; it now logs the database error and returns the method's documented array sentinel, matching the other storage read paths.

Database deletion had the same uncaught-exception behavior and ran paste/comment deletion sequentially without isolation. A failure deleting the paste prevented comment cleanup from even being attempted. Each statement is now guarded independently, matching the best-effort cleanup contract of the filesystem and cloud backends.

Database enumeration also returned every stored `dataid` verbatim. A directly inserted malformed identifier was therefore exposed to administration and migration callers as a phantom paste. Enumeration now returns only lowercase 16-character hexadecimal paste IDs, matching the model and other storage backends.

## Tests

- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit Data/DatabaseTest.php --testdox`
  - 25 tests, 105 assertions passed
- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit --filter '/^(?!.*ServerSaltTest)/'`
  - 272 tests, 6516 assertions passed
- `php -l lib/Data/Database.php`
- `php -l tst/Data/DatabaseTest.php`
- `git diff --check`

The local full suite still has the pre-existing environment-sensitive `ServerSaltTest` assertion failures where PHPUnit displays identical expected and actual salt strings.

## Compatibility and privacy

Valid database rows and enumerated IDs retain their existing response shape. Invalid paste rows use the backend's existing `false` contract; invalid comment rows and identifiers are isolated so the remaining discussion can load. Malformed paste identifiers are hidden from administrative and migration enumeration. A query failure returns no comments instead of exposing a database exception, and deletion continues with whichever table remains available. Logs contain only structural, identifier, or database error messages, never encrypted row contents.

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.