### PR TITLE
Handle missing client IP addresses

### DIFF
--- a/lib/Persistence/TrafficLimiter.php
+++ b/lib/Persistence/TrafficLimiter.php
@@ -127,7 +127,20 @@ class TrafficLimiter extends AbstractPersistence
      */
     public static function getHash($algo = 'sha512')
     {
-        return hash_hmac($algo, $_SERVER[self::$_ipKey], ServerSalt::get());
+        return hash_hmac($algo, self::getClientIp(), ServerSalt::get());
+    }
+
+    /**
+     * Get the current visitor's IP address.
+     *
+     * @access private
+     * @static
+     * @return string
+     */
+    private static function getClientIp()
+    {
+        $address = $_SERVER[self::$_ipKey] ?? '';
+        return is_string($address) ? $address : '';
     }
 
     /**
@@ -140,18 +153,19 @@ class TrafficLimiter extends AbstractPersistence
      */
     private static function matchIp($ipRange = null)
     {
-        if (is_string($ipRange)) {
-            $ipRange = trim($ipRange);
+        if (!is_string($ipRange) || ($ipRange = trim($ipRange)) === '') {
+            return false;
         }
-        $address = Factory::parseAddressString($_SERVER[self::$_ipKey]);
-        $range   = Factory::parseRangeString(
+        $clientIp = self::getClientIp();
+        $address  = Factory::parseAddressString($clientIp);
+        $range    = Factory::parseRangeString(
             $ipRange,
             ParseStringFlag::IPV4_MAYBE_NON_DECIMAL | ParseStringFlag::IPV4SUBNET_MAYBE_COMPACT | ParseStringFlag::IPV4ADDRESS_MAYBE_NON_QUAD_DOTTED
         );
 
         // address could not be parsed, we might not be in IP space and try a string comparison instead
         if (is_null($address)) {
-            return $_SERVER[self::$_ipKey] === $ipRange;
+            return $clientIp === $ipRange;
         }
         // range could not be parsed, possibly an invalid ip range given in config
         if (is_null($range)) {

--- a/lib/Persistence/TrafficLimiter.php
+++ b/lib/Persistence/TrafficLimiter.php
@@ -72,6 +72,7 @@ class TrafficLimiter extends AbstractPersistence
         self::setCreators($conf->getKey('creators', 'traffic'));
         self::setExempted($conf->getKey('exempted', 'traffic'));
         self::setLimit($conf->getKey('limit', 'traffic'));
+        self::$_ipKey = 'REMOTE_ADDR';
 
         if (!empty($option = $conf->getKey('header', 'traffic'))) {
             $httpHeader = 'HTTP_' . $option;

--- a/tst/Persistence/TrafficLimiterTest.php
+++ b/tst/Persistence/TrafficLimiterTest.php
@@ -1,6 +1,7 @@
 <?php declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
+use PrivateBin\Configuration;
 use PrivateBin\Data\Filesystem;
 use PrivateBin\Exception\TranslatedException;
 use PrivateBin\Persistence\ServerSalt;
@@ -70,6 +71,34 @@ class TrafficLimiterTest extends TestCase
             $this->assertSame('Your IP is not authorized to create documents.', $e->getMessage());
         } finally {
             TrafficLimiter::setCreators(null);
+        }
+    }
+
+    public function testConfiguredHeaderDoesNotLeakAcrossRequests()
+    {
+        $options                      = parse_ini_file(CONF_SAMPLE, true);
+        $options['traffic']['header'] = 'X_FORWARDED_FOR';
+        Helper::confBackup();
+        Helper::createIniFile(CONF, $options);
+        try {
+            $configuration                      = new Configuration;
+            $_SERVER['REMOTE_ADDR']              = '127.0.0.1';
+            $_SERVER['HTTP_X_FORWARDED_FOR']     = '192.0.2.1';
+            TrafficLimiter::setConfiguration($configuration);
+            $this->assertSame(
+                hash_hmac('sha256', '192.0.2.1', ServerSalt::get()),
+                TrafficLimiter::getHash('sha256')
+            );
+
+            unset($_SERVER['HTTP_X_FORWARDED_FOR']);
+            TrafficLimiter::setConfiguration($configuration);
+            $this->assertSame(
+                hash_hmac('sha256', '127.0.0.1', ServerSalt::get()),
+                TrafficLimiter::getHash('sha256')
+            );
+        } finally {
+            unlink(CONF);
+            Helper::confRestore();
         }
     }
 

--- a/tst/Persistence/TrafficLimiterTest.php
+++ b/tst/Persistence/TrafficLimiterTest.php
@@ -81,7 +81,7 @@ class TrafficLimiterTest extends TestCase
         Helper::confBackup();
         Helper::createIniFile(CONF, $options);
         try {
-            $configuration                      = new Configuration;
+            $configuration                       = new Configuration;
             $_SERVER['REMOTE_ADDR']              = '127.0.0.1';
             $_SERVER['HTTP_X_FORWARDED_FOR']     = '192.0.2.1';
             TrafficLimiter::setConfiguration($configuration);

--- a/tst/Persistence/TrafficLimiterTest.php
+++ b/tst/Persistence/TrafficLimiterTest.php
@@ -2,6 +2,7 @@
 
 use PHPUnit\Framework\TestCase;
 use PrivateBin\Data\Filesystem;
+use PrivateBin\Exception\TranslatedException;
 use PrivateBin\Persistence\ServerSalt;
 use PrivateBin\Persistence\TrafficLimiter;
 
@@ -31,6 +32,45 @@ class TrafficLimiterTest extends TestCase
         $_SERVER['REMOTE_ADDR'] = 'foobar';
         TrafficLimiter::canPass();
         $this->assertFileExists($htaccess, 'htaccess recreated');
+    }
+
+    /**
+     * @dataProvider provideInvalidClientAddresses
+     */
+    public function testInvalidClientAddressIsSafelyHashed($address)
+    {
+        if ($address === null) {
+            unset($_SERVER['REMOTE_ADDR']);
+        } else {
+            $_SERVER['REMOTE_ADDR'] = $address;
+        }
+        $this->assertSame(
+            hash_hmac('sha256', '', ServerSalt::get()),
+            TrafficLimiter::getHash('sha256')
+        );
+    }
+
+    public function provideInvalidClientAddresses()
+    {
+        return [
+            [null],
+            [[]],
+            [123],
+        ];
+    }
+
+    public function testMissingClientAddressDoesNotMatchEmptyCreatorRange()
+    {
+        unset($_SERVER['REMOTE_ADDR']);
+        TrafficLimiter::setCreators('127.0.0.1,');
+        try {
+            TrafficLimiter::canPass();
+            $this->fail('missing client address must not match an empty creator range');
+        } catch (TranslatedException $e) {
+            $this->assertSame('Your IP is not authorized to create documents.', $e->getMessage());
+        } finally {
+            TrafficLimiter::setCreators(null);
+        }
     }
 
     public function testTrafficGetsLimited()


### PR DESCRIPTION
## Summary

- normalize missing or non-string client-address state to an empty string
- use the same normalized value for limiter hashing and creator/exemption matching
- reject empty configured IP ranges instead of matching an absent client address
- reset the selected proxy-header key on every configuration pass
- keep missing-address requests in one conservative shared limiter bucket

## Why

`TrafficLimiter` read `$_SERVER[self::$_ipKey]` directly. If `REMOTE_ADDR` is absent in a serverless, CLI, or custom SAPI environment, hashing emitted an undefined-key error. Array or integer proxy-header state reached `hash_hmac()` and raised a `TypeError`.

Once missing addresses are normalized, an empty entry produced by a trailing comma in `creators` would otherwise compare equal to the empty client address and authorize it. Empty ranges are now ignored, so creator restrictions fail closed.

`setConfiguration()` also retained the previously selected proxy-header key. In a long-running PHP process, a request containing the configured header made the next header-less request keep reading that missing header instead of falling back to `REMOTE_ADDR`. The key now resets before each request's header selection.

## Tests

- regression first:
  - missing `REMOTE_ADDR` produced `Undefined array key "REMOTE_ADDR"`
  - array and integer values produced `hash_hmac(): Argument #2 ($data) must be of type string`
- sequential proxy-header regression: the second request hashed the empty address instead of `REMOTE_ADDR`
- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit Persistence/TrafficLimiterTest.php` — 9 tests, 30 assertions
- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit --filter '/^(?!.*ServerSaltTest)/'` — 271 tests, 6511 assertions
- PHP syntax checks for the implementation and test
- `git diff --check`

The `ServerSaltTest` class is excluded from the local full-suite result because its permission tests are not meaningful when PHPUnit runs as root.

## Compatibility and security

Valid string IP addresses and present configured proxy headers are unchanged. Header-less requests use `REMOTE_ADDR` on every configuration pass. Missing/invalid addresses do not gain creator or exemption privileges; when unrestricted creation is enabled, they share one rate-limit identity instead of bypassing or crashing the limiter.

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.