### PR TITLE
Handle configuration option shape mismatches

### DIFF
--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -228,7 +228,7 @@ class Configuration
                     if (array_key_exists($key, $config[$section])) {
                         if ($val === null) {
                             $result = $config[$section][$key];
-                        } elseif (is_bool($val)) {
+                        } elseif (is_bool($val) && is_scalar($config[$section][$key])) {
                             $val = strtolower($config[$section][$key]);
                             if (in_array($val, ['true', 'yes', 'on'])) {
                                 $result = true;
@@ -237,9 +237,13 @@ class Configuration
                             } else {
                                 $result = (bool) $config[$section][$key];
                             }
-                        } elseif (is_int($val)) {
+                        } elseif (is_int($val) && is_scalar($config[$section][$key])) {
                             $result = (int) $config[$section][$key];
-                        } elseif (is_string($val) && !empty($config[$section][$key])) {
+                        } elseif (
+                            is_string($val) &&
+                            is_scalar($config[$section][$key]) &&
+                            !empty($config[$section][$key])
+                        ) {
                             $result = (string) $config[$section][$key];
                         } elseif (is_array($val) && is_array($config[$section][$key])) {
                             $result = $config[$section][$key];

--- a/tst/ConfigurationTest.php
+++ b/tst/ConfigurationTest.php
@@ -114,6 +114,21 @@ class ConfigurationTest extends TestCase
         $this->assertEquals($original_options, $conf->get(), 'incorrect types are corrected');
     }
 
+    public function testHandleWrongOptionShapes()
+    {
+        file_put_contents(
+            CONF,
+            '[main]' . PHP_EOL .
+            'discussion[] = true' . PHP_EOL .
+            'availabletemplates = "bootstrap5"' . PHP_EOL .
+            '[model]' . PHP_EOL .
+            '[model_options]'
+        );
+        $conf = new Configuration;
+        $this->assertSame($this->_options['main']['discussion'], $conf->getKey('discussion'));
+        $this->assertSame($this->_options['main']['availabletemplates'], $conf->getKey('availabletemplates'));
+    }
+
     public function testHandleMissingSubKeys()
     {
         $options = $this->_options;


### PR DESCRIPTION
## Summary

- apply boolean, integer, and string coercion only to scalar INI values
- preserve defaults when a configured value has the wrong scalar/array shape
- keep valid array defaults and nullable model options unchanged
- add regressions for array-valued booleans and scalar-valued array options

## Reproduction

An otherwise valid configuration containing:

```ini
[main]
discussion[] = true
```

is parsed as an array. Configuration then calls `strtolower()` on that array and raises a `TypeError` during startup. Similar shape mismatches can reach integer/string casts or propagate a scalar where later code requires an array.

## Tests

- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit ConfigurationTest.php --testdox`
  - 12 tests, 16 assertions passed
- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit --filter '/^(?!.*ServerSaltTest)/'`
  - 267 tests, 6507 assertions passed
- `php -l lib/Configuration.php`
- `git diff --check`

The local full suite still has the pre-existing environment-sensitive `ServerSaltTest` assertion failures where PHPUnit displays identical expected and actual salt strings.

## Compatibility

Existing scalar coercion remains unchanged. Only values with an incompatible scalar/array shape fall back to the documented default, avoiding startup errors from malformed INI array syntax.

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.