### PR TITLE
Ignore invalid template cookie types

### DIFF
--- a/lib/TemplateSwitcher.php
+++ b/lib/TemplateSwitcher.php
@@ -73,7 +73,10 @@ class TemplateSwitcher
      */
     public static function getTemplate(): string
     {
-        if (array_key_exists('template', $_COOKIE)) {
+        if (
+            array_key_exists('template', $_COOKIE) &&
+            is_string($_COOKIE['template'])
+        ) {
             $template = basename($_COOKIE['template']);
             if (self::isTemplateAvailable($template)) {
                 return $template;

--- a/tst/TemplateSwitcherTest.php
+++ b/tst/TemplateSwitcherTest.php
@@ -53,6 +53,9 @@ class TemplateSwitcherTest extends TestCase
 
         $_COOKIE['template'] = $escapeTemplateDirectory;
         $this->assertEquals($defaultTemplateFallback, TemplateSwitcher::getTemplate(), 'Fallback on escaping template directory');
+
+        $_COOKIE['template'] = [$customTemplate];
+        $this->assertEquals($defaultTemplateFallback, TemplateSwitcher::getTemplate(), 'Fallback on invalid cookie type');
     }
 
     public function testGetAvailableTemplates()


### PR DESCRIPTION
## Summary

- accept a template cookie only when its value is a string
- fall back to the configured template for structured/malformed cookie values
- retain the existing allowlist and path-normalization behavior for valid strings

## Why

`TemplateSwitcher::getTemplate()` passed any `$_COOKIE['template']` value directly to `basename()`. A structured cookie value represented as an array therefore raised a `TypeError` before the configured fallback could be selected.

## Tests

- regression first: the malformed cookie reproduced `basename(): Argument #1 ($path) must be of type string, array given`
- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit TemplateSwitcherTest.php` — 5 tests, 11 assertions
- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit --filter '/^(?!.*ServerSaltTest)/'` — 266 tests, 6506 assertions
- `php -l lib/TemplateSwitcher.php`
- `php -l tst/TemplateSwitcherTest.php`
- `git diff --check`

The `ServerSaltTest` class is excluded from the local full-suite result because its permission tests are not meaningful when PHPUnit runs as root.

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.