### PR TITLE
Validate Host headers before building URLs

### DIFF
--- a/lib/Request.php
+++ b/lib/Request.php
@@ -218,8 +218,15 @@ class Request
      */
     public function getHost()
     {
-        $host = array_key_exists('HTTP_HOST', $_SERVER) ? filter_var($_SERVER['HTTP_HOST'], FILTER_SANITIZE_URL) : '';
-        return empty($host) ? 'localhost' : $host;
+        $host = $_SERVER['HTTP_HOST'] ?? '';
+        if (
+            !is_string($host) ||
+            !preg_match('/\A(?:\[[0-9A-Fa-f:.]+\]|[A-Za-z0-9._-]+)(?::[0-9]{1,5})?\z/', $host)
+        ) {
+            return 'localhost';
+        }
+        $url = parse_url('http://' . $host);
+        return is_array($url) && isset($url['host']) ? $host : 'localhost';
     }
 
     /**

--- a/tst/RequestTest.php
+++ b/tst/RequestTest.php
@@ -39,6 +39,37 @@ class RequestTest extends TestCase
         $this->assertEquals('view', $request->getOperation());
     }
 
+    /**
+     * @dataProvider provideHosts
+     */
+    public function testHostValidation($host, $expected)
+    {
+        $this->reset();
+        if ($host !== null) {
+            $_SERVER['HTTP_HOST'] = $host;
+        }
+        $request = new Request;
+        $this->assertSame($expected, $request->getHost());
+    }
+
+    public function provideHosts()
+    {
+        return [
+            [null, 'localhost'],
+            ['example.com', 'example.com'],
+            ['example.com:8080', 'example.com:8080'],
+            ['127.0.0.1:80', '127.0.0.1:80'],
+            ['[::1]', '[::1]'],
+            ['[::1]:8080', '[::1]:8080'],
+            ['trusted.example@evil.example', 'localhost'],
+            ['example.com/path', 'localhost'],
+            ['example.com?query', 'localhost'],
+            ['example.com#fragment', 'localhost'],
+            ["example.com\r\nX-Test: injected", 'localhost'],
+            ['example.com:99999', 'localhost'],
+        ];
+    }
+
     public function testRead()
     {
         $this->reset();


### PR DESCRIPTION
## Summary

- validate `HTTP_HOST` before using it to build an absolute URL
- preserve ordinary domain, port, IPv4, and bracketed IPv6 host forms
- fall back to `localhost` for userinfo, paths, query strings, fragments, control characters, and invalid ports

## Why

`FILTER_SANITIZE_URL` removes some invalid bytes but does not validate Host-header authority syntax. Values such as `trusted.example@evil.example` and `example.com/path` therefore survived `Request::getHost()`. The controller can use that value when constructing its HTTPS fallback link, allowing a malformed Host header to make that link point at a different authority.

## Tests

- regression first: `testHostValidation` failed 6 of 12 cases on the previous implementation
- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit RequestTest.php` — 27 tests, 68 assertions
- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit --filter '/^(?!.*ServerSaltTest)/'` — 278 tests, 6517 assertions
- `php -l lib/Request.php`
- `php -l tst/RequestTest.php`
- `git diff --check`

The `ServerSaltTest` class is excluded from the local full-suite result because its permission tests are not meaningful when PHPUnit runs as root.

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.