### PR TITLE
Reject damaged source pastes during migration

### DIFF
--- a/bin/migrate
+++ b/bin/migrate
@@ -67,7 +67,10 @@ $ids      = $srcstore->getAllPastes();
 
 foreach ($ids as $id) {
     debug("Reading document ID " . $id);
-    $paste    = $srcstore->read($id);
+    $paste = $srcstore->read($id);
+    if (!is_array($paste)) {
+        dieerr("Unable to read document ID " . $id);
+    }
     $comments = $srcstore->readComments($id);
 
     savePaste($force_overwrite, $dryrun, $id, $paste, $dststore);

--- a/tst/MigrateTest.php
+++ b/tst/MigrateTest.php
@@ -81,4 +81,35 @@ class MigrateTest extends TestCase
         $this->assertTrue($this->_model_1->exists(Helper::getPasteId()), 'paste migrated back');
         $this->assertTrue($this->_model_1->existsComment(Helper::getPasteId(), Helper::getPasteId(), Helper::getCommentId()), 'comment migrated back');
     }
+
+    public function testDamagedSourcePasteIsPreserved()
+    {
+        $this->_model_1->delete(Helper::getPasteId());
+        $paste = Helper::getPaste();
+        $this->_model_1->create(Helper::getPasteId(), $paste);
+        file_put_contents(
+            $this->_path_instance_1 . DIRECTORY_SEPARATOR . 'data' . DIRECTORY_SEPARATOR .
+            substr(Helper::getPasteId(), 0, 2) . DIRECTORY_SEPARATOR .
+            substr(Helper::getPasteId(), 2, 2) . DIRECTORY_SEPARATOR .
+            Helper::getPasteId() . '.php',
+            Filesystem::PROTECTION_LINE . PHP_EOL . '{'
+        );
+
+        $output    = null;
+        $exit_code = 0;
+        exec(
+            'php ' . PATH . 'bin' . DIRECTORY_SEPARATOR . 'migrate --delete-after ' .
+            $this->_path_instance_1 . DIRECTORY_SEPARATOR . 'cfg ' .
+            $this->_path_instance_2 . DIRECTORY_SEPARATOR . 'cfg 2>&1',
+            $output,
+            $exit_code
+        );
+
+        $this->assertSame(1, $exit_code, implode(PHP_EOL, $output));
+        $this->assertStringContainsString(
+            'ERROR: Unable to read document ID ' . Helper::getPasteId(),
+            implode(PHP_EOL, $output)
+        );
+        $this->assertTrue($this->_model_1->exists(Helper::getPasteId()));
+    }
 }


### PR DESCRIPTION
## Summary

- validate that a source paste was decoded before passing it to the destination backend
- replace an uncontrolled PHP type error with an actionable migration error
- preserve unreadable source data when `--delete-after` is requested
- add a filesystem-to-database regression with malformed stored JSON

## Reproduction

Filesystem storage returns `false` when an enumerated paste cannot be decoded. `bin/migrate` passed that value to the destination backend's array-typed `create()` method, causing a fatal `TypeError`, a stack trace, and exit code 255.

The migration now checks the documented `array|false` read result before reading comments or writing anything. For a damaged paste it reports `ERROR: Unable to read document ID …` and exits through the command's existing controlled error path with status 1.

The regression runs the actual migration with `--delete-after`. Before the fix it reproduces exit 255; after the fix it verifies the deliberate error and confirms the damaged source paste still exists.

## Tests

- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit MigrateTest.php --testdox`
  - 2 tests, 11 assertions passed
- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit --filter '/^(?!.*ServerSaltTest)/'`
  - 267 tests, 6508 assertions passed
- `php -l bin/migrate`
- `php -l tst/MigrateTest.php`
- `git diff --check`

The excluded `ServerSaltTest` cases are environment-sensitive under the root-owned local test workspace and are unrelated to this change.

## Compatibility and data safety

Valid migrations are unchanged. Invalid data is neither copied nor deleted, including with `--delete-after`. The error identifies only the paste ID and does not expose the encrypted stored payload.

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.