### PR TITLE
Protect converted filesystem records

### DIFF
--- a/lib/Data/Filesystem.php
+++ b/lib/Data/Filesystem.php
@@ -520,6 +520,7 @@ class Filesystem extends AbstractData
             file_put_contents($destFile, self::PROTECTION_LINE . PHP_EOL);
             file_put_contents($destFile, $handle, FILE_APPEND);
             fclose($handle);
+            chmod($destFile, 0640); // protect file from access by other users on the host
         }
         if (!unlink($srcFile)) {
             error_log('Error deleting converted document: ' . $srcFile);

--- a/tst/Data/FilesystemTest.php
+++ b/tst/Data/FilesystemTest.php
@@ -163,16 +163,31 @@ class FilesystemTest extends TestCase
             file_put_contents($storagedir . $dataid . '.' . $commentid . '.' . $dataid, json_encode($comment));
         }
         // check that all 10 pastes were converted after the purge
-        $this->_model->purge(10);
+        $oldUmask = umask(0000);
+        try {
+            $this->_model->purge(10);
+        } finally {
+            umask($oldUmask);
+        }
         foreach ($ids as $dataid => $storagedir) {
             $dataid = (string) $dataid; // undue potential key cast, see https://www.php.net/manual/en/language.types.array.php
             $this->assertFileExists($storagedir . $dataid . '.php', "paste $dataid exists in new format");
+            $this->assertSame(
+                0640,
+                fileperms($storagedir . $dataid . '.php') & 0777,
+                "converted paste $dataid has protected permissions"
+            );
             $this->assertFileDoesNotExist($storagedir . $dataid, "old format paste $dataid got removed");
             $this->assertTrue($this->_model->exists($dataid), "paste $dataid exists");
             $this->assertEquals($this->_model->read($dataid), $paste, "paste $dataid wasn't modified in the conversion");
 
             $storagedir .= $dataid . '.discussion' . DIRECTORY_SEPARATOR;
             $this->assertFileExists($storagedir . $dataid . '.' . $commentid . '.' . $dataid . '.php', "comment of $dataid exists in new format");
+            $this->assertSame(
+                0640,
+                fileperms($storagedir . $dataid . '.' . $commentid . '.' . $dataid . '.php') & 0777,
+                "converted comment of $dataid has protected permissions"
+            );
             $this->assertFileDoesNotExist($storagedir . $dataid . '.' . $commentid . '.' . $dataid, "old format comment of $dataid got removed");
             $this->assertTrue($this->_model->existsComment($dataid, $dataid, $commentid), "comment in paste $dataid exists");
             $comment             = $comment;


### PR DESCRIPTION
## Summary

- apply PrivateBin's `0640` filesystem protection to legacy paste and comment files after conversion
- cover conversion under a permissive process umask

## Problem

Regular filesystem writes explicitly restrict record files to `0640`, but the legacy conversion path created its destination files with permissions derived from the process umask. With a permissive umask, converted encrypted paste and comment records could remain readable by other users on the host.

## Tests

- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit --filter testOldFilesGetConverted Data/FilesystemTest.php`
- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit Data/FilesystemTest.php`
- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit --filter '/^(?!.*ServerSaltTest)/'`

The broad suite passes with 266 tests and 6,525 assertions. `ServerSaltTest` is excluded because its permission-denial scenarios are not meaningful when the test process runs as root.

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.