### PR TITLE
Validate URL shortener responses

### DIFF
--- a/lib/Proxy/AbstractProxy.php
+++ b/lib/Proxy/AbstractProxy.php
@@ -95,6 +95,11 @@ abstract class AbstractProxy
             $this->logErrorWithClassName('Error calling proxy: ' . $e->getMessage());
             return;
         }
+        if (!is_array($jsonData)) {
+            $this->_error = 'Proxy error: Error parsing proxy response. This can be a configuration issue, like wrong or missing config keys.';
+            $this->logErrorWithClassName('Error calling proxy: unexpected response structure');
+            return;
+        }
 
         $url = $this->_extractShortUrl($jsonData);
 

--- a/lib/Proxy/AbstractProxy.php
+++ b/lib/Proxy/AbstractProxy.php
@@ -101,9 +101,15 @@ abstract class AbstractProxy
             return;
         }
 
-        $url = $this->_extractShortUrl($jsonData);
+        $url    = $this->_extractShortUrl($jsonData);
+        $scheme = is_string($url) ? parse_url($url, PHP_URL_SCHEME) : null;
 
-        if ($url === null || empty($url)) {
+        if (
+            $url === null ||
+            filter_var($url, FILTER_VALIDATE_URL) === false ||
+            !is_string($scheme) ||
+            !in_array(strtolower($scheme), ['http', 'https'], true)
+        ) {
             $this->_error = 'Proxy error: Error parsing proxy response. This can be a configuration issue, like wrong or missing config keys.';
             $this->logErrorWithClassName('Error calling proxy: ' . $data);
         } else {

--- a/lib/Proxy/ShlinkProxy.php
+++ b/lib/Proxy/ShlinkProxy.php
@@ -71,6 +71,7 @@ class ShlinkProxy extends AbstractProxy
      */
     protected function _extractShortUrl(array $data): ?string
     {
-        return $data['shortUrl'] ?? null;
+        $url = $data['shortUrl'] ?? null;
+        return is_string($url) ? $url : null;
     }
 }

--- a/lib/Proxy/YourlsProxy.php
+++ b/lib/Proxy/YourlsProxy.php
@@ -66,7 +66,8 @@ class YourlsProxy extends AbstractProxy
     protected function _extractShortUrl(array $data): ?string
     {
         if ((int) ($data['statusCode'] ?? 0) === 200) {
-            return $data['shorturl'] ?? null;
+            $url = $data['shorturl'] ?? null;
+            return is_string($url) ? $url : null;
         }
         return null;
     }

--- a/tst/YourlsProxyTest.php
+++ b/tst/YourlsProxyTest.php
@@ -148,6 +148,25 @@ class YourlsProxyTest extends TestCase
         $this->assertEquals($yourls->getError(), 'Proxy error: Error parsing proxy response. This can be a configuration issue, like wrong or missing config keys.');
     }
 
+    /**
+     * @dataProvider providerMalformedResponses
+     */
+    public function testMalformedResponseShapeIsRejected($response)
+    {
+        file_put_contents($this->_mock_yourls_service, $response);
+        $yourls = new YourlsProxy($this->_conf, 'https://example.com/?foo#bar');
+        $this->assertTrue($yourls->isError());
+        $this->assertEquals($yourls->getError(), 'Proxy error: Error parsing proxy response. This can be a configuration issue, like wrong or missing config keys.');
+    }
+
+    public function providerMalformedResponses(): array
+    {
+        return [
+            ['true'],
+            ['{"statusCode":"200","shorturl":[]}'],
+        ];
+    }
+
     public function testServerError()
     {
         // simulate some other server error that results in a non-JSON reply

--- a/tst/YourlsProxyTest.php
+++ b/tst/YourlsProxyTest.php
@@ -164,6 +164,9 @@ class YourlsProxyTest extends TestCase
         return [
             ['true'],
             ['{"statusCode":"200","shorturl":[]}'],
+            ['{"statusCode":"200","shorturl":"not a URL"}'],
+            ['{"statusCode":"200","shorturl":"javascript:alert(1)"}'],
+            ['{"statusCode":"200","shorturl":"ftp:\/\/example.com\/1"}'],
         ];
     }
 


### PR DESCRIPTION
## Summary

- reject decoded shortener responses that are not JSON objects
- require YOURLS and Shlink URL fields to be strings
- require returned links to be valid HTTP or HTTPS URLs
- preserve the existing controlled proxy error for malformed remote responses
- add regressions for scalar JSON, array-valued URL fields, invalid URLs, and unsafe schemes

## Reproduction

A shortener response containing valid JSON `true` is passed to `_extractShortUrl(array $data)`, causing a `TypeError`. A response such as `{"statusCode":"200","shorturl":[]}` reaches the declared `?string` return and raises another `TypeError`.

Both inputs come from the configured remote URL-shortening service and currently abort the request instead of returning the normal proxy error.

The proxy also accepted any non-empty string as the rendered link target. Responses containing `not a URL`, `javascript:alert(1)`, or an `ftp:` URL were treated as successful short links. They now use the same controlled proxy-error path; legitimate HTTP and HTTPS short links remain unchanged.

## Tests

- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit YourlsProxyTest.php --testdox`
  - 23 tests, 48 assertions passed
- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit --filter '/^(?!.*ServerSaltTest)/'`
  - 271 tests, 6515 assertions passed
- PHP syntax checks for all three modified proxy classes
- `git diff --check`

The local full suite still has the pre-existing environment-sensitive `ServerSaltTest` assertion failures where PHPUnit displays identical expected and actual salt strings.

## Compatibility and privacy

Valid HTTP and HTTPS URLs from YOURLS and Shlink are unchanged. Invalid response bodies and non-web URL schemes use the existing error path and do not expose API keys or request payloads.

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.