### PR TITLE
Stabilize database configuration values

### DIFF
--- a/lib/Data/Database.php
+++ b/lib/Data/Database.php
@@ -392,12 +392,21 @@ class Database extends AbstractData
         $configKey = strtoupper($namespace);
         $value     = $this->_getConfig($configKey);
         if ($value === '') {
-            // initialize the row, so that setValue can rely on UPDATE queries
-            $this->_exec(
-                'INSERT INTO "' . $this->_sanitizeIdentifier('config') .
-                '" VALUES(?,?)',
-                [$configKey, '']
-            );
+            if (!$this->_configKeyExists($configKey)) {
+                // initialize the row, so that setValue can rely on UPDATE queries
+                try {
+                    $this->_exec(
+                        'INSERT INTO "' . $this->_sanitizeIdentifier('config') .
+                        '" VALUES(?,?)',
+                        [$configKey, '']
+                    );
+                } catch (PDOException $e) {
+                    // another request may have initialized the row concurrently
+                    if (!$this->_configKeyExists($configKey)) {
+                        throw $e;
+                    }
+                }
+            }
 
             // migrate filesystem based salt into database
             $file = 'data' . DIRECTORY_SEPARATOR . 'salt.php';
@@ -562,6 +571,25 @@ class Database extends AbstractData
                 );
         }
         return $sql;
+    }
+
+    /**
+     * checks whether a configuration row exists
+     *
+     * @access private
+     * @param  string $key
+     * @return bool
+     */
+    private function _configKeyExists($key)
+    {
+        try {
+            return (bool) $this->_select(
+                'SELECT "id" FROM "' . $this->_sanitizeIdentifier('config') .
+                '" WHERE "id" = ?', [$key], true
+            );
+        } catch (PDOException $e) {
+            return false;
+        }
     }
 
     /**

--- a/lib/Data/Database.php
+++ b/lib/Data/Database.php
@@ -363,6 +363,7 @@ class Database extends AbstractData
      */
     public function setValue($value, $namespace, $key = '')
     {
+        $configKey = strtoupper($namespace);
         if ($namespace === 'traffic_limiter') {
             $this->_last_cache[$key] = $value;
             try {
@@ -372,10 +373,24 @@ class Database extends AbstractData
                 return false;
             }
         }
+        if (!$this->_configKeyExists($configKey)) {
+            try {
+                return $this->_exec(
+                    'INSERT INTO "' . $this->_sanitizeIdentifier('config') .
+                    '" VALUES(?,?)',
+                    [$configKey, $value]
+                );
+            } catch (PDOException $e) {
+                // another request may have initialized the row concurrently
+                if (!$this->_configKeyExists($configKey)) {
+                    throw $e;
+                }
+            }
+        }
         return $this->_exec(
             'UPDATE "' . $this->_sanitizeIdentifier('config') .
             '" SET "value" = ? WHERE "id" = ?',
-            [$value, strtoupper($namespace)]
+            [$value, $configKey]
         );
     }
 

--- a/tst/Data/DatabaseTest.php
+++ b/tst/Data/DatabaseTest.php
@@ -156,6 +156,12 @@ class DatabaseTest extends TestCase
         $this->assertFalse($this->_model->exists(Helper::getPasteId()), 'paste does still not exist');
     }
 
+    public function testRepeatedEmptyConfigReads()
+    {
+        $this->assertSame('', $this->_model->getValue('purge_limiter'));
+        $this->assertSame('', $this->_model->getValue('purge_limiter'));
+    }
+
     public function testCommentErrorDetection()
     {
         $error_log_setting = ini_get('error_log');

--- a/tst/Data/DatabaseTest.php
+++ b/tst/Data/DatabaseTest.php
@@ -162,6 +162,14 @@ class DatabaseTest extends TestCase
         $this->assertSame('', $this->_model->getValue('purge_limiter'));
     }
 
+    public function testConfigWriteBeforeRead()
+    {
+        $this->assertTrue($this->_model->setValue('123', 'purge_limiter'));
+        $this->assertSame('123', $this->_model->getValue('purge_limiter'));
+        $this->assertTrue($this->_model->setValue('456', 'traffic_limiter', 'client'));
+        $this->assertSame('456', $this->_model->getValue('traffic_limiter', 'client'));
+    }
+
     public function testCommentErrorDetection()
     {
         $error_log_setting = ini_get('error_log');


### PR DESCRIPTION
## Summary

- distinguish an absent database configuration row from an existing empty row
- avoid duplicate primary-key inserts on repeated empty-value reads
- persist `setValue()` calls even when no earlier read initialized the row
- tolerate another request winning either first-row initialization race
- add direct SQLite regressions for repeated reads and write-before-read

## Reproduction

Database configuration rows are initialized lazily so later `setValue()` calls can use `UPDATE`. `_getConfig()` returns an empty string both for a missing row and for an existing row whose value is empty.

On the first `getValue('purge_limiter')`, PrivateBin inserted the expected empty row. The same call a second time interpreted that row as absent and attempted another insert with the same primary key, raising a `PDOException`:

`UNIQUE constraint failed: config.id`

Initialization now checks whether the key already exists before inserting. If two requests race after the check, a rejected insert is accepted only when a recheck proves the row now exists; unrelated database failures continue to propagate.

`setValue()` had the inverse problem. It always issued `UPDATE`, relying on `getValue()` having initialized the row first. When called before any read, PDO reported a successful statement but updated zero rows, and the value was silently lost. Missing rows are now inserted with the requested value; if another request inserts first, the current request updates that row. Regressions cover both a scalar purge-limiter value and keyed traffic-limiter state.

## Tests

- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit Data/DatabaseTest.php --testdox`
  - 21 tests, 100 assertions passed
- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit --filter '/^(?!.*ServerSaltTest)/'`
  - 268 tests, 6511 assertions passed
- `php -l lib/Data/Database.php`
- `php -l tst/Data/DatabaseTest.php`
- `git diff --check`

The excluded `ServerSaltTest` cases are environment-sensitive under the root-owned local test workspace and are unrelated to this change.

## Compatibility and safety

Existing values and successful first-time reads are unchanged. Empty values remain readable instead of crashing, and first-time writes are no longer discarded. The change stores only the values already supplied to the persistence API and preserves filesystem salt migration behavior.

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.