### PR TITLE
Quote the administration storage path

### DIFF
--- a/bin/administration
+++ b/bin/administration
@@ -121,7 +121,7 @@ class Administration
             self::_error('instance not using Filesystem storage, no directories to empty', 4);
         }
         $dir = $this->_conf->getKey('dir', 'model_options');
-        passthru("find $dir -type d -empty -delete", $code);
+        passthru('find ' . escapeshellarg($dir) . ' -type d -empty -delete', $code);
         exit($code);
     }
 

--- a/tst/AdministrationEmptyDirsTest.php
+++ b/tst/AdministrationEmptyDirsTest.php
@@ -1,0 +1,52 @@
+<?php declare(strict_types=1);
+use PHPUnit\Framework\TestCase;
+
+class AdministrationEmptyDirsTest extends TestCase
+{
+    private $_path;
+
+    public function setUp(): void
+    {
+        $this->_path = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'privatebin administration';
+        Helper::rmDir($this->_path);
+        mkdir($this->_path);
+        mkdir($this->_path . DIRECTORY_SEPARATOR . 'cfg');
+
+        $dataPath = $this->_path . DIRECTORY_SEPARATOR . 'data with spaces';
+        mkdir($dataPath);
+        mkdir($dataPath . DIRECTORY_SEPARATOR . 'empty' . DIRECTORY_SEPARATOR . 'nested', 0777, true);
+        file_put_contents($dataPath . DIRECTORY_SEPARATOR . 'keep.txt', 'keep');
+
+        $options                         = parse_ini_file(CONF_SAMPLE, true);
+        $options['model_options']['dir'] = $dataPath;
+        Helper::createIniFile(
+            $this->_path . DIRECTORY_SEPARATOR . 'cfg' . DIRECTORY_SEPARATOR . 'conf.php',
+            $options
+        );
+    }
+
+    public function tearDown(): void
+    {
+        Helper::rmDir($this->_path);
+    }
+
+    public function testEmptyDirsSupportsStoragePathsWithSpaces()
+    {
+        $command = 'CONFIG_PATH=' .
+            escapeshellarg($this->_path . DIRECTORY_SEPARATOR . 'cfg') . ' ' .
+            escapeshellarg(PHP_BINARY) . ' ' .
+            escapeshellarg(realpath(PATH . 'bin' . DIRECTORY_SEPARATOR . 'administration')) .
+            ' --empty-dirs 2>&1';
+        exec($command, $output, $exitCode);
+
+        $this->assertSame(0, $exitCode, implode(PHP_EOL, $output));
+        $this->assertDirectoryDoesNotExist(
+            $this->_path . DIRECTORY_SEPARATOR . 'data with spaces' .
+            DIRECTORY_SEPARATOR . 'empty'
+        );
+        $this->assertFileExists(
+            $this->_path . DIRECTORY_SEPARATOR . 'data with spaces' .
+            DIRECTORY_SEPARATOR . 'keep.txt'
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- shell-escape the configured filesystem storage path passed to `find`
- support valid storage paths containing spaces
- prevent shell metacharacters in a configured path from being interpreted
- add a real CLI regression for nested empty directories under a spaced path

## Reproduction

`administration --empty-dirs` interpolated the configured model directory directly into a shell command. With a storage directory such as `/tmp/privatebin administration/data with spaces`, `find` treated the path as four separate operands, printed four “No such file or directory” errors, returned exit code 1, and left the empty directories in place.

The command now applies `escapeshellarg()` to the one user-configurable operand. The regression invokes the actual CLI via `CONFIG_PATH`, verifies nested empty directories are removed, and verifies a non-empty sibling remains untouched.

## Tests

- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit AdministrationEmptyDirsTest.php --testdox`
  - 1 test, 3 assertions passed
- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit --filter '/^(?!.*ServerSaltTest)/'`
  - 267 tests, 6508 assertions passed
- `php -l bin/administration`
- `php -l tst/AdministrationEmptyDirsTest.php`
- `git diff --check`

The excluded `ServerSaltTest` cases are environment-sensitive under the root-owned local test workspace and are unrelated to this change.

## Compatibility and security

Paths without shell-sensitive characters behave exactly as before. Paths with spaces or shell metacharacters are now passed to `find` as one literal operand. This both restores legitimate filesystem compatibility and removes command interpretation of configuration data.

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.