### PR TITLE
Fall back for pathless request URIs

### DIFF
--- a/lib/Request.php
+++ b/lib/Request.php
@@ -231,7 +231,8 @@ class Request
     public function getRequestUri()
     {
         $uri = array_key_exists('REQUEST_URI', $_SERVER) ? filter_var($_SERVER['REQUEST_URI'], FILTER_SANITIZE_URL) : '';
-        return empty($uri) ? '/' : parse_url($uri, PHP_URL_PATH);
+        $path = empty($uri) ? '' : parse_url($uri, PHP_URL_PATH);
+        return is_string($path) && $path !== '' ? $path : '/';
     }
 
     /**

--- a/lib/Request.php
+++ b/lib/Request.php
@@ -230,7 +230,7 @@ class Request
      */
     public function getRequestUri()
     {
-        $uri = array_key_exists('REQUEST_URI', $_SERVER) ? filter_var($_SERVER['REQUEST_URI'], FILTER_SANITIZE_URL) : '';
+        $uri  = array_key_exists('REQUEST_URI', $_SERVER) ? filter_var($_SERVER['REQUEST_URI'], FILTER_SANITIZE_URL) : '';
         $path = empty($uri) ? '' : parse_url($uri, PHP_URL_PATH);
         return is_string($path) && $path !== '' ? $path : '/';
     }

--- a/tst/RequestTest.php
+++ b/tst/RequestTest.php
@@ -39,6 +39,30 @@ class RequestTest extends TestCase
         $this->assertEquals('view', $request->getOperation());
     }
 
+    /**
+     * @dataProvider provideRequestUris
+     */
+    public function testRequestUriValidation($uri, $expected)
+    {
+        $this->reset();
+        if ($uri !== null) {
+            $_SERVER['REQUEST_URI'] = $uri;
+        }
+        $request = new Request;
+        $this->assertSame($expected, $request->getRequestUri());
+    }
+
+    public function provideRequestUris()
+    {
+        return [
+            [null, '/'],
+            ['/', '/'],
+            ['/path/to/privatebin?query=value', '/path/to/privatebin'],
+            ['?query=value', '/'],
+            ['http://[', '/'],
+        ];
+    }
+
     public function testRead()
     {
         $this->reset();


### PR DESCRIPTION
## Summary

- guarantee that `Request::getRequestUri()` returns a non-empty path string
- preserve valid paths while stripping query parameters as before
- use `/` when the request target is absent, pathless, or malformed

## Why

`parse_url(..., PHP_URL_PATH)` returns `null` for request targets such as `?query=value` and malformed values such as `http://[`. `getRequestUri()` passed that result through despite documenting a string return. Callers use the method in string operations and absolute-link construction, so malformed input could cause a `TypeError` or an invalid fallback link.

## Tests

- regression first: pathless and malformed request targets failed 2 of 5 cases on the previous implementation
- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit RequestTest.php` — 20 tests, 61 assertions
- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit --filter '/^(?!.*ServerSaltTest)/'` — 271 tests, 6510 assertions
- `php -l lib/Request.php`
- `php -l tst/RequestTest.php`
- `git diff --check`

The `ServerSaltTest` class is excluded from the local full-suite result because its permission tests are not meaningful when PHPUnit runs as root.

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.