### PR TITLE
Harden administration data handling

### DIFF
--- a/bin/administration
+++ b/bin/administration
@@ -96,10 +96,9 @@ class Administration
     {
         $ids = $this->_store->getAllPastes();
         foreach ($ids as $pasteid) {
-            try {
-                $paste = $this->_store->read($pasteid);
-            } catch (Exception $e) {
-                echo "Error reading document {$pasteid}: ", $e->getMessage(), PHP_EOL;
+            $paste = $this->_read($pasteid);
+            if ($paste === false) {
+                continue;
             }
             if (array_key_exists('adata', $paste)) {
                 continue;
@@ -194,6 +193,28 @@ EOT, PHP_EOL;
     }
 
     /**
+     * reads a document and reports damaged data
+     *
+     * @access private
+     * @param  string $pasteid
+     * @return array|false
+     */
+    private function _read($pasteid)
+    {
+        try {
+            $paste = $this->_store->read($pasteid);
+        } catch (Exception $e) {
+            echo "Error reading document {$pasteid}: ", $e->getMessage(), PHP_EOL;
+            return false;
+        }
+        if (!is_array($paste)) {
+            echo "Error reading document {$pasteid}: damaged data", PHP_EOL;
+            return false;
+        }
+        return $paste;
+    }
+
+    /**
      * return option for given short or long keyname, if it got set
      *
      * @access private
@@ -275,42 +296,41 @@ EOT, PHP_EOL;
 
         echo "Total:\t\t\t{$counters['total']}", PHP_EOL;
         foreach ($ids as $pasteid) {
-            try {
-                $paste = $this->_store->read($pasteid);
-            } catch (Exception $e) {
-                echo "Error reading document {$pasteid}: ", $e->getMessage(), PHP_EOL;
-                ++$counters['damaged'];
-            }
+            $paste = $this->_read($pasteid);
             ++$counters['progress'];
 
-            if (
-                array_key_exists('meta', $paste) &&
-                array_key_exists('expire_date', $paste['meta']) &&
-                $paste['meta']['expire_date'] < $time
-            ) {
-                ++$counters['expired'];
-            }
-
-            if (array_key_exists('adata', $paste)) {
-                switch ($paste['adata'][Paste::ADATA_FORMATTER]) {
-                    case 'plaintext':
-                        ++$counters['plain'];
-                        break;
-                    case 'syntaxhighlighting':
-                        ++$counters['syntax'];
-                        break;
-                    case 'markdown':
-                        ++$counters['md'];
-                        break;
-                    default:
-                        ++$counters['unknown'];
-                        break;
-                }
-                $counters['discussion'] += (int) $paste['adata'][Paste::ADATA_OPEN_DISCUSSION];
-                $counters['burn'] += (int) $paste['adata'][Paste::ADATA_BURN_AFTER_READING];
+            if ($paste === false) {
+                ++$counters['damaged'];
             } else {
-                echo "Unsupported v1 paste ", $pasteid, PHP_EOL;
-                ++$counters['legacy'];
+                if (
+                    array_key_exists('meta', $paste) &&
+                    array_key_exists('expire_date', $paste['meta']) &&
+                    $paste['meta']['expire_date'] < $time
+                ) {
+                    ++$counters['expired'];
+                }
+
+                if (array_key_exists('adata', $paste)) {
+                    switch ($paste['adata'][Paste::ADATA_FORMATTER]) {
+                        case 'plaintext':
+                            ++$counters['plain'];
+                            break;
+                        case 'syntaxhighlighting':
+                            ++$counters['syntax'];
+                            break;
+                        case 'markdown':
+                            ++$counters['md'];
+                            break;
+                        default:
+                            ++$counters['unknown'];
+                            break;
+                    }
+                    $counters['discussion'] += (int) $paste['adata'][Paste::ADATA_OPEN_DISCUSSION];
+                    $counters['burn'] += (int) $paste['adata'][Paste::ADATA_BURN_AFTER_READING];
+                } else {
+                    echo "Unsupported v1 paste ", $pasteid, PHP_EOL;
+                    ++$counters['legacy'];
+                }
             }
 
             // display progress

--- a/bin/administration
+++ b/bin/administration
@@ -466,10 +466,15 @@ EOT, PHP_EOL;
 
         if ($this->_option('p', 'purge') !== null) {
             try {
-                $this->_store->purge(PHP_INT_MAX);
+                if (!$this->_store->purge(PHP_INT_MAX)) {
+                    self::_error('expired documents exist after deletion, permission problem?', 7);
+                }
             } catch (Exception $e) {
-                echo 'Error purging documents: ', $e->getMessage(), PHP_EOL,
-                    'Run the statistics to find damaged document IDs and either delete them or restore them from backup.', PHP_EOL;
+                self::_error(
+                    'purging documents failed: ' . $e->getMessage() . PHP_EOL .
+                    'Run the statistics to find damaged document IDs and either delete them or restore them from backup.',
+                    8
+                );
             }
             exit('purging of expired documents concluded' . PHP_EOL);
         }

--- a/bin/administration
+++ b/bin/administration
@@ -88,13 +88,7 @@ class Administration
                 $failed[] = $pasteid;
             }
         }
-        if (count($failed) > 0) {
-            self::_error(
-                'documents exist after deletion, permission problem? IDs: ' .
-                implode(', ', $failed),
-                7
-            );
-        }
+        self::_report_deletion_failures($failed);
         exit("All documents successfully deleted" . PHP_EOL);
     }
 
@@ -105,7 +99,8 @@ class Administration
      */
     private function _delete_v1()
     {
-        $ids = $this->_store->getAllPastes();
+        $ids    = $this->_store->getAllPastes();
+        $failed = array();
         foreach ($ids as $pasteid) {
             $paste = $this->_read($pasteid);
             if ($paste === false) {
@@ -116,8 +111,30 @@ class Administration
             }
             echo "Deleting v1 document ID: $pasteid" . PHP_EOL;
             $this->_store->delete($pasteid);
+            if ($this->_store->exists($pasteid)) {
+                $failed[] = $pasteid;
+            }
         }
+        self::_report_deletion_failures($failed);
         exit("All unsupported legacy v1 documents successfully deleted" . PHP_EOL);
+    }
+
+    /**
+     * reports documents that remain after a bulk deletion
+     *
+     * @access private
+     * @static
+     * @param  array $failed
+     */
+    private static function _report_deletion_failures(array $failed)
+    {
+        if (count($failed) > 0) {
+            self::_error(
+                'documents exist after deletion, permission problem? IDs: ' .
+                implode(', ', $failed),
+                7
+            );
+        }
     }
 
     /**

--- a/bin/administration
+++ b/bin/administration
@@ -79,10 +79,21 @@ class Administration
      */
     private function _delete_all()
     {
-        $ids = $this->_store->getAllPastes();
+        $ids    = $this->_store->getAllPastes();
+        $failed = array();
         foreach ($ids as $pasteid) {
             echo "Deleting document ID: $pasteid" . PHP_EOL;
             $this->_store->delete($pasteid);
+            if ($this->_store->exists($pasteid)) {
+                $failed[] = $pasteid;
+            }
+        }
+        if (count($failed) > 0) {
+            self::_error(
+                'documents exist after deletion, permission problem? IDs: ' .
+                implode(', ', $failed),
+                7
+            );
         }
         exit("All documents successfully deleted" . PHP_EOL);
     }

--- a/bin/administration
+++ b/bin/administration
@@ -207,11 +207,42 @@ EOT, PHP_EOL;
             echo "Error reading document {$pasteid}: ", $e->getMessage(), PHP_EOL;
             return false;
         }
-        if (!is_array($paste)) {
+        if (!is_array($paste) || !$this->_isValidPaste($paste)) {
             echo "Error reading document {$pasteid}: damaged data", PHP_EOL;
             return false;
         }
         return $paste;
+    }
+
+    /**
+     * checks whether a stored document can safely be classified
+     *
+     * @access private
+     * @param  array $paste
+     * @return bool
+     */
+    private function _isValidPaste(array $paste)
+    {
+        if (!array_key_exists('meta', $paste) || !is_array($paste['meta'])) {
+            return false;
+        }
+        if (array_key_exists('expire_date', $paste['meta'])) {
+            $expireDate = $paste['meta']['expire_date'];
+            if (
+                !is_int($expireDate) &&
+                !(is_string($expireDate) && preg_match('/\A[+-]?\d+\z/', $expireDate) === 1)
+            ) {
+                return false;
+            }
+        }
+        if (!array_key_exists('adata', $paste)) {
+            return array_key_exists('data', $paste) && is_string($paste['data']);
+        }
+        $adata = $paste['adata'];
+        return is_array($adata) &&
+            is_string($adata[Paste::ADATA_FORMATTER] ?? null) &&
+            is_int($adata[Paste::ADATA_OPEN_DISCUSSION] ?? null) &&
+            is_int($adata[Paste::ADATA_BURN_AFTER_READING] ?? null);
     }
 
     /**

--- a/lib/Data/AbstractData.php
+++ b/lib/Data/AbstractData.php
@@ -148,18 +148,24 @@ abstract class AbstractData
      *
      * @access public
      * @param  int $batchsize
+     * @return bool
      */
     public function purge($batchsize)
     {
         if ($batchsize < 1) {
-            return;
+            return true;
         }
+        $success = true;
         $pastes = $this->_getExpiredPastes($batchsize);
         if (count($pastes)) {
             foreach ($pastes as $pasteid) {
                 $this->delete($pasteid);
+                if ($this->exists($pasteid)) {
+                    $success = false;
+                }
             }
         }
+        return $success;
     }
 
     /**

--- a/lib/Data/AbstractData.php
+++ b/lib/Data/AbstractData.php
@@ -156,7 +156,7 @@ abstract class AbstractData
             return true;
         }
         $success = true;
-        $pastes = $this->_getExpiredPastes($batchsize);
+        $pastes  = $this->_getExpiredPastes($batchsize);
         if (count($pastes)) {
             foreach ($pastes as $pasteid) {
                 $this->delete($pasteid);

--- a/tst/AdministrationTest.php
+++ b/tst/AdministrationTest.php
@@ -124,7 +124,7 @@ class AdministrationTest extends TestCase
     {
         $databasePath = $this->_path . DIRECTORY_SEPARATOR . 'administration-' .
             bin2hex(random_bytes(4)) . '.sq3';
-        $options      = parse_ini_file(CONF_SAMPLE, true);
+        $options                   = parse_ini_file(CONF_SAMPLE, true);
         $options['model']['class'] = 'Database';
         $options['model_options']  = [
             'dsn' => 'sqlite:' . $databasePath,

--- a/tst/AdministrationTest.php
+++ b/tst/AdministrationTest.php
@@ -1,0 +1,74 @@
+<?php declare(strict_types=1);
+use PHPUnit\Framework\TestCase;
+use PrivateBin\Data\Filesystem;
+
+class AdministrationTest extends TestCase
+{
+    private $_path;
+
+    private $_store;
+
+    public function setUp(): void
+    {
+        $this->_path = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'privatebin_administration';
+        Helper::rmDir($this->_path);
+        mkdir($this->_path);
+        mkdir($this->_path . DIRECTORY_SEPARATOR . 'cfg');
+
+        $options                         = parse_ini_file(CONF_SAMPLE, true);
+        $options['model_options']['dir'] = $this->_path . DIRECTORY_SEPARATOR . 'data';
+        Helper::createIniFile(
+            $this->_path . DIRECTORY_SEPARATOR . 'cfg' . DIRECTORY_SEPARATOR . 'conf.php',
+            $options
+        );
+
+        $this->_store = new Filesystem($options['model_options']);
+        $paste        = Helper::getPaste();
+        $this->_store->create(Helper::getPasteId(), $paste);
+        file_put_contents(
+            $options['model_options']['dir'] . DIRECTORY_SEPARATOR .
+            substr(Helper::getPasteId(), 0, 2) . DIRECTORY_SEPARATOR .
+            substr(Helper::getPasteId(), 2, 2) . DIRECTORY_SEPARATOR .
+            Helper::getPasteId() . '.php',
+            Filesystem::PROTECTION_LINE . PHP_EOL . '{'
+        );
+    }
+
+    public function tearDown(): void
+    {
+        Helper::rmDir($this->_path);
+    }
+
+    public function testStatisticsSkipsDamagedPastes()
+    {
+        [$exitCode, $output] = $this->runAdministration('--statistics');
+
+        $this->assertSame(0, $exitCode);
+        $this->assertStringContainsString("Damaged:\t\t1", $output);
+        $this->assertStringNotContainsString('Unsupported v1 paste', $output);
+    }
+
+    public function testDeleteV1PreservesDamagedPastes()
+    {
+        [$exitCode, $output] = $this->runAdministration('--delete-v1');
+
+        $this->assertSame(0, $exitCode);
+        $this->assertStringContainsString(
+            'Error reading document ' . Helper::getPasteId(),
+            $output
+        );
+        $this->assertTrue($this->_store->exists(Helper::getPasteId()));
+    }
+
+    private function runAdministration($option)
+    {
+        $command = 'CONFIG_PATH=' .
+            escapeshellarg($this->_path . DIRECTORY_SEPARATOR . 'cfg') . ' ' .
+            escapeshellarg(PHP_BINARY) . ' ' .
+            escapeshellarg(realpath(PATH . 'bin' . DIRECTORY_SEPARATOR . 'administration')) . ' ' .
+            escapeshellarg($option) . ' 2>&1';
+        exec($command, $output, $exitCode);
+
+        return [$exitCode, implode(PHP_EOL, $output)];
+    }
+}

--- a/tst/AdministrationTest.php
+++ b/tst/AdministrationTest.php
@@ -1,5 +1,6 @@
 <?php declare(strict_types=1);
 use PHPUnit\Framework\TestCase;
+use PrivateBin\Data\Database;
 use PrivateBin\Data\Filesystem;
 
 class AdministrationTest extends TestCase
@@ -97,7 +98,32 @@ class AdministrationTest extends TestCase
 
     public function testDeleteAllReportsRecordsThatRemain()
     {
-        $databasePath = $this->_path . DIRECTORY_SEPARATOR . 'administration.sq3';
+        $store = $this->createUndeletableDatabasePaste(Helper::getPaste());
+
+        [$exitCode, $output] = $this->runAdministration('--delete-all');
+
+        $this->assertSame(7, $exitCode);
+        $this->assertStringContainsString(Helper::getPasteId(), $output);
+        $this->assertStringNotContainsString('All documents successfully deleted', $output);
+        $this->assertTrue($store->exists(Helper::getPasteId()));
+    }
+
+    public function testDeleteV1ReportsRecordsThatRemain()
+    {
+        $store = $this->createUndeletableDatabasePaste(['data' => '', 'meta' => []]);
+
+        [$exitCode, $output] = $this->runAdministration('--delete-v1');
+
+        $this->assertSame(7, $exitCode);
+        $this->assertStringContainsString(Helper::getPasteId(), $output);
+        $this->assertStringNotContainsString('All unsupported legacy v1 documents successfully deleted', $output);
+        $this->assertTrue($store->exists(Helper::getPasteId()));
+    }
+
+    private function createUndeletableDatabasePaste(array $paste)
+    {
+        $databasePath = $this->_path . DIRECTORY_SEPARATOR . 'administration-' .
+            bin2hex(random_bytes(4)) . '.sq3';
         $options      = parse_ini_file(CONF_SAMPLE, true);
         $options['model']['class'] = 'Database';
         $options['model_options']  = [
@@ -111,8 +137,7 @@ class AdministrationTest extends TestCase
             $options
         );
 
-        $store = new PrivateBin\Data\Database($options['model_options']);
-        $paste = Helper::getPaste();
+        $store = new Database($options['model_options']);
         $this->assertTrue($store->create(Helper::getPasteId(), $paste));
         $database = new PDO('sqlite:' . $databasePath);
         $database->exec(
@@ -120,12 +145,7 @@ class AdministrationTest extends TestCase
             'BEGIN SELECT RAISE(IGNORE); END'
         );
 
-        [$exitCode, $output] = $this->runAdministration('--delete-all');
-
-        $this->assertSame(7, $exitCode);
-        $this->assertStringContainsString(Helper::getPasteId(), $output);
-        $this->assertStringNotContainsString('All documents successfully deleted', $output);
-        $this->assertTrue($store->exists(Helper::getPasteId()));
+        return $store;
     }
 
     private function overwritePaste($data)

--- a/tst/AdministrationTest.php
+++ b/tst/AdministrationTest.php
@@ -95,6 +95,39 @@ class AdministrationTest extends TestCase
         $this->assertFalse($this->_store->exists(Helper::getPasteId()));
     }
 
+    public function testDeleteAllReportsRecordsThatRemain()
+    {
+        $databasePath = $this->_path . DIRECTORY_SEPARATOR . 'administration.sq3';
+        $options      = parse_ini_file(CONF_SAMPLE, true);
+        $options['model']['class'] = 'Database';
+        $options['model_options']  = [
+            'dsn' => 'sqlite:' . $databasePath,
+            'usr' => '',
+            'pwd' => '',
+            'opt' => [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION],
+        ];
+        Helper::createIniFile(
+            $this->_path . DIRECTORY_SEPARATOR . 'cfg' . DIRECTORY_SEPARATOR . 'conf.php',
+            $options
+        );
+
+        $store = new PrivateBin\Data\Database($options['model_options']);
+        $paste = Helper::getPaste();
+        $this->assertTrue($store->create(Helper::getPasteId(), $paste));
+        $database = new PDO('sqlite:' . $databasePath);
+        $database->exec(
+            'CREATE TRIGGER keep_paste BEFORE DELETE ON paste ' .
+            'BEGIN SELECT RAISE(IGNORE); END'
+        );
+
+        [$exitCode, $output] = $this->runAdministration('--delete-all');
+
+        $this->assertSame(7, $exitCode);
+        $this->assertStringContainsString(Helper::getPasteId(), $output);
+        $this->assertStringNotContainsString('All documents successfully deleted', $output);
+        $this->assertTrue($store->exists(Helper::getPasteId()));
+    }
+
     private function overwritePaste($data)
     {
         file_put_contents(

--- a/tst/AdministrationTest.php
+++ b/tst/AdministrationTest.php
@@ -60,6 +60,52 @@ class AdministrationTest extends TestCase
         $this->assertTrue($this->_store->exists(Helper::getPasteId()));
     }
 
+    public function testStatisticsSkipsStructurallyDamagedPastes()
+    {
+        $this->overwritePaste('{"adata":[],"meta":"invalid"}');
+
+        [$exitCode, $output] = $this->runAdministration('--statistics');
+
+        $this->assertSame(0, $exitCode);
+        $this->assertStringContainsString("Damaged:\t\t1", $output);
+        $this->assertStringNotContainsString('Unsupported v1 paste', $output);
+    }
+
+    public function testDeleteV1PreservesStructurallyDamagedPastes()
+    {
+        $this->overwritePaste('{"meta":[]}');
+
+        [$exitCode, $output] = $this->runAdministration('--delete-v1');
+
+        $this->assertSame(0, $exitCode);
+        $this->assertStringContainsString(
+            'Error reading document ' . Helper::getPasteId(),
+            $output
+        );
+        $this->assertTrue($this->_store->exists(Helper::getPasteId()));
+    }
+
+    public function testDeleteV1DeletesLegacyPastes()
+    {
+        $this->overwritePaste('{"data":"","meta":{}}');
+
+        [$exitCode] = $this->runAdministration('--delete-v1');
+
+        $this->assertSame(0, $exitCode);
+        $this->assertFalse($this->_store->exists(Helper::getPasteId()));
+    }
+
+    private function overwritePaste($data)
+    {
+        file_put_contents(
+            $this->_path . DIRECTORY_SEPARATOR . 'data' . DIRECTORY_SEPARATOR .
+            substr(Helper::getPasteId(), 0, 2) . DIRECTORY_SEPARATOR .
+            substr(Helper::getPasteId(), 2, 2) . DIRECTORY_SEPARATOR .
+            Helper::getPasteId() . '.php',
+            Filesystem::PROTECTION_LINE . PHP_EOL . $data
+        );
+    }
+
     private function runAdministration($option)
     {
         $command = 'CONFIG_PATH=' .

--- a/tst/AdministrationTest.php
+++ b/tst/AdministrationTest.php
@@ -120,7 +120,35 @@ class AdministrationTest extends TestCase
         $this->assertTrue($store->exists(Helper::getPasteId()));
     }
 
-    private function createUndeletableDatabasePaste(array $paste)
+    public function testPurgeReportsRecordsThatRemain()
+    {
+        $store = $this->createUndeletableDatabasePaste(
+            Helper::getPaste(['expire_date' => time() - 60])
+        );
+
+        [$exitCode, $output] = $this->runAdministration('--purge');
+
+        $this->assertSame(7, $exitCode);
+        $this->assertStringNotContainsString('purging of expired documents concluded', $output);
+        $this->assertTrue($store->exists(Helper::getPasteId()));
+    }
+
+    public function testPurgeReportsBackendErrors()
+    {
+        $store = $this->createUndeletableDatabasePaste(
+            Helper::getPaste(['expire_date' => time() - 60]),
+            true
+        );
+
+        [$exitCode, $output] = $this->runAdministration('--purge');
+
+        $this->assertSame(8, $exitCode);
+        $this->assertStringContainsString('Error: purging documents failed', $output);
+        $this->assertStringNotContainsString('purging of expired documents concluded', $output);
+        $this->assertTrue($store->exists(Helper::getPasteId()));
+    }
+
+    private function createUndeletableDatabasePaste(array $paste, $throw = false)
     {
         $databasePath = $this->_path . DIRECTORY_SEPARATOR . 'administration-' .
             bin2hex(random_bytes(4)) . '.sq3';
@@ -142,7 +170,9 @@ class AdministrationTest extends TestCase
         $database = new PDO('sqlite:' . $databasePath);
         $database->exec(
             'CREATE TRIGGER keep_paste BEFORE DELETE ON paste ' .
-            'BEGIN SELECT RAISE(IGNORE); END'
+            'BEGIN SELECT RAISE(' .
+            ($throw ? 'ABORT, "deletion blocked"' : 'IGNORE') .
+            '); END'
         );
 
         return $store;


### PR DESCRIPTION
## Summary

- centralize administration-command paste reads and reject malformed results
- count unreadable records as damaged during `--statistics` without classifying their contents
- preserve unreadable records during `--delete-v1` instead of treating them as legacy data
- distinguish structurally usable v2 records from recognizable legacy v1 records
- verify that every `--delete-all` and `--delete-v1` record is actually gone before reporting success
- verify purge deletions and return nonzero status for retained records or backend errors
- add subprocess regressions using a real filesystem configuration and malformed stored pastes

## Reproduction

The filesystem backend returns `false` when a stored paste cannot be decoded. Both `--statistics` and `--delete-v1` passed that value directly to `array_key_exists()`, causing a PHP `TypeError` and exit code 255.

The exception path had the same control-flow problem: after reporting the exception, the command continued with an unset or previous-loop `$paste` value.

The new tests create a valid enumerated paste, corrupt its JSON on disk, and invoke the actual CLI through `CONFIG_PATH`. Before the fix, both commands terminated with exit code 255. They now complete normally; statistics reports one damaged record, while legacy cleanup reports and preserves the unreadable paste.

Array-shaped corruption also bypassed the original scalar guard. Non-array metadata still crashed statistics, while a record containing neither v2 `adata` nor legacy v1 `data` was deleted as an unsupported legacy paste. The shared read boundary now verifies metadata, expiration, and the fields administration actually inspects. Malformed arrays are reported as damaged; a valid `{"data":"…","meta":{…}}` v1 record remains eligible for legacy deletion.

`--delete-all` and `--delete-v1` previously printed success and exited zero after merely issuing each backend delete. A SQLite trigger that ignores deletion reproduces the false success while leaving both current and recognizable legacy pastes present. Both bulk deletion paths now check every attempted ID, continue through the full set, and report all remaining IDs with exit code 7.

`--purge` had two equivalent false-success paths: ignored deletes were undetectable because the shared purge method returned no result, and caught backend exceptions were followed by exit code 0 plus “concluded.” The shared purge method now verifies each deletion and returns a boolean result. The administration command exits 7 when expired records remain and 8 when the backend throws, without printing its success message.

## Tests

- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit AdministrationTest.php --testdox`
  - 9 tests, 33 assertions passed
- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit --filter '/^(?!.*ServerSaltTest)/'`
  - 275 tests, 6538 assertions passed
- `php -l bin/administration`
- `php -l tst/AdministrationTest.php`
- `git diff --check`

The excluded `ServerSaltTest` cases are environment-sensitive under the root-owned local test workspace and are unrelated to this change.

## Compatibility and safety

Valid v1 and v2 records retain their existing handling. Damaged records are never printed or inspected beyond the existing identifier, so encrypted payloads remain private. Most importantly, `--delete-v1` only removes recognizable legacy records and no longer deletes unreadable or unclassifiable data speculatively; administrators can restore or inspect it separately. Bulk deletion and purge still attempt every eligible record, but no command tells an operator that cleanup succeeded when a backend silently left records behind. Web-request purge callers remain compatible because they may ignore the new boolean result.

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.