### PR TITLE
Verify paste deletion before reporting success

### DIFF
--- a/lib/Model/Paste.php
+++ b/lib/Model/Paste.php
@@ -116,10 +116,14 @@ class Paste extends AbstractModel
      * Delete the paste.
      *
      * @access public
+     * @throws TranslatedException
      */
     public function delete()
     {
         $this->_store->delete($this->getId());
+        if ($this->exists()) {
+            throw new TranslatedException('Error deleting document. Sorry.', 77);
+        }
     }
 
     /**

--- a/tst/PasteDeleteTest.php
+++ b/tst/PasteDeleteTest.php
@@ -1,0 +1,63 @@
+<?php declare(strict_types=1);
+use PHPUnit\Framework\TestCase;
+use PrivateBin\Configuration;
+use PrivateBin\Data\Filesystem;
+use PrivateBin\Exception\TranslatedException;
+use PrivateBin\Model\Paste;
+
+class NonDeletingFilesystem extends Filesystem
+{
+    public function delete($pasteid)
+    {
+    }
+}
+
+class PasteDeleteTest extends TestCase
+{
+    private $_path;
+
+    private $_store;
+
+    public function setUp(): void
+    {
+        $this->_path = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'privatebin_paste_delete';
+        Helper::rmDir($this->_path);
+        $this->_store = new Filesystem(['dir' => $this->_path]);
+        $paste        = Helper::getPaste();
+        $this->_store->create(Helper::getPasteId(), $paste);
+    }
+
+    public function tearDown(): void
+    {
+        $this->_store->delete(Helper::getPasteId());
+        Helper::rmDir($this->_path);
+    }
+
+    public function testSuccessfulDeletion()
+    {
+        $paste = $this->createPaste($this->_store);
+        $paste->delete();
+
+        $this->assertFalse($paste->exists());
+    }
+
+    public function testFailedDeletionIsReported()
+    {
+        $paste = $this->createPaste(new NonDeletingFilesystem(['dir' => $this->_path]));
+
+        try {
+            $paste->delete();
+            $this->fail('failed deletion was reported as successful');
+        } catch (TranslatedException $e) {
+            $this->assertSame(77, $e->getCode());
+        }
+        $this->assertTrue($paste->exists());
+    }
+
+    private function createPaste(Filesystem $store)
+    {
+        $paste = new Paste(new Configuration, $store);
+        $paste->setId(Helper::getPasteId());
+        return $paste;
+    }
+}


### PR DESCRIPTION
## Summary

- verify that a paste no longer exists after requesting backend deletion
- raise a controlled model error when a backend silently leaves the paste present
- prevent successful deletion responses and burn-after-reading delivery after failed deletion
- add model regressions for successful and no-op backend deletion

## Reproduction

The storage deletion contract returns no result, and filesystem or cloud backends may absorb operational failures. `Paste::delete()` previously returned immediately, so the controller reported “Document was properly deleted” even when the object remained readable.

The same model method is used before returning an expired or burn-after-reading paste. In the burn case, a silent delete failure allowed the response to proceed while leaving the supposedly single-read paste stored.

The model now checks `exists()` after deletion and raises translated error code 77 if the paste remains. The regression uses a filesystem test double whose delete method intentionally does nothing; it fails on the previous implementation and now receives the controlled error. A normal deletion case confirms the successful path is unchanged.

## Tests

- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit PasteDeleteTest.php --testdox`
  - 2 tests, 3 assertions passed
- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit --filter '/^(?!.*ServerSaltTest)/'`
  - 268 tests, 6508 assertions passed
- `php -l lib/Model/Paste.php`
- `php -l tst/PasteDeleteTest.php`
- `git diff --check`

The excluded `ServerSaltTest` cases are environment-sensitive under the root-owned local test workspace and are unrelated to this change.

## Security, privacy, and compatibility

Successful deletion behavior is unchanged. A failed deletion now returns an error instead of a false success. No payload data is exposed, and burn-after-reading content is not delivered when its deletion prerequisite cannot be confirmed.

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.