### PR TITLE
Preserve database pastes when comment deletion fails

### DIFF
--- a/lib/Data/Database.php
+++ b/lib/Data/Database.php
@@ -222,12 +222,12 @@ class Database extends AbstractData
     public function delete($pasteid)
     {
         $this->_exec(
-            'DELETE FROM "' . $this->_sanitizeIdentifier('paste') .
-            '" WHERE "dataid" = ?', [$pasteid]
-        );
-        $this->_exec(
             'DELETE FROM "' . $this->_sanitizeIdentifier('comment') .
             '" WHERE "pasteid" = ?', [$pasteid]
+        );
+        $this->_exec(
+            'DELETE FROM "' . $this->_sanitizeIdentifier('paste') .
+            '" WHERE "dataid" = ?', [$pasteid]
         );
     }
 

--- a/tst/Data/DatabaseTest.php
+++ b/tst/Data/DatabaseTest.php
@@ -109,6 +109,38 @@ class DatabaseTest extends TestCase
         $this->assertEquals($original, $this->_model->read(Helper::getPasteId()));
     }
 
+    public function testPasteIsPreservedWhenCommentDeletionFails()
+    {
+        mkdir($this->_path);
+        $path           = $this->_path . DIRECTORY_SEPARATOR . 'delete-comment.sq3';
+        $options        = $this->_options;
+        $options['dsn'] = 'sqlite:' . $path;
+        $model          = new Database($options);
+        $pasteid        = Helper::getPasteId();
+        $commentid      = Helper::getCommentId();
+        $paste          = Helper::getPaste();
+        $comment        = Helper::getComment();
+        $this->assertTrue($model->create($pasteid, $paste));
+        $this->assertTrue($model->createComment($pasteid, $pasteid, $commentid, $comment));
+
+        $database = new PDO($options['dsn'], $options['usr'], $options['pwd'], $options['opt']);
+        $database->exec(
+            'CREATE TRIGGER keep_comment BEFORE DELETE ON comment ' .
+            'BEGIN SELECT RAISE(ABORT, "deletion blocked"); END'
+        );
+
+        $failed = false;
+        try {
+            $model->delete($pasteid);
+        } catch (PDOException $e) {
+            $failed = true;
+        }
+
+        $this->assertTrue($failed, 'comment deletion failure was reported');
+        $this->assertTrue($model->exists($pasteid));
+        $this->assertTrue($model->existsComment($pasteid, $pasteid, $commentid));
+    }
+
     /**
      * pastes a-g are expired and should get deleted, x never expires and y-z expire in an hour
      */


### PR DESCRIPTION
## Summary

- delete database comments before deleting their parent paste
- preserve both paste and comments when comment cleanup fails
- add a SQLite trigger regression for the failure ordering

## Reproduction

`Database::delete()` deleted the paste row first and its comments second. If the comment deletion failed, the exception reached the caller only after the paste had disappeared, leaving orphaned encrypted comments that could no longer be addressed through the paste.

The regression creates a paste and comment, installs a SQLite trigger that aborts comment deletion, and invokes the real database backend. Before the fix, the exception is reported but the paste is already gone. After reordering the statements, the failed prerequisite leaves both records intact, allowing the caller to report failure without orphaning discussion data.

## Tests

- focused deletion-order regression
  - 1 test, 5 assertions passed
- complete `DatabaseTest`
  - 20 tests, 99 assertions passed
- broad PHP suite excluding environment-sensitive `ServerSaltTest`
  - 267 tests, 6,510 assertions passed
- PHP syntax checks for both changed files
- `git diff --check`

## Privacy and compatibility

Successful deletion still removes comments and the paste. On a comment-deletion failure, the paste remains addressable and no additional discussion data is lost. No payload data is logged or exposed.

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.