### PR TITLE
Reject malformed translation structures

### DIFF
--- a/lib/I18n.php
+++ b/lib/I18n.php
@@ -186,7 +186,8 @@ class I18n
             self::$_translations = [];
         } else {
             $data                = file_get_contents(self::_getPath(self::$_language . '.json'));
-            self::$_translations = Json::decode($data);
+            $translations        = Json::decode($data);
+            self::$_translations = is_array($translations) ? $translations : [];
         }
     }
 
@@ -277,7 +278,8 @@ class I18n
         $file = self::_getPath('languages.json');
         if (count(self::$_languageLabels) === 0 && is_readable($file)) {
             $data                  = file_get_contents($file);
-            self::$_languageLabels = Json::decode($data);
+            $labels                = Json::decode($data);
+            self::$_languageLabels = is_array($labels) ? $labels : [];
         }
         if (count($languages) === 0) {
             return self::$_languageLabels;

--- a/lib/I18n.php
+++ b/lib/I18n.php
@@ -187,7 +187,8 @@ class I18n
         } else {
             $data                = file_get_contents(self::_getPath(self::$_language . '.json'));
             $translations        = Json::decode($data);
-            self::$_translations = is_array($translations) ? $translations : [];
+            self::$_translations = is_array($translations) ?
+                self::_filterCatalog($translations) : [];
         }
     }
 
@@ -279,7 +280,8 @@ class I18n
         if (count(self::$_languageLabels) === 0 && is_readable($file)) {
             $data                  = file_get_contents($file);
             $labels                = Json::decode($data);
-            self::$_languageLabels = is_array($labels) ? $labels : [];
+            self::$_languageLabels = is_array($labels) ?
+                self::_filterCatalog($labels) : [];
         }
         if (count($languages) === 0) {
             return self::$_languageLabels;
@@ -340,6 +342,34 @@ class I18n
             self::$_path = PUBLIC_PATH . DIRECTORY_SEPARATOR . 'i18n';
         }
         return self::$_path . (empty($file) ? '' : DIRECTORY_SEPARATOR . $file);
+    }
+
+    /**
+     * remove values that cannot be used as messages or language labels
+     *
+     * @access private
+     * @static
+     * @param  array $catalog
+     * @return array
+     */
+    private static function _filterCatalog(array $catalog)
+    {
+        foreach ($catalog as $key => $entry) {
+            if (is_string($entry)) {
+                continue;
+            }
+            if (!is_array($entry) || count($entry) === 0) {
+                unset($catalog[$key]);
+                continue;
+            }
+            foreach ($entry as $value) {
+                if (!is_string($value)) {
+                    unset($catalog[$key]);
+                    break;
+                }
+            }
+        }
+        return $catalog;
     }
 
     /**

--- a/tst/I18nTest.php
+++ b/tst/I18nTest.php
@@ -259,6 +259,21 @@ class I18nTest extends TestCase
             I18n::loadTranslations();
             $this->assertSame('fallback message', I18n::_('fallback message'));
             $this->assertSame([], I18n::getLanguageLabels());
+
+            file_put_contents(
+                $path . DIRECTORY_SEPARATOR . 'zz.json',
+                '{"fallback message":true,"valid message":"translated"}'
+            );
+            file_put_contents(
+                $path . DIRECTORY_SEPARATOR . 'languages.json',
+                '{"zz":true,"yy":["Valid","Valid"]}'
+            );
+            I18nMock::resetLanguageLabels();
+            I18nMock::resetTranslations();
+            I18n::loadTranslations();
+            $this->assertSame('fallback message', I18n::_('fallback message'));
+            $this->assertSame('translated', I18n::_('valid message'));
+            $this->assertSame(['yy' => ['Valid', 'Valid']], I18n::getLanguageLabels());
         } finally {
             unset($_COOKIE['lang']);
             I18nMock::resetPath();

--- a/tst/I18nTest.php
+++ b/tst/I18nTest.php
@@ -11,6 +11,16 @@ class I18nMock extends I18n
         self::$_availableLanguages = [];
     }
 
+    public static function resetLanguageLabels()
+    {
+        self::$_languageLabels = [];
+    }
+
+    public static function resetTranslations()
+    {
+        self::$_translations = [];
+    }
+
     public static function resetPath($path = '')
     {
         self::$_path = $path;
@@ -229,6 +239,34 @@ class I18nTest extends TestCase
         I18nMock::resetAvailableLanguages();
         I18nMock::resetPath();
         Helper::rmDir($path);
+    }
+
+    public function testMalformedTranslationStructuresAreIgnored()
+    {
+        $path = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'privatebin_i18n_malformed';
+        if (!is_dir($path)) {
+            mkdir($path);
+        }
+        file_put_contents($path . DIRECTORY_SEPARATOR . 'zz.json', 'true');
+        file_put_contents($path . DIRECTORY_SEPARATOR . 'languages.json', 'true');
+        I18nMock::resetPath($path);
+        I18nMock::resetAvailableLanguages();
+        I18nMock::resetLanguageLabels();
+        I18nMock::resetTranslations();
+        $_COOKIE['lang'] = 'zz';
+
+        try {
+            I18n::loadTranslations();
+            $this->assertSame('fallback message', I18n::_('fallback message'));
+            $this->assertSame([], I18n::getLanguageLabels());
+        } finally {
+            unset($_COOKIE['lang']);
+            I18nMock::resetPath();
+            I18nMock::resetAvailableLanguages();
+            I18nMock::resetLanguageLabels();
+            I18nMock::resetTranslations();
+            Helper::rmDir($path);
+        }
     }
 
     public function testGetCopyHotkey()


### PR DESCRIPTION
## Summary

- require decoded translation catalogs to be arrays
- require decoded language-label catalogs to be arrays
- discard boolean, empty-array, and nested-nonstring catalog entries individually
- preserve valid entries alongside malformed ones
- fall back to empty catalogs for syntactically valid but structurally unusable JSON
- add isolated malformed locale fixtures for both caches

## Reproduction

`Json::decode()` accepts scalar JSON such as `true`. `I18n::loadTranslations()` stores that boolean directly in the translation cache, and the next translation calls `array_key_exists()` with a boolean, causing `TypeError`. `getLanguageLabels()` has the same contract violation and can return a boolean where callers expect an array.

The regression supplies `true` as both `zz.json` and `languages.json`. Before the fix, the first fallback translation crashes. After the fix, untranslated messages use their message ID and labels return an empty array.

Array-root catalogs could still contain boolean message or label values. A boolean message was rendered as `"1"`, and malformed plural arrays could trigger undefined offsets or formatter type errors. Catalog filtering now accepts strings and non-empty string arrays only, dropping malformed entries without discarding valid neighbors.

## Tests

- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit --filter testMalformedTranslationStructuresAreIgnored I18nTest.php`
  - 1 test, 5 assertions passed
- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit I18nTest.php`
  - 19 tests, 5507 assertions passed
- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit --filter '/^(?!.*ServerSaltTest)/'`
  - 267 tests, 6510 assertions passed
- `php -l lib/I18n.php`
- `php -l tst/I18nTest.php`
- `git diff --check`

The local full suite still has the pre-existing environment-sensitive `ServerSaltTest` assertion failures where PHPUnit displays identical expected and actual salt strings.

## Compatibility and security

Valid associative translation and label catalogs are unchanged. Invalid roots no longer poison process-wide static caches, and bad individual entries fall back without disabling the rest of a locale. Translation content is not logged or exposed.

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.