### PR TITLE
Repair empty filesystem protection files

### DIFF
--- a/lib/Data/Filesystem.php
+++ b/lib/Data/Filesystem.php
@@ -472,7 +472,7 @@ class Filesystem extends AbstractData
         }
         $file        = $this->_path . DIRECTORY_SEPARATOR . '.htaccess';
         $fileCreated = is_file($file);
-        if (!$fileCreated || filesize($file) === 0) {
+        if (!$fileCreated || (!is_link($file) && filesize($file) === 0)) {
             $writtenBytes = 0;
             if ($fileCreated || ($fileCreated = @touch($file))) {
                 $writtenBytes = @file_put_contents(

--- a/lib/Data/Filesystem.php
+++ b/lib/Data/Filesystem.php
@@ -470,10 +470,11 @@ class Filesystem extends AbstractData
                 return false;
             }
         }
-        $file = $this->_path . DIRECTORY_SEPARATOR . '.htaccess';
-        if (!is_file($file)) {
+        $file        = $this->_path . DIRECTORY_SEPARATOR . '.htaccess';
+        $fileCreated = is_file($file);
+        if (!$fileCreated || filesize($file) === 0) {
             $writtenBytes = 0;
-            if ($fileCreated = @touch($file)) {
+            if ($fileCreated || ($fileCreated = @touch($file))) {
                 $writtenBytes = @file_put_contents(
                     $file,
                     self::HTACCESS_LINE . PHP_EOL,

--- a/tst/Data/FilesystemTest.php
+++ b/tst/Data/FilesystemTest.php
@@ -138,6 +138,15 @@ class FilesystemTest extends TestCase
         $this->assertFalse($this->_model->existsComment(Helper::getPasteId(), Helper::getPasteId(), Helper::getCommentId()), 'comment does still not exist');
     }
 
+    public function testEmptyHtaccessIsRepaired()
+    {
+        $file = $this->_path . DIRECTORY_SEPARATOR . '.htaccess';
+        file_put_contents($file, '');
+
+        $this->assertTrue($this->_model->setValue('123', 'purge_limiter'));
+        $this->assertSame(Filesystem::HTACCESS_LINE . PHP_EOL, file_get_contents($file));
+    }
+
     public function testOldFilesGetConverted()
     {
         // generate 10 (default purge batch size) pastes in the old format

--- a/tst/Data/FilesystemTest.php
+++ b/tst/Data/FilesystemTest.php
@@ -147,6 +147,20 @@ class FilesystemTest extends TestCase
         $this->assertSame(Filesystem::HTACCESS_LINE . PHP_EOL, file_get_contents($file));
     }
 
+    public function testEmptyHtaccessSymlinkIsNotOverwritten()
+    {
+        $target = $this->_path . DIRECTORY_SEPARATOR . 'custom-apache-config';
+        $link   = $this->_path . DIRECTORY_SEPARATOR . '.htaccess';
+        file_put_contents($target, '');
+        symlink($target, $link);
+        try {
+            $this->assertTrue($this->_model->setValue('123', 'purge_limiter'));
+            $this->assertSame('', file_get_contents($target));
+        } finally {
+            unlink($link);
+        }
+    }
+
     public function testOldFilesGetConverted()
     {
         // generate 10 (default purge batch size) pastes in the old format


### PR DESCRIPTION
## Summary

- detect an existing but empty filesystem `.htaccess`
- retry writing PrivateBin's `Require all denied` protection line
- preserve non-empty/custom protection files and symlinks unchanged

## Why

Filesystem initialization touched `.htaccess` before writing its deny rule. If that write failed or was interrupted, the zero-byte file remained. Every later store operation checked only `is_file()`, treated it as initialized, and successfully wrote paste/config data without ever restoring the Apache protection rule.

The retry is deliberately limited to real zero-byte files, avoiding changes to non-empty administrator-provided Apache configurations and never following a symlink to overwrite its target.

## Tests

- regression first: storing a limiter value succeeded while a pre-existing empty `.htaccess` remained empty
- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit Data/FilesystemTest.php` — 9 tests, 161 assertions
- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit --filter '/^(?!.*ServerSaltTest)/'` — 268 tests, 6509 assertions
- PHP syntax checks for the implementation and regression test
- `git diff --check`

The `ServerSaltTest` class is excluded from the local full-suite result because its permission tests are not meaningful when PHPUnit runs as root.

## Security and compatibility

This restores the intended defense-in-depth against direct Apache access to the data directory after a partial initialization failure. Existing non-empty `.htaccess` files and symlink targets are not overwritten.

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.