### PR TITLE
Reject corrupt cloud paste records

### DIFF
--- a/lib/Data/GoogleCloudStorage.php
+++ b/lib/Data/GoogleCloudStorage.php
@@ -151,8 +151,8 @@ class GoogleCloudStorage extends AbstractData
     public function read($pasteid)
     {
         try {
-            $o    = $this->_bucket->object($this->_getKey($pasteid));
-            $data = $o->downloadAsString();
+            $o     = $this->_bucket->object($this->_getKey($pasteid));
+            $data  = $o->downloadAsString();
             $paste = Json::decode($data);
             if (!is_array($paste) || !isset($paste['meta']) || !is_array($paste['meta'])) {
                 error_log('failed to read ' . $pasteid . ' from ' . $this->_bucket->name() .

--- a/lib/Data/GoogleCloudStorage.php
+++ b/lib/Data/GoogleCloudStorage.php
@@ -153,7 +153,13 @@ class GoogleCloudStorage extends AbstractData
         try {
             $o    = $this->_bucket->object($this->_getKey($pasteid));
             $data = $o->downloadAsString();
-            return Json::decode($data);
+            $paste = Json::decode($data);
+            if (!is_array($paste) || !isset($paste['meta']) || !is_array($paste['meta'])) {
+                error_log('failed to read ' . $pasteid . ' from ' . $this->_bucket->name() .
+                    ', invalid data structure');
+                return false;
+            }
+            return $paste;
         } catch (NotFoundException $e) {
             return false;
         } catch (Exception $e) {

--- a/lib/Data/S3Storage.php
+++ b/lib/Data/S3Storage.php
@@ -211,7 +211,13 @@ class S3Storage extends AbstractData
                 'Key'    => $this->_getKey($pasteid),
             ]);
             $data = $object['Body']->getContents();
-            return Json::decode($data);
+            $paste = Json::decode($data);
+            if (!is_array($paste) || !isset($paste['meta']) || !is_array($paste['meta'])) {
+                error_log('failed to read ' . $pasteid . ' from ' . $this->_bucket .
+                    ', invalid data structure');
+                return false;
+            }
+            return $paste;
         } catch (S3Exception $e) {
             error_log('failed to read ' . $pasteid . ' from ' . $this->_bucket . ', ' .
                 trim(preg_replace('/\s\s+/', ' ', $e->getMessage())));

--- a/lib/Data/S3Storage.php
+++ b/lib/Data/S3Storage.php
@@ -210,7 +210,7 @@ class S3Storage extends AbstractData
                 'Bucket' => $this->_bucket,
                 'Key'    => $this->_getKey($pasteid),
             ]);
-            $data = $object['Body']->getContents();
+            $data  = $object['Body']->getContents();
             $paste = Json::decode($data);
             if (!is_array($paste) || !isset($paste['meta']) || !is_array($paste['meta'])) {
                 error_log('failed to read ' . $pasteid . ' from ' . $this->_bucket .

--- a/tst/Data/GoogleCloudStorageTest.php
+++ b/tst/Data/GoogleCloudStorageTest.php
@@ -120,6 +120,16 @@ class GoogleCloudStorageTest extends TestCase
         $this->assertFalse($this->_model->exists(Helper::getPasteId()), 'paste does still not exist');
     }
 
+    public function testCorruptPastesAreRejected()
+    {
+        foreach ([true, [], ['meta' => true]] as $corruptPaste) {
+            self::$_bucket->upload(json_encode($corruptPaste), [
+                'name' => 'pastes/' . Helper::getPasteId(),
+            ]);
+            $this->assertFalse($this->_model->read(Helper::getPasteId()));
+        }
+    }
+
     public function testCommentErrorDetection()
     {
         $this->_model->delete(Helper::getPasteId());

--- a/tst/Data/S3StorageTest.php
+++ b/tst/Data/S3StorageTest.php
@@ -1,0 +1,65 @@
+<?php declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use PrivateBin\Data\S3Storage;
+
+class S3BodyStub
+{
+    public $data = '';
+
+    public function getContents()
+    {
+        return $this->data;
+    }
+}
+
+class S3ClientStub
+{
+    public $body;
+
+    public function __construct()
+    {
+        $this->body = new S3BodyStub;
+    }
+
+    public function getObject(array $options)
+    {
+        return ['Body' => $this->body];
+    }
+}
+
+class S3StorageTest extends TestCase
+{
+    private $_client;
+    private $_model;
+
+    public function setUp(): void
+    {
+        $reflection    = new ReflectionClass(S3Storage::class);
+        $this->_client = new S3ClientStub;
+        $this->_model  = $reflection->newInstanceWithoutConstructor();
+        foreach (['_client' => $this->_client, '_bucket' => 'bucket', '_prefix' => ''] as $name => $value) {
+            $property = $reflection->getProperty($name);
+            $property->setAccessible(true);
+            $property->setValue($this->_model, $value);
+        }
+    }
+
+    public function testCorruptPastesAreRejected()
+    {
+        $paste                     = Helper::getPaste();
+        $this->_client->body->data = json_encode($paste);
+        $this->assertSame($paste, $this->_model->read(Helper::getPasteId()));
+
+        $errorLog = ini_get('error_log');
+        ini_set('error_log', '/dev/null');
+        try {
+            foreach ([true, [], ['meta' => true]] as $corruptPaste) {
+                $this->_client->body->data = json_encode($corruptPaste);
+                $this->assertFalse($this->_model->read(Helper::getPasteId()));
+            }
+        } finally {
+            ini_set('error_log', $errorLog);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- enforce the documented `array|false` paste-read contract in the S3 and Google Cloud backends
- reject decoded paste roots that are not arrays
- reject paste arrays with missing or non-array metadata
- add direct regression coverage for both cloud adapters

## Reproduction

An S3 or Google Cloud paste object containing valid JSON such as `true`, `[]`, or `{"meta":true}` is currently returned as an existing paste. The cloud `read()` methods therefore violate their `array|false` backend contract. `Paste::get()` subsequently performs nested array operations on the value, causing a request-level `TypeError` instead of PrivateBin's normal not-found response.

## Tests

- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit --filter testCorruptPastesAreRejected Data/GoogleCloudStorageTest.php`
  - 1 test, 3 assertions passed
- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit Data/GoogleCloudStorageTest.php`
  - 7 tests, 76 assertions passed
- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit Data/S3StorageTest.php`
  - 1 test, 4 assertions passed
- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit --filter '/^(?!.*ServerSaltTest)/'`
  - 268 tests, 6511 assertions passed
- `php -l` on both adapters and both test files
- `git diff --check`

The S3 regression uses a constructor-free adapter instance with an in-memory client double, so it exercises the real `S3Storage::read()` implementation without network access or credentials.

The local full suite still has the pre-existing environment-sensitive `ServerSaltTest` assertion failures where PHPUnit displays identical expected and actual salt strings.

## Compatibility and privacy

Objects written by PrivateBin always have an array root and array metadata, so valid stored pastes are unchanged. Corrupt records now follow the backend's existing error response. Logs identify the affected object and bucket as before but do not include ciphertext or metadata.

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.