### PR TITLE
Skip corrupt local comments

### DIFF
--- a/lib/Data/Database.php
+++ b/lib/Data/Database.php
@@ -314,7 +314,10 @@ class Database extends AbstractData
                     $data = Json::decode($row['data']);
                 } catch (JsonException $e) {
                     error_log('Error while reading a comment from the database: ' . $e->getMessage());
-                    $data = [];
+                    continue;
+                }
+                if (!is_array($data)) {
+                    continue;
                 }
                 $i                          = $this->getOpenSlot($comments, (int) $row['postdate']);
                 $comments[$i]               = $data;

--- a/lib/Data/Filesystem.php
+++ b/lib/Data/Filesystem.php
@@ -215,6 +215,13 @@ class Filesystem extends AbstractData
                 // - parentid is the comment this comment replies to (It can be pasteid)
                 if ($file->isFile()) {
                     $comment = $this->_get($file->getPathname());
+                    if (
+                        !is_array($comment) ||
+                        !isset($comment['meta']['created']) ||
+                        !(is_int($comment['meta']['created']) || is_string($comment['meta']['created']))
+                    ) {
+                        continue;
+                    }
                     $items   = explode('.', $file->getBasename('.php'));
                     // Add some meta information not contained in file.
                     $comment['id']       = $items[1];

--- a/tst/Data/DatabaseTest.php
+++ b/tst/Data/DatabaseTest.php
@@ -172,6 +172,39 @@ class DatabaseTest extends TestCase
         $this->assertFalse($this->_model->existsComment(Helper::getPasteId(), Helper::getPasteId(), Helper::getCommentId()), 'comment does still not exist');
     }
 
+    public function testCorruptCommentsAreIgnored()
+    {
+        mkdir($this->_path);
+        $path           = $this->_path . DIRECTORY_SEPARATOR . 'corrupt-comment.sq3';
+        $options        = $this->_options;
+        $options['dsn'] = 'sqlite:' . $path;
+        $model          = new Database($options);
+        $pasteid        = Helper::getPasteId();
+        $commentid      = Helper::getCommentId();
+        $comment        = Helper::getComment();
+        $corruptId      = 'ffffffffffffffff';
+        $scalarId       = 'eeeeeeeeeeeeeeee';
+
+        $this->assertTrue($model->createComment($pasteid, $pasteid, $commentid, $comment));
+        $this->assertTrue($model->createComment($pasteid, $pasteid, $corruptId, $comment));
+        $this->assertTrue($model->createComment($pasteid, $pasteid, $scalarId, $comment));
+
+        $database  = new PDO($options['dsn'], $options['usr'], $options['pwd'], $options['opt']);
+        $statement = $database->prepare('UPDATE "comment" SET "data" = ? WHERE "dataid" = ?');
+        $statement->execute(['{', $corruptId]);
+        $statement->execute(['true', $scalarId]);
+
+        $error_log_setting = ini_get('error_log');
+        ini_set('error_log', '/dev/null');
+        try {
+            $comments = $model->readComments($pasteid);
+        } finally {
+            ini_set('error_log', $error_log_setting);
+        }
+        $this->assertCount(1, $comments);
+        $this->assertSame($commentid, current($comments)['id']);
+    }
+
     public function testGetIbmInstance()
     {
         $this->expectException(PDOException::class);

--- a/tst/Data/FilesystemTest.php
+++ b/tst/Data/FilesystemTest.php
@@ -138,6 +138,36 @@ class FilesystemTest extends TestCase
         $this->assertFalse($this->_model->existsComment(Helper::getPasteId(), Helper::getPasteId(), Helper::getCommentId()), 'comment does still not exist');
     }
 
+    public function testCorruptCommentsAreIgnored()
+    {
+        $pasteid   = Helper::getPasteId();
+        $commentid = Helper::getCommentId();
+        $comment   = Helper::getComment();
+        $this->assertTrue($this->_model->createComment($pasteid, $pasteid, $commentid, $comment));
+
+        $discussion = $this->_path . DIRECTORY_SEPARATOR . substr($pasteid, 0, 2) .
+            DIRECTORY_SEPARATOR . substr($pasteid, 2, 2) . DIRECTORY_SEPARATOR .
+            $pasteid . '.discussion' . DIRECTORY_SEPARATOR;
+        file_put_contents(
+            $discussion . $pasteid . '.ffffffffffffffff.' . $pasteid . '.php',
+            Filesystem::PROTECTION_LINE . PHP_EOL . '{'
+        );
+        file_put_contents(
+            $discussion . $pasteid . '.eeeeeeeeeeeeeeee.' . $pasteid . '.php',
+            Filesystem::PROTECTION_LINE . PHP_EOL . 'true'
+        );
+
+        $error_log_setting = ini_get('error_log');
+        ini_set('error_log', '/dev/null');
+        try {
+            $comments = $this->_model->readComments($pasteid);
+        } finally {
+            ini_set('error_log', $error_log_setting);
+        }
+        $this->assertCount(1, $comments);
+        $this->assertSame($commentid, current($comments)['id']);
+    }
+
     public function testOldFilesGetConverted()
     {
         // generate 10 (default purge batch size) pastes in the old format


### PR DESCRIPTION
## Summary

- skip undecodable and non-array comments in the database backend
- skip filesystem comments without usable creation metadata
- keep returning valid comments when neighboring stored records are corrupt

## Reproduction

The filesystem decoder returns `false` for malformed JSON. `readComments()` then indexed that value as a comment and attempted to read `meta.created`, producing a PHP error that aborted the discussion response.

The database backend caught JSON decoding failures but replaced the body with an empty array, then added IDs and metadata and returned it as an apparently valid comment. Valid scalar JSON such as `true` similarly flowed into array operations or malformed responses.

The regressions place valid, truncated, and scalar-JSON comments in each backend and verify that only the valid comment is returned.

## Tests

- focused corrupt-comment regressions for `FilesystemTest` and `DatabaseTest`
- complete `FilesystemTest`: 8 tests, 160 assertions
- complete `DatabaseTest`: 20 tests, 98 assertions
- broad PHP suite excluding environment-sensitive `ServerSaltTest`: 268 tests, 6,513 assertions
- PHP syntax checks for all four changed files
- `git diff --check`

`ServerSaltTest` is excluded because its permission-denial scenarios are not meaningful when PHPUnit runs as root.

## Compatibility and privacy

Valid comments retain their current response shape and ordering. Only records that cannot represent a usable comment are omitted. Error logs include decoder diagnostics but never log encrypted comment bodies.

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.