### PR TITLE
Reload translations for each request

### DIFF
--- a/lib/Controller.php
+++ b/lib/Controller.php
@@ -207,6 +207,7 @@ class Controller
             $_COOKIE['lang'] = $lang;
             setcookie('lang', $lang, ['SameSite' => 'Lax', 'Secure' => true]);
         }
+        I18n::loadTranslations();
     }
 
     /**

--- a/tst/ControllerTest.php
+++ b/tst/ControllerTest.php
@@ -4,6 +4,7 @@ use PHPUnit\Framework\TestCase;
 use PrivateBin\Configuration;
 use PrivateBin\Controller;
 use PrivateBin\Data\Filesystem;
+use PrivateBin\I18n;
 use PrivateBin\Persistence\ServerSalt;
 use PrivateBin\Persistence\TrafficLimiter;
 use PrivateBin\Request;
@@ -92,6 +93,26 @@ class ControllerTest extends TestCase
             $content,
             'outputs title correctly'
         );
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testViewReloadsLanguageBetweenRequests()
+    {
+        $_COOKIE['lang'] = 'de';
+        I18n::loadTranslations();
+        $this->assertSame('de', I18n::getLanguage());
+
+        $_COOKIE['lang'] = 'fr';
+        ob_start();
+        try {
+            new Controller;
+        } finally {
+            ob_end_clean();
+            unset($_COOKIE['lang']);
+        }
+        $this->assertSame('fr', I18n::getLanguage());
     }
 
     /**


### PR DESCRIPTION
## Summary

- load translations explicitly during each Controller initialization
- replace stale static language/translation state in persistent PHP workers
- preserve the existing cookie, browser-negotiation, and configured-fallback selection

## Why

`I18n` caches the selected language and translations in static properties. `Controller` previously relied on lazy loading only when the translation cache was empty. In a long-running worker, a German request populated that cache; a subsequent request with a French language cookie reused the German cache and never updated `I18n::$_language`.

Traditional PHP-FPM request isolation masks the issue, but serverless and persistent-worker runtimes reuse the same process. Loading once during each Controller initialization gives those runtimes the same per-request behavior as PHP-FPM.

## Tests

- regression first: after a simulated German request, a French Controller request left `I18n::getLanguage()` at `de`
- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit ControllerTest.php` — 37 tests, 106 assertions
- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit I18nTest.php` — 18 tests, 5502 assertions
- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit --filter '/^(?!.*ServerSaltTest)/'` — 269 tests, 6511 assertions
- PHP syntax checks for the implementation and regression test
- `git diff --check`

The `ServerSaltTest` class is excluded from the local full-suite result because its permission tests are not meaningful when PHPUnit runs as root.

## Compatibility and privacy

Language choice semantics are unchanged for ordinary isolated requests. Persistent workers no longer leak one visitor's language choice into the next visitor's rendered page.

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.