### PR TITLE
Protect validated template render paths

### DIFF
--- a/lib/View.php
+++ b/lib/View.php
@@ -58,7 +58,7 @@ class View
         if (!in_array($path, glob($dir . '*.php', GLOB_NOSORT | GLOB_ERR), true)) {
             throw new Exception('Template ' . $file . '.php not found in ' . $dir . '!', 81);
         }
-        extract($this->_variables);
+        extract($this->_variables, EXTR_SKIP);
         include $path;
     }
 

--- a/tst/ViewTest.php
+++ b/tst/ViewTest.php
@@ -129,4 +129,18 @@ class ViewTest extends TestCase
         $this->expectExceptionCode(81);
         $test->draw('../index');
     }
+
+    public function testAssignedVariableCannotOverrideTemplatePath()
+    {
+        $test = new View;
+        $test->assign('NAME', 'PrivateBinTest');
+        $test->assign('ERROR', 'expected error');
+        $test->assign('path', PATH . 'tpl' . DIRECTORY_SEPARATOR . 'does-not-exist.php');
+
+        ob_start();
+        $test->draw('shortenerproxy');
+        $content = ob_get_clean();
+
+        $this->assertStringContainsString('expected error', $content);
+    }
 }


### PR DESCRIPTION
## Summary

- prevent assigned template variables from overwriting `View::draw()` locals
- keep the already validated template path intact through the final `include`
- add a regression that assigns a conflicting lowercase `path` variable

## Reproduction

`View::draw()` validates its computed `$path`, then calls `extract($this->_variables)` immediately before `include $path`. Because the default extraction mode overwrites existing variables, `assign('path', ...)` replaces the validated path and redirects or suppresses the include.

The regression assigns a nonexistent path while drawing `shortenerproxy`. Before the fix, PHP raises a failed-include error from the assigned path. With `EXTR_SKIP`, renderer locals remain authoritative and the validated template renders normally.

## Tests

- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit --filter testAssignedVariableCannotOverrideTemplatePath ViewTest.php`
  - 1 test, 1 assertion passed
- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit ViewTest.php`
  - 4 tests, 11 assertions passed
- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit --filter '/^(?!.*ServerSaltTest)/'`
  - 267 tests, 6506 assertions passed
- `php -l lib/View.php`
- `php -l tst/ViewTest.php`
- `git diff --check`

The local full suite still has the pre-existing environment-sensitive `ServerSaltTest` assertion failures where PHPUnit displays identical expected and actual salt strings.

## Compatibility and security

Controller-provided template variable names are uppercase and do not collide with renderer locals, so normal templates are unchanged. Assigned names such as `path`, `file`, and `dir` were not safely available to templates because they collided with internal state; they are now skipped during extraction. This prevents an API caller from changing the include target after validation.

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.