### PR TITLE
Ignore corrupt traffic limiter state

### DIFF
--- a/lib/Data/Database.php
+++ b/lib/Data/Database.php
@@ -414,6 +414,9 @@ class Database extends AbstractData
         if ($value && $namespace === 'traffic_limiter') {
             try {
                 $this->_last_cache = Json::decode($value);
+                if (!is_array($this->_last_cache)) {
+                    $this->_last_cache = [];
+                }
             } catch (JsonException $e) {
                 error_log('Error decoding JSON from table "config", row "traffic_limiter": ' . $e->getMessage());
                 $this->_last_cache = [];
@@ -421,6 +424,7 @@ class Database extends AbstractData
             if (array_key_exists($key, $this->_last_cache)) {
                 return $this->_last_cache[$key];
             }
+            return '';
         }
         return (string) $value;
     }

--- a/lib/Data/Filesystem.php
+++ b/lib/Data/Filesystem.php
@@ -317,7 +317,10 @@ class Filesystem extends AbstractData
                 $file = $this->_path . DIRECTORY_SEPARATOR . 'traffic_limiter.php';
                 if (is_readable($file)) {
                     require $file;
-                    if (array_key_exists('traffic_limiter', $GLOBALS)) {
+                    if (
+                        array_key_exists('traffic_limiter', $GLOBALS) &&
+                        is_array($GLOBALS['traffic_limiter'])
+                    ) {
                         $this->_last_cache = $GLOBALS['traffic_limiter'];
                         if (array_key_exists($key, $this->_last_cache)) {
                             return $this->_last_cache[$key];

--- a/tst/Data/DatabaseTest.php
+++ b/tst/Data/DatabaseTest.php
@@ -156,6 +156,19 @@ class DatabaseTest extends TestCase
         $this->assertFalse($this->_model->exists(Helper::getPasteId()), 'paste does still not exist');
     }
 
+    public function testInvalidTrafficLimiterState()
+    {
+        $this->assertSame('', $this->_model->getValue('traffic_limiter', 'client'));
+        $property  = (new ReflectionClass(Database::class))->getProperty('_db');
+        $database  = $property->getValue($this->_model);
+        $statement = $database->prepare('UPDATE config SET value = ? WHERE id = ?');
+        $statement->execute(['true', 'TRAFFIC_LIMITER']);
+
+        $this->assertSame('', $this->_model->getValue('traffic_limiter', 'client'));
+        $this->assertTrue($this->_model->setValue('123', 'traffic_limiter', 'client'));
+        $this->assertSame('123', $this->_model->getValue('traffic_limiter', 'client'));
+    }
+
     public function testCommentErrorDetection()
     {
         $error_log_setting = ini_get('error_log');

--- a/tst/Data/FilesystemTest.php
+++ b/tst/Data/FilesystemTest.php
@@ -195,4 +195,15 @@ class FilesystemTest extends TestCase
             $this->assertEquals($model->getValue($namespace), VALID, 'valid value returned');
         }
     }
+
+    public function testInvalidTrafficLimiterState()
+    {
+        $file  = $this->_invalidPath . DIRECTORY_SEPARATOR . 'traffic_limiter.php';
+        file_put_contents($file, '<?php $GLOBALS[\'traffic_limiter\'] = true;');
+        $model = new Filesystem(['dir' => $this->_invalidPath]);
+
+        $this->assertSame('', $model->getValue('traffic_limiter', 'client'));
+        $this->assertTrue($model->setValue('123', 'traffic_limiter', 'client'));
+        $this->assertSame('123', $model->getValue('traffic_limiter', 'client'));
+    }
 }


### PR DESCRIPTION
## Summary

- reject decoded database traffic-limiter state unless it is an array
- reject scalar traffic-limiter globals loaded by the filesystem backend
- return the standard empty sentinel when a database limiter key is absent
- verify that both backends can recover by writing and reading a new timestamp

## Why

The traffic limiter assumes its persisted cache is an array. A database row containing valid scalar JSON such as `true`, or a filesystem state file assigning a scalar, was accepted into `_last_cache`. The next `array_key_exists()` or array write then raised a `TypeError`, preventing requests from reaching the normal limiter behavior.

The database backend also returned the entire encoded cache when a requested client key was absent. Returning `''` now matches the filesystem and cloud backend contract.

## Tests

- regression first: the database test reproduced `array_key_exists(): Argument #2 ($array) must be of type array, true given`
- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit Data/DatabaseTest.php` — 20 tests, 98 assertions
- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit Data/FilesystemTest.php` — 8 tests, 160 assertions
- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit --filter '/^(?!.*ServerSaltTest)/'` — 268 tests, 6512 assertions
- PHP syntax checks for all four changed files
- `git diff --check`

The `ServerSaltTest` class is excluded from the local full-suite result because its permission tests are not meaningful when PHPUnit runs as root.

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.