### PR TITLE
Accept the minimum Format V2 iteration count

### DIFF
--- a/lib/FormatV2.php
+++ b/lib/FormatV2.php
@@ -102,7 +102,7 @@ class FormatV2
             return false;
         }
         // - iterations, refuse less then 10000 iterations (minimum NIST recommendation)
-        if (!is_int($cipherParams[2]) || $cipherParams[2] <= 10000) {
+        if (!is_int($cipherParams[2]) || $cipherParams[2] < 10000) {
             return false;
         }
         // - key size

--- a/tst/FormatV2Test.php
+++ b/tst/FormatV2Test.php
@@ -50,6 +50,14 @@ class FormatV2Test extends TestCase
         $this->assertFalse(FormatV2::isValid($paste), 'not enough iterations');
 
         $paste                = Helper::getPastePost();
+        $paste['adata'][0][2] = 10000;
+        $this->assertTrue(FormatV2::isValid($paste), 'minimum iteration count');
+
+        $paste                = Helper::getPastePost();
+        $paste['adata'][0][2] = 9999;
+        $this->assertFalse(FormatV2::isValid($paste), 'below minimum iteration count');
+
+        $paste                = Helper::getPastePost();
         $paste['adata'][0][3] = 127;
         $this->assertFalse(FormatV2::isValid($paste), 'invalid key size');
 


### PR DESCRIPTION
## Summary

- accept exactly 10,000 PBKDF iterations, the validator's documented minimum
- continue rejecting integer iteration counts below that minimum
- add explicit tests on both sides of the boundary

## Reproduction

The Format V2 validator describes its policy as refusing fewer than 10,000 iterations, but implemented the check with `<= 10000`. A structurally valid encrypted paste using exactly 10,000 iterations was therefore rejected as invalid.

The comparison now uses `< 10000`. The regression fails on the previous implementation at exactly 10,000 and independently confirms that 9,999 is still rejected.

## Tests

- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit FormatV2Test.php --testdox`
  - 2 tests, 28 assertions passed
- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit --filter '/^(?!.*ServerSaltTest)/'`
  - 266 tests, 6507 assertions passed
- `php -l lib/FormatV2.php`
- `php -l tst/FormatV2Test.php`
- `git diff --check`

The excluded `ServerSaltTest` cases are environment-sensitive under the root-owned local test workspace and are unrelated to this change.

## Security and compatibility

No iteration count below the existing stated minimum becomes valid. This only restores the boundary value itself, improving compatibility with clients that follow the documented 10,000-iteration minimum while preserving all other cipher validation.

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.