### PR TITLE
Validate filesystem paste enumeration

### DIFF
--- a/lib/Data/Filesystem.php
+++ b/lib/Data/Filesystem.php
@@ -391,7 +391,20 @@ class Filesystem extends AbstractData
         $pastes = [];
         foreach (new GlobIterator($this->_path . self::PASTE_FILE_PATTERN) as $file) {
             if ($file->isFile()) {
-                $pastes[] = $file->getBasename('.php');
+                if (
+                    preg_match('/\A([a-f0-9]{16})(?:\.php)?\z/', $file->getFilename(), $matches) !== 1
+                ) {
+                    continue;
+                }
+                $pasteid = $matches[1];
+                $path    = $file->getPath();
+                if (
+                    basename($path) !== substr($pasteid, 2, 2) ||
+                    basename(dirname($path)) !== substr($pasteid, 0, 2)
+                ) {
+                    continue;
+                }
+                $pastes[] = $pasteid;
             }
         }
         return $pastes;

--- a/tst/Data/FilesystemTest.php
+++ b/tst/Data/FilesystemTest.php
@@ -109,6 +109,30 @@ class FilesystemTest extends TestCase
         }
     }
 
+    public function testPasteEnumerationValidatesFilenameAndShard()
+    {
+        $pasteid = Helper::getPasteId();
+        $paste   = Helper::getPaste();
+        $this->assertTrue($this->_model->create($pasteid, $paste));
+        $path = $this->_path . DIRECTORY_SEPARATOR . substr($pasteid, 0, 2) .
+            DIRECTORY_SEPARATOR . substr($pasteid, 2, 2) . DIRECTORY_SEPARATOR;
+        file_put_contents($path . $pasteid . '.php.bak', '{}');
+        file_put_contents($path . $pasteid . 'extra', '{}');
+        file_put_contents($path . 'ffffffffffffffff.php', '{}');
+
+        $legacyid   = 'aaaaaaaaaaaaaaaa';
+        $legacyPath = $this->_path . DIRECTORY_SEPARATOR . 'aa' .
+            DIRECTORY_SEPARATOR . 'aa' . DIRECTORY_SEPARATOR;
+        mkdir($legacyPath, 0700, true);
+        file_put_contents($legacyPath . $legacyid, '{}');
+
+        $expected = [$pasteid, $legacyid];
+        $actual   = $this->_model->getAllPastes();
+        sort($expected);
+        sort($actual);
+        $this->assertSame($expected, $actual);
+    }
+
     public function testErrorDetection()
     {
         $error_log_setting = ini_get('error_log');


### PR DESCRIPTION
## Summary

- accept only exact 16-hex legacy filenames or exact 16-hex `.php` paste filenames
- require each enumerated paste ID to match its two filesystem shard directories
- exclude backup suffixes, trailing junk, and misplaced paste files
- preserve enumeration of correctly sharded legacy files for conversion

## Reproduction

The filesystem glob intentionally permits a suffix so it can find both legacy files and protected `.php` files. `getAllPastes()` previously removed `.php` when present but performed no further validation. Files such as `<id>.php.bak` and `<id>extra` were returned as paste IDs, while a valid-looking ID stored under another ID's shard directories was also returned.

These phantom IDs are exposed by administration and migration commands. They also enter the randomized purge scan, where enough junk entries can consume the `10 * batchsize` inspection limit before expired pastes are examined.

## Tests

- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit --filter testPasteEnumerationValidatesFilenameAndShard Data/FilesystemTest.php`
  - 1 test, 2 assertions passed
- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit Data/FilesystemTest.php`
  - 8 tests, 159 assertions passed
- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit --filter '/^(?!.*ServerSaltTest)/'`
  - 267 tests, 6507 assertions passed
- `php -l lib/Data/Filesystem.php`
- `php -l tst/Data/FilesystemTest.php`
- `git diff --check`

The local full suite still has the pre-existing environment-sensitive `ServerSaltTest` assertion failures where PHPUnit displays identical expected and actual salt strings.

## Compatibility and safety

PrivateBin's protected `<id>.php` format and legacy bare `<id>` format remain supported. Enumeration now reflects only paths that normal read, delete, purge, and conversion methods can address. No files are modified or deleted by the new validation.

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.