### PR TITLE
Reject ambiguous administration options

### DIFF
--- a/bin/administration
+++ b/bin/administration
@@ -233,9 +233,13 @@ EOT, PHP_EOL;
             self::_help(2);
         }
 
-        $this->_opts = getopt('hd:elps', array('help', 'delete:', 'delete-all', 'delete-v1', 'empty-dirs', 'list-ids', 'purge', 'statistics'));
+        $this->_opts = getopt(
+            'hd:elps',
+            array('help', 'delete:', 'delete-all', 'delete-v1', 'empty-dirs', 'list-ids', 'purge', 'statistics'),
+            $restIndex
+        );
 
-        if (!$this->_opts) {
+        if (!$this->_opts || count($this->_opts) !== 1 || $restIndex < $arguments) {
             self::_error_echo('unsupported arguments given');
             echo PHP_EOL;
             self::_help(3);

--- a/tst/AdministrationOptionsTest.php
+++ b/tst/AdministrationOptionsTest.php
@@ -1,0 +1,42 @@
+<?php declare(strict_types=1);
+use PHPUnit\Framework\TestCase;
+
+class AdministrationOptionsTest extends TestCase
+{
+    public function testAcceptsSingleAction()
+    {
+        [$exitCode, $output] = $this->runAdministration('--help');
+
+        $this->assertSame(0, $exitCode, $output);
+        $this->assertStringContainsString('Usage:', $output);
+    }
+
+    /**
+     * @dataProvider invalidArgumentsProvider
+     */
+    public function testRejectsAmbiguousArguments($arguments)
+    {
+        [$exitCode, $output] = $this->runAdministration($arguments);
+
+        $this->assertSame(3, $exitCode, $output);
+        $this->assertStringContainsString('Error: unsupported arguments given', $output);
+    }
+
+    private function runAdministration($arguments)
+    {
+        $command = escapeshellarg(PHP_BINARY) . ' ' .
+            escapeshellarg(realpath(PATH . 'bin' . DIRECTORY_SEPARATOR . 'administration')) .
+            ' ' . $arguments . ' 2>&1';
+        exec($command, $output, $exitCode);
+
+        return [$exitCode, implode(PHP_EOL, $output)];
+    }
+
+    public function invalidArgumentsProvider()
+    {
+        return [
+            'trailing positional argument' => ['--help unexpected'],
+            'multiple actions'             => ['--help --delete-all'],
+        ];
+    }
+}


### PR DESCRIPTION
## Summary

- require exactly one administration action per invocation
- reject unconsumed positional arguments before command dispatch
- preserve the existing unsupported-argument message and exit status
- add real-process regressions for ambiguous and valid invocations

## Reproduction

The administration command limited only the raw argument count and checked whether `getopt()` returned anything. It did not verify that all arguments were consumed or that only one action was selected.

As a result, `administration --help unexpected` and `administration --help --delete-all` both exited successfully. For destructive actions, the same behavior allows a command to execute despite a trailing typo or conflicting second action.

The parser now uses `getopt()`’s option index to reject positional leftovers and requires exactly one parsed option before dispatch. Both ambiguous examples return the existing unsupported-argument status 3, while a normal `--help` invocation remains successful.

## Tests

- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit AdministrationOptionsTest.php --testdox`
  - 3 tests, 6 assertions passed
- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit --filter '/^(?!.*ServerSaltTest)/'`
  - 269 tests, 6511 assertions passed
- `php -l bin/administration`
- `php -l tst/AdministrationOptionsTest.php`
- `git diff --check`

The excluded `ServerSaltTest` cases are environment-sensitive under the root-owned local test workspace and are unrelated to this change.

## Compatibility and safety

All documented single-action forms, including `--delete <id>`, remain accepted because their values are consumed by `getopt()`. Only previously ambiguous or unsupported invocations are rejected, preventing accidental destructive dispatch without changing storage or output data.

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.