### PR TITLE
Reject corrupt filesystem paste records

### DIFF
--- a/lib/Data/Filesystem.php
+++ b/lib/Data/Filesystem.php
@@ -106,7 +106,12 @@ class Filesystem extends AbstractData
     public function read($pasteid)
     {
         if ($this->exists($pasteid)) {
-            return $this->_get($this->_dataid2path($pasteid) . $pasteid . '.php');
+            $paste = $this->_get($this->_dataid2path($pasteid) . $pasteid . '.php');
+            if (!is_array($paste) || !isset($paste['meta']) || !is_array($paste['meta'])) {
+                error_log('Error while reading a paste from the filesystem: invalid data structure');
+                return false;
+            }
+            return $paste;
         }
         return false;
     }

--- a/tst/Data/FilesystemTest.php
+++ b/tst/Data/FilesystemTest.php
@@ -75,6 +75,30 @@ class FilesystemTest extends TestCase
         $this->assertEquals($original, $this->_model->read(Helper::getPasteId()));
     }
 
+    public function testCorruptPastesAreRejected()
+    {
+        $pasteid   = Helper::getPasteId();
+        $paste     = Helper::getPaste();
+        $pastePath = $this->_path . DIRECTORY_SEPARATOR . substr($pasteid, 0, 2) .
+            DIRECTORY_SEPARATOR . substr($pasteid, 2, 2) . DIRECTORY_SEPARATOR .
+            $pasteid . '.php';
+        $this->assertTrue($this->_model->create($pasteid, $paste));
+
+        $errorLog = ini_get('error_log');
+        ini_set('error_log', '/dev/null');
+        try {
+            foreach ([true, [], ['meta' => true]] as $corruptPaste) {
+                file_put_contents(
+                    $pastePath,
+                    Filesystem::PROTECTION_LINE . PHP_EOL . json_encode($corruptPaste)
+                );
+                $this->assertFalse($this->_model->read($pasteid));
+            }
+        } finally {
+            ini_set('error_log', $errorLog);
+        }
+    }
+
     /**
      * pastes a-g are expired and should get deleted, x never expires and y-z expire in an hour
      */


### PR DESCRIPTION
## Summary

- enforce the filesystem backend's documented `array|false` paste-read contract
- reject decoded paste roots that are not arrays
- reject paste arrays with missing or non-array metadata
- add regression coverage for all three corrupt storage shapes

## Reproduction

A readable filesystem paste containing valid JSON such as `true`, `[]`, or `{"meta":true}` is currently treated as an existing paste. `Filesystem::read()` returns the decoded value even though its documented return type is `array|false`. `Paste::get()` then performs nested array operations on that value, causing a request-level `TypeError` instead of PrivateBin's normal not-found response.

## Tests

- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit --filter testCorruptPastesAreRejected Data/FilesystemTest.php`
  - 1 test, 4 assertions passed
- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit Data/FilesystemTest.php`
  - 8 tests, 161 assertions passed
- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit --filter '/^(?!.*ServerSaltTest)/'`
  - 267 tests, 6509 assertions passed
- `php -l lib/Data/Filesystem.php`
- `php -l tst/Data/FilesystemTest.php`
- `git diff --check`

The local full suite still has the pre-existing environment-sensitive `ServerSaltTest` assertion failures where PHPUnit displays identical expected and actual salt strings.

## Compatibility and privacy

Files written by PrivateBin always have an array root and array metadata, so valid stored pastes are unchanged. Corrupt records now follow the backend's existing not-found/error path. The log records only the structural error and does not include the paste ID, path, ciphertext, or metadata.

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.