### PR TITLE
Preserve failed legacy filesystem conversions

### DIFF
--- a/lib/Data/Filesystem.php
+++ b/lib/Data/Filesystem.php
@@ -518,8 +518,19 @@ class Filesystem extends AbstractData
      */
     private function _prependRename($srcFile, $destFile)
     {
+        $protectionLine = self::PROTECTION_LINE . PHP_EOL;
+
         // delete the legacy source if a converted file already exists
         if (is_file($destFile) && is_readable($destFile)) {
+            $sourceData      = @file_get_contents($srcFile);
+            $destinationData = @file_get_contents($destFile);
+            if (
+                $sourceData === false ||
+                $destinationData !== $protectionLine . $sourceData
+            ) {
+                error_log('Error converting document, destination differs: ' . $destFile);
+                return;
+            }
             if (!unlink($srcFile)) {
                 error_log('Error deleting converted document: ' . $srcFile);
             }
@@ -538,7 +549,6 @@ class Filesystem extends AbstractData
             return;
         }
         $stat           = fstat($handle);
-        $protectionLine = self::PROTECTION_LINE . PHP_EOL;
         $writtenBytes   = @file_put_contents($destFile, $protectionLine, LOCK_EX);
         $appendedBytes  = $writtenBytes === strlen($protectionLine) ?
             @file_put_contents($destFile, $handle, FILE_APPEND | LOCK_EX) : false;

--- a/lib/Data/Filesystem.php
+++ b/lib/Data/Filesystem.php
@@ -159,14 +159,18 @@ class Filesystem extends AbstractData
         // convert to PHP protected files if needed
         if (is_readable($basePath)) {
             $this->_prependRename($basePath, $pastePath);
+        }
 
-            // convert comments, too
-            $discdir = $this->_dataid2discussionpath($pasteid);
-            if (is_dir($discdir)) {
-                foreach (new DirectoryIterator($discdir) as $file) {
-                    if ($file->getExtension() !== 'php' && strlen($file->getFilename()) >= 16) {
-                        $this->_prependRename($file->getPathname(), $file->getPathname() . '.php');
-                    }
+        // convert comments, too, including retries after paste conversion
+        $discdir = $this->_dataid2discussionpath($pasteid);
+        if (is_dir($discdir)) {
+            foreach (new DirectoryIterator($discdir) as $file) {
+                if (
+                    $file->isFile() &&
+                    $file->getExtension() !== 'php' &&
+                    strlen($file->getFilename()) >= 16
+                ) {
+                    $this->_prependRename($file->getPathname(), $file->getPathname() . '.php');
                 }
             }
         }

--- a/lib/Data/Filesystem.php
+++ b/lib/Data/Filesystem.php
@@ -170,7 +170,7 @@ class Filesystem extends AbstractData
                 }
             }
         }
