### PR TITLE
Preserve pastes when discussion deletion fails

### DIFF
--- a/lib/Data/Filesystem.php
+++ b/lib/Data/Filesystem.php
@@ -121,26 +121,38 @@ class Filesystem extends AbstractData
     {
         $pastedir = $this->_dataid2path($pasteid);
         if (is_dir($pastedir)) {
-            // Delete the paste itself.
+            // Delete discussion if it exists.
+            $discdir = $this->_dataid2discussionpath($pasteid);
+            if (is_dir($discdir)) {
+                $commentfiles = [];
+                foreach (new DirectoryIterator($discdir) as $file) {
+                    if ($file->isDot()) {
+                        continue;
+                    }
+                    if (!$file->isFile() && !$file->isLink()) {
+                        error_log('Error deleting discussion, unexpected entry: ' . $file->getPathname());
+                        return;
+                    }
+                    $commentfiles[] = $file->getPathname();
+                }
+                foreach ($commentfiles as $commentfile) {
+                    if (!@unlink($commentfile) && file_exists($commentfile)) {
+                        error_log('Error deleting comment: ' . $commentfile);
+                        return;
+                    }
+                }
+                if (!@rmdir($discdir) && is_dir($discdir)) {
+                    error_log('Error deleting discussion: ' . $discdir);
+                    return;
+                }
+            }
+
+            // Delete the paste only after its discussion has been removed.
             $pastefile = $pastedir . $pasteid . '.php';
             if (is_file($pastefile)) {
                 if (!unlink($pastefile)) {
                     error_log('Error deleting paste: ' . $pastefile);
                 }
-            }
-
-            // Delete discussion if it exists.
-            $discdir = $this->_dataid2discussionpath($pasteid);
-            if (is_dir($discdir)) {
-                // Delete all files in discussion directory
-                foreach (new DirectoryIterator($discdir) as $file) {
-                    if ($file->isFile()) {
-                        if (!unlink($file->getPathname())) {
-                            error_log('Error deleting comment: ' . $file->getPathname());
-                        }
-                    }
-                }
-                rmdir($discdir);
             }
         }
     }

--- a/tst/Data/FilesystemTest.php
+++ b/tst/Data/FilesystemTest.php
@@ -75,6 +75,36 @@ class FilesystemTest extends TestCase
         $this->assertEquals($original, $this->_model->read(Helper::getPasteId()));
     }
 
+    public function testPasteIsPreservedWhenDiscussionCannotBeDeleted()
+    {
+        $pasteid   = Helper::getPasteId();
+        $commentid = Helper::getCommentId();
+        $paste     = Helper::getPaste();
+        $comment   = Helper::getComment();
+        $this->assertTrue($this->_model->create($pasteid, $paste));
+        $this->assertTrue($this->_model->createComment($pasteid, $pasteid, $commentid, $comment));
+
+        $discussion = $this->_path . DIRECTORY_SEPARATOR . substr($pasteid, 0, 2) .
+            DIRECTORY_SEPARATOR . substr($pasteid, 2, 2) . DIRECTORY_SEPARATOR .
+            $pasteid . '.discussion' . DIRECTORY_SEPARATOR;
+        mkdir($discussion . 'unexpected');
+
+        $error_log_setting = ini_get('error_log');
+        ini_set('error_log', '/dev/null');
+        set_error_handler(function () {
+            return true;
+        });
+        try {
+            $this->_model->delete($pasteid);
+        } finally {
+            restore_error_handler();
+            ini_set('error_log', $error_log_setting);
+        }
+
+        $this->assertTrue($this->_model->exists($pasteid));
+        $this->assertTrue($this->_model->existsComment($pasteid, $pasteid, $commentid));
+    }
+
     /**
      * pastes a-g are expired and should get deleted, x never expires and y-z expire in an hour
      */


### PR DESCRIPTION
## Summary

- inspect a filesystem discussion before deleting any of its records
- remove discussion files and verify the directory is gone before deleting the paste
- preserve the paste and valid comments when an unexpected discussion entry prevents cleanup

## Reproduction

`Filesystem::delete()` removed the paste file first, then attempted to remove its discussion. If the discussion contained an unexpected directory or a comment could not be removed, cleanup failed after the paste was already gone. Higher layers could only verify that the paste no longer existed, so they reported successful deletion while encrypted discussion data remained orphaned on disk.

The regression creates a normal paste and comment plus an unexpected nested discussion entry. Before the fix, deletion removes the paste and valid comment, then fails to remove the discussion directory. After the fix, preflight detects the unsupported entry and preserves both records, leaving the paste visible so the model-level deletion verification can return an error.

## Tests

- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit --filter testPasteIsPreservedWhenDiscussionCannotBeDeleted Data/FilesystemTest.php`
  - 1 test, 4 assertions passed
- complete `FilesystemTest`
  - 8 tests, 161 assertions passed
- broad PHP suite excluding environment-sensitive `ServerSaltTest`
  - 267 tests, 6,509 assertions passed
- PHP syntax checks for both changed files
- `git diff --check`

## Privacy and compatibility

Normal paste and discussion deletion is unchanged. On incomplete discussion cleanup, PrivateBin now favors preserving an addressable paste over silently orphaning encrypted comments. No ciphertext or metadata is logged; diagnostics contain only filesystem paths already available to the server operator.

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.