### PR TITLE
Validate parameter types before routing

### DIFF
--- a/lib/Request.php
+++ b/lib/Request.php
@@ -143,15 +143,31 @@ class Request
         }
 
         // prepare operation, depending on current parameters
-        if (array_key_exists('pasteid', $this->_params) && !empty($this->_params['pasteid'])) {
-            if (array_key_exists('deletetoken', $this->_params) && !empty($this->_params['deletetoken'])) {
+        if (
+            array_key_exists('pasteid', $this->_params) &&
+            is_string($this->_params['pasteid']) &&
+            !empty($this->_params['pasteid'])
+        ) {
+            if (
+                array_key_exists('deletetoken', $this->_params) &&
+                is_string($this->_params['deletetoken']) &&
+                !empty($this->_params['deletetoken'])
+            ) {
                 $this->_operation = 'delete';
             } elseif ($this->_operation !== 'create') {
                 $this->_operation = 'read';
             }
-        } elseif (array_key_exists('jsonld', $this->_params) && !empty($this->_params['jsonld'])) {
+        } elseif (
+            array_key_exists('jsonld', $this->_params) &&
+            is_string($this->_params['jsonld']) &&
+            !empty($this->_params['jsonld'])
+        ) {
             $this->_operation = 'jsonld';
-        } elseif (array_key_exists('link', $this->_params) && !empty($this->_params['link'])) {
+        } elseif (
+            array_key_exists('link', $this->_params) &&
+            is_string($this->_params['link']) &&
+            !empty($this->_params['link'])
+        ) {
             if (str_contains($this->getRequestUri(), '/shortenviayourls') || array_key_exists('shortenviayourls', $this->_params)) {
                 $this->_operation = 'yourlsproxy';
             }

--- a/tst/RequestTest.php
+++ b/tst/RequestTest.php
@@ -178,6 +178,34 @@ class RequestTest extends TestCase
         }
     }
 
+    /**
+     * @dataProvider provideInvalidRoutingParameters
+     */
+    public function testPostInvalidRoutingParameters($parameters)
+    {
+        $this->reset();
+        $_SERVER['REQUEST_METHOD']        = 'POST';
+        $_SERVER['HTTP_X_REQUESTED_WITH'] = 'JSONHttpRequest';
+        $file                             = Helper::createTempFile();
+        file_put_contents($file, json_encode($parameters));
+        Request::setInputStream($file);
+        $request = new Request;
+        unlink($file);
+        $this->assertSame('create', $request->getOperation());
+    }
+
+    public function provideInvalidRoutingParameters()
+    {
+        return [
+            [['pasteid' => '0123456789abcdef', 'deletetoken' => ['invalid']]],
+            [['pasteid' => '0123456789abcdef', 'deletetoken' => 123]],
+            [['pasteid' => ['0123456789abcdef'], 'deletetoken' => 'invalid']],
+            [['jsonld' => ['paste']]],
+            [['link' => ['https://example.com/'], 'shortenviayourls' => true]],
+            [['link' => 123, 'shortenviashlink' => true]],
+        ];
+    }
+
     public function testReadWithNegotiation()
     {
         $this->reset();


### PR DESCRIPTION
## Summary

- require string values before routing paste IDs, deletion tokens, JSON-LD requests, or shortener links
- keep malformed POST bodies on the normal creation-validation path
- preserve valid delete, read, JSON-LD, and shortener routing

## Why

The request body is decoded before Format V2 validation, and routing previously relied only on `!empty()`. Non-empty arrays or integers could therefore select a route whose controller or proxy expects strings. Examples include an array deletion token reaching `hash_equals()` and an array link reaching the shortener constructor, both of which can raise `TypeError` instead of returning the standard invalid-data response.

## Tests

- regression first: all 6 malformed route cases selected `delete`, `jsonld`, or a shortener route on the previous implementation
- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit RequestTest.php` — 21 tests, 62 assertions
- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit --filter '/^(?!.*ServerSaltTest)/'` — 272 tests, 6511 assertions
- `php -l lib/Request.php`
- `php -l tst/RequestTest.php`
- `git diff --check`

The `ServerSaltTest` class is excluded from the local full-suite result because its permission tests are not meaningful when PHPUnit runs as root.

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.