-        return is_readable($pastePath);
+        return is_file($pastePath) && is_readable($pastePath);
     }
 
     /**
@@ -514,12 +514,42 @@ class Filesystem extends AbstractData
      */
     private function _prependRename($srcFile, $destFile)
     {
-        // don't overwrite already converted file
-        if (!is_readable($destFile)) {
-            $handle = fopen($srcFile, 'r', false, stream_context_create());
-            file_put_contents($destFile, self::PROTECTION_LINE . PHP_EOL);
-            file_put_contents($destFile, $handle, FILE_APPEND);
-            fclose($handle);
+        // delete the legacy source if a converted file already exists
+        if (is_file($destFile) && is_readable($destFile)) {
+            if (!unlink($srcFile)) {
+                error_log('Error deleting converted document: ' . $srcFile);
+            }
+            return;
+        }
+
+        // don't overwrite a conflicting or unreadable destination
+        if (file_exists($destFile) || is_link($destFile)) {
+            error_log('Error converting document, destination already exists: ' . $destFile);
+            return;
+        }
+
+        $handle = @fopen($srcFile, 'r', false, stream_context_create());
+        if ($handle === false) {
+            error_log('Error reading document for conversion: ' . $srcFile);
+            return;
+        }
+        $stat           = fstat($handle);
+        $protectionLine = self::PROTECTION_LINE . PHP_EOL;
+        $writtenBytes   = @file_put_contents($destFile, $protectionLine, LOCK_EX);
+        $appendedBytes  = $writtenBytes === strlen($protectionLine) ?
+            @file_put_contents($destFile, $handle, FILE_APPEND | LOCK_EX) : false;
+        fclose($handle);
+        if (
+            $stat === false ||
+            $writtenBytes !== strlen($protectionLine) ||
+            $appendedBytes !== $stat['size'] ||
+            !@chmod($destFile, 0640)
+        ) {
+            if (is_file($destFile) && !is_link($destFile)) {
+                @unlink($destFile);
+            }
+            error_log('Error converting document: ' . $srcFile);
+            return;
         }
         if (!unlink($srcFile)) {
             error_log('Error deleting converted document: ' . $srcFile);

--- a/lib/Data/Filesystem.php
+++ b/lib/Data/Filesystem.php
@@ -531,6 +531,10 @@ class Filesystem extends AbstractData
                 error_log('Error converting document, destination differs: ' . $destFile);
                 return;
             }
+            if (!@chmod($destFile, 0640)) {
+                error_log('Error protecting converted document: ' . $destFile);
+                return;
+            }
             if (!unlink($srcFile)) {
                 error_log('Error deleting converted document: ' . $srcFile);
             }

--- a/tst/Data/FilesystemTest.php
+++ b/tst/Data/FilesystemTest.php
@@ -182,6 +182,27 @@ class FilesystemTest extends TestCase
         }
     }
 
+    public function testFailedOldFileConversionPreservesSource()
+    {
+        $pasteid    = Helper::getPasteId();
+        $storageDir = $this->_path . DIRECTORY_SEPARATOR . substr($pasteid, 0, 2) .
+            DIRECTORY_SEPARATOR . substr($pasteid, 2, 2) . DIRECTORY_SEPARATOR;
+        mkdir($storageDir, 0700, true);
+        $source      = $storageDir . $pasteid;
+        $destination = $source . '.php';
+        file_put_contents($source, json_encode(Helper::getPaste()));
+        mkdir($destination);
+        $errorLog = ini_get('error_log');
+        ini_set('error_log', '/dev/null');
+        try {
+            $this->assertFalse($this->_model->exists($pasteid));
+            $this->assertFileExists($source);
+        } finally {
+            ini_set('error_log', $errorLog);
+            rmdir($destination);
+        }
+    }
+
     public function testValueFileErrorHandling()
     {
         define('VALID', 'valid content');

--- a/tst/Data/FilesystemTest.php
+++ b/tst/Data/FilesystemTest.php
@@ -227,6 +227,26 @@ class FilesystemTest extends TestCase
         }
     }
 
+    public function testMatchingOldFileConversionProtectsDestination()
+    {
+        $pasteid    = Helper::getPasteId();
+        $storageDir = $this->_path . DIRECTORY_SEPARATOR . substr($pasteid, 0, 2) .
+            DIRECTORY_SEPARATOR . substr($pasteid, 2, 2) . DIRECTORY_SEPARATOR;
+        mkdir($storageDir, 0700, true);
+        $source      = $storageDir . $pasteid;
+        $destination = $source . '.php';
+        $data        = json_encode(Helper::getPaste());
+        file_put_contents($source, $data);
+        file_put_contents($destination, Filesystem::PROTECTION_LINE . PHP_EOL . $data);
+        chmod($destination, 0666);
+
+        $this->assertTrue($this->_model->exists($pasteid));
+
+        clearstatcache(true, $destination);
+        $this->assertFileDoesNotExist($source);
+        $this->assertSame(0640, fileperms($destination) & 0777);
+    }
+
     public function testOldCommentConversionIsRetried()
     {
         $pasteid   = Helper::getPasteId();

--- a/tst/Data/FilesystemTest.php
+++ b/tst/Data/FilesystemTest.php
@@ -203,6 +203,24 @@ class FilesystemTest extends TestCase
         }
     }
 
+    public function testOldCommentConversionIsRetried()
+    {
+        $pasteid   = Helper::getPasteId();
+        $commentid = Helper::getCommentId();
+        $paste     = Helper::getPaste();
+        $this->assertTrue($this->_model->create($pasteid, $paste));
+        $discussionDir = $this->_path . DIRECTORY_SEPARATOR . substr($pasteid, 0, 2) .
+            DIRECTORY_SEPARATOR . substr($pasteid, 2, 2) . DIRECTORY_SEPARATOR .
+            $pasteid . '.discussion' . DIRECTORY_SEPARATOR;
+        mkdir($discussionDir, 0700, true);
+        $comment = $discussionDir . $pasteid . '.' . $commentid . '.' . $pasteid;
+        file_put_contents($comment, json_encode(Helper::getComment()));
+
+        $this->assertTrue($this->_model->exists($pasteid));
+        $this->assertFileDoesNotExist($comment);
+        $this->assertFileExists($comment . '.php');
+    }
+
     public function testValueFileErrorHandling()
     {
         define('VALID', 'valid content');

--- a/tst/Data/FilesystemTest.php
+++ b/tst/Data/FilesystemTest.php
@@ -203,6 +203,30 @@ class FilesystemTest extends TestCase
         }
     }
 
+    public function testConflictingOldFileConversionPreservesSource()
+    {
+        $pasteid    = Helper::getPasteId();
+        $storageDir = $this->_path . DIRECTORY_SEPARATOR . substr($pasteid, 0, 2) .
+            DIRECTORY_SEPARATOR . substr($pasteid, 2, 2) . DIRECTORY_SEPARATOR;
+        mkdir($storageDir, 0700, true);
+        $source      = $storageDir . $pasteid;
+        $destination = $source . '.php';
+        file_put_contents($source, json_encode(Helper::getPaste()));
+        file_put_contents($destination, Filesystem::PROTECTION_LINE . PHP_EOL . '{}');
+        $errorLog = ini_get('error_log');
+        ini_set('error_log', '/dev/null');
+        try {
+            $this->_model->exists($pasteid);
+            $this->assertFileExists($source);
+            $this->assertSame(
+                Filesystem::PROTECTION_LINE . PHP_EOL . '{}',
+                file_get_contents($destination)
+            );
+        } finally {
+            ini_set('error_log', $errorLog);
+        }
+    }
+
     public function testOldCommentConversionIsRetried()
     {
         $pasteid   = Helper::getPasteId();


### PR DESCRIPTION
## Summary

- preserve legacy paste/comment sources when protected-file conversion fails
- reject directories, links, and conflicting files at the conversion destination
- remove a duplicate legacy source only when the protected destination exactly matches it
- harden an existing matching destination to `0640` before removing its legacy source
- retry legacy comment conversion on later paste existence checks
- verify complete writes and permission hardening before unlinking the source

## Reproduction

Legacy records are converted lazily by writing a PHP-protected destination and then deleting the old source. The original path unlinked the source unconditionally—even when the destination could not be created or was an unrelated readable directory/file. A directory named `<paste-id>.php` therefore caused `exists()` to report the directory as a paste and delete the only valid legacy record.

The conversion now verifies the destination type, header bytes, appended source byte count, and `0640` permission change before deleting the source. If a protected destination already exists, the legacy source is removed only when its complete content exactly matches that destination and the destination has been hardened to `0640`.

Comment conversion previously ran only while the paste itself still needed conversion. If a comment conversion failed after the paste succeeded, later requests never retried it. Comment scanning now runs independently on every existence check and only considers real legacy files.

## Tests

- failed directory destination, conflicting/matching file destinations, and comment retry regressions
  - 4 tests, 11 assertions passed
- complete `FilesystemTest`
  - 11 tests, 168 assertions passed
- broad PHP suite excluding environment-sensitive `ServerSaltTest`
  - 270 tests, 6,516 assertions passed
- PHP syntax checks for both changed files
- `git diff --check`

## Data safety and compatibility

Valid legacy pastes and comments still convert to the same protected format. Failed or conflicting conversions preserve the original bytes for a later retry or operator recovery. No encrypted payload content is logged.

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.