### PR TITLE
Propagate S3 storage errors

### DIFF
--- a/lib/Data/S3Storage.php
+++ b/lib/Data/S3Storage.php
@@ -228,30 +228,18 @@ class S3Storage extends AbstractData
     {
         $name = $this->_getKey($pasteid);
 
-        try {
-            $comments = $this->_listAllObjects($name . '/discussion/');
-            foreach ($comments as $comment) {
-                try {
-                    $this->_client->deleteObject([
-                        'Bucket' => $this->_bucket,
-                        'Key'    => $comment['Key'],
-                    ]);
-                } catch (S3Exception $e) {
-                    // ignore if already deleted.
-                }
-            }
-        } catch (S3Exception $e) {
-            // there are no discussions associated with the paste
-        }
-
-        try {
+        $comments = $this->_listAllObjects($name . '/discussion/');
+        foreach ($comments as $comment) {
             $this->_client->deleteObject([
                 'Bucket' => $this->_bucket,
-                'Key'    => $name,
+                'Key'    => $comment['Key'],
             ]);
-        } catch (S3Exception $e) {
-            // ignore if already deleted
         }
+
+        $this->_client->deleteObject([
+            'Bucket' => $this->_bucket,
+            'Key'    => $name,
+        ]);
     }
 
     /**

--- a/lib/Data/S3Storage.php
+++ b/lib/Data/S3Storage.php
@@ -398,7 +398,10 @@ class S3Storage extends AbstractData
             ]);
             return $object['Body']->getContents();
         } catch (S3Exception $e) {
-            return '';
+            if ($e->getAwsErrorCode() === 'NoSuchKey') {
+                return '';
+            }
+            throw $e;
         }
     }
 

--- a/lib/Data/S3Storage.php
+++ b/lib/Data/S3Storage.php
@@ -155,6 +155,17 @@ class S3Storage extends AbstractData
     }
 
     /**
+     * tests whether an S3 exception represents a missing object
+     *
+     * @param  S3Exception $exception
+     * @return bool
+     */
+    private function _isMissingObject(S3Exception $exception)
+    {
+        return in_array($exception->getAwsErrorCode(), ['NoSuchKey', 'NotFound'], true);
+    }
+
+    /**
      * Uploads the payload in the $this->_bucket under the specified key.
      * The entire payload is stored as a JSON document. The metadata is replicated
      * as the S3 object's metadata except for the field salt.
@@ -213,8 +224,10 @@ class S3Storage extends AbstractData
             $data = $object['Body']->getContents();
             return Json::decode($data);
         } catch (S3Exception $e) {
-            error_log('failed to read ' . $pasteid . ' from ' . $this->_bucket . ', ' .
-                trim(preg_replace('/\s\s+/', ' ', $e->getMessage())));
+            if ($this->_isMissingObject($e)) {
+                return false;
+            }
+            throw $e;
         } catch (JsonException $e) {
             error_log('failed to JSON decode ' . $pasteid . ', ' . $e->getMessage());
         }
@@ -269,23 +282,26 @@ class S3Storage extends AbstractData
     {
         $comments = [];
         $prefix   = $this->_getKey($pasteid) . '/discussion/';
-        try {
-            $entries = $this->_listAllObjects($prefix);
-            foreach ($entries as $entry) {
+        $entries  = $this->_listAllObjects($prefix);
+        foreach ($entries as $entry) {
+            try {
                 $object = $this->_client->getObject([
                     'Bucket' => $this->_bucket,
                     'Key'    => $entry['Key'],
                 ]);
-                $data             = $object['Body']->getContents();
-                $body             = JSON::decode($data);
-                $items            = explode('/', $entry['Key']);
-                $body['id']       = $items[3];
-                $body['parentid'] = $items[2];
-                $slot             = $this->getOpenSlot($comments, (int) $object['Metadata']['created']);
-                $comments[$slot]  = $body;
+            } catch (S3Exception $e) {
+                if ($this->_isMissingObject($e)) {
+                    continue;
+                }
+                throw $e;
             }
-        } catch (S3Exception $e) {
-            // no comments found
+            $data             = $object['Body']->getContents();
+            $body             = JSON::decode($data);
+            $items            = explode('/', $entry['Key']);
+            $body['id']       = $items[3];
+            $body['parentid'] = $items[2];
+            $slot             = $this->getOpenSlot($comments, (int) $object['Metadata']['created']);
+            $comments[$slot]  = $body;
         }
         return $comments;
     }
@@ -310,30 +326,29 @@ class S3Storage extends AbstractData
         }
         $path .= 'config/' . $namespace;
 
-        try {
-            foreach ($this->_listAllObjects($path) as $object) {
-                $name = $object['Key'];
-                if (strlen($name) > strlen($path) && substr($name, strlen($path), 1) !== '/') {
-                    continue;
-                }
+        foreach ($this->_listAllObjects($path) as $object) {
+            $name = $object['Key'];
+            if (strlen($name) > strlen($path) && substr($name, strlen($path), 1) !== '/') {
+                continue;
+            }
+            try {
                 $head = $this->_client->headObject([
                     'Bucket' => $this->_bucket,
                     'Key'    => $name,
                 ]);
-                $value = $head->get('Metadata')['value'] ?? '';
-                if (is_numeric($value) && intval($value) < $time) {
-                    try {
-                        $this->_client->deleteObject([
-                            'Bucket' => $this->_bucket,
-                            'Key'    => $name,
-                        ]);
-                    } catch (S3Exception $e) {
-                        // deleted by another instance.
-                    }
+            } catch (S3Exception $e) {
+                if ($this->_isMissingObject($e)) {
+                    continue;
                 }
+                throw $e;
             }
-        } catch (S3Exception $e) {
-            // no objects in the bucket yet
+            $value = $head->get('Metadata')['value'] ?? '';
+            if (is_numeric($value) && intval($value) < $time) {
+                $this->_client->deleteObject([
+                    'Bucket' => $this->_bucket,
+                    'Key'    => $name,
+                ]);
+            }
         }
     }
 
@@ -398,7 +413,7 @@ class S3Storage extends AbstractData
             ]);
             return $object['Body']->getContents();
         } catch (S3Exception $e) {
-            if ($e->getAwsErrorCode() === 'NoSuchKey') {
+            if ($this->_isMissingObject($e)) {
                 return '';
             }
             throw $e;
@@ -417,23 +432,26 @@ class S3Storage extends AbstractData
             $prefix .= '/';
         }
 
-        try {
-            foreach ($this->_listAllObjects($prefix) as $object) {
+        foreach ($this->_listAllObjects($prefix) as $object) {
+            try {
                 $head = $this->_client->headObject([
                     'Bucket' => $this->_bucket,
                     'Key'    => $object['Key'],
                 ]);
-                $expire_at = $head->get('Metadata')['expire_date'] ?? '';
-                if (is_numeric($expire_at) && intval($expire_at) < $now) {
-                    array_push($expired, $object['Key']);
+            } catch (S3Exception $e) {
+                if ($this->_isMissingObject($e)) {
+                    continue;
                 }
-
-                if (count($expired) > $batchsize) {
-                    break;
-                }
+                throw $e;
             }
-        } catch (S3Exception $e) {
-            // no objects in the bucket yet
+            $expire_at = $head->get('Metadata')['expire_date'] ?? '';
+            if (is_numeric($expire_at) && intval($expire_at) < $now) {
+                array_push($expired, $object['Key']);
+            }
+
+            if (count($expired) > $batchsize) {
+                break;
+            }
         }
         return $expired;
     }
@@ -449,15 +467,11 @@ class S3Storage extends AbstractData
             $prefix .= '/';
         }
 
-        try {
-            foreach ($this->_listAllObjects($prefix) as $object) {
-                $candidate = substr($object['Key'], strlen($prefix));
-                if (!str_contains($candidate, '/')) {
-                    $pastes[] = $candidate;
-                }
+        foreach ($this->_listAllObjects($prefix) as $object) {
+            $candidate = substr($object['Key'], strlen($prefix));
+            if (!str_contains($candidate, '/')) {
+                $pastes[] = $candidate;
             }
-        } catch (S3Exception $e) {
-            // no objects in the bucket yet
         }
         return $pastes;
     }

--- a/tst/Data/S3DeleteTest.php
+++ b/tst/Data/S3DeleteTest.php
@@ -4,6 +4,19 @@ namespace Aws\S3\Exception {
     if (!class_exists(S3Exception::class)) {
         class S3Exception extends \Exception
         {
+            const TEST_STUB = true;
+
+            private $_awsErrorCode;
+
+            public function __construct($awsErrorCode = null)
+            {
+                $this->_awsErrorCode = $awsErrorCode;
+            }
+
+            public function getAwsErrorCode()
+            {
+                return $this->_awsErrorCode;
+            }
         }
     }
 }
@@ -48,6 +61,21 @@ namespace {
         }
     }
 
+    class S3ValueClientStub
+    {
+        private $_exception;
+
+        public function __construct(S3Exception $exception)
+        {
+            $this->_exception = $exception;
+        }
+
+        public function getObject($options)
+        {
+            throw $this->_exception;
+        }
+    }
+
     class S3DeleteTest extends TestCase
     {
         public function testCommentDeletionErrorsStopPasteDeletion()
@@ -82,6 +110,44 @@ namespace {
             }
 
             $this->assertTrue($failed);
+        }
+
+        public function testValueReadErrorsArePropagated()
+        {
+            $storage = $this->getStorage(
+                new S3ValueClientStub($this->getS3Exception('AccessDenied'))
+            );
+
+            $failed = false;
+            try {
+                $storage->getValue('salt');
+            } catch (S3Exception $e) {
+                $failed = true;
+            }
+
+            $this->assertTrue($failed);
+        }
+
+        public function testMissingValuesRemainEmpty()
+        {
+            $storage = $this->getStorage(
+                new S3ValueClientStub($this->getS3Exception('NoSuchKey'))
+            );
+
+            $this->assertSame('', $storage->getValue('salt'));
+        }
+
+        private function getS3Exception($awsErrorCode)
+        {
+            if (defined(S3Exception::class . '::TEST_STUB')) {
+                return new S3Exception($awsErrorCode);
+            }
+            $exception = $this->getMockBuilder(S3Exception::class)
+                ->disableOriginalConstructor()
+                ->onlyMethods(['getAwsErrorCode'])
+                ->getMock();
+            $exception->method('getAwsErrorCode')->willReturn($awsErrorCode);
+            return $exception;
         }
 
         private function getStorage($client)

--- a/tst/Data/S3DeleteTest.php
+++ b/tst/Data/S3DeleteTest.php
@@ -76,6 +76,47 @@ namespace {
         }
     }
 
+    class S3ListClientStub
+    {
+        private $_exception;
+
+        public function __construct(S3Exception $exception)
+        {
+            $this->_exception = $exception;
+        }
+
+        public function listObjects($options)
+        {
+            throw $this->_exception;
+        }
+    }
+
+    class S3CommentReadClientStub
+    {
+        private $_exception;
+
+        public function __construct(S3Exception $exception)
+        {
+            $this->_exception = $exception;
+        }
+
+        public function listObjects($options)
+        {
+            return [
+                'Contents'    => [[
+                    'Key' => Helper::getPasteId() . '/discussion/' .
+                        Helper::getPasteId() . '/' . Helper::getCommentId(),
+                ]],
+                'IsTruncated' => false,
+            ];
+        }
+
+        public function getObject($options)
+        {
+            throw $this->_exception;
+        }
+    }
+
     class S3DeleteTest extends TestCase
     {
         public function testCommentDeletionErrorsStopPasteDeletion()
@@ -135,6 +176,86 @@ namespace {
             );
 
             $this->assertSame('', $storage->getValue('salt'));
+        }
+
+        public function testPasteReadErrorsArePropagated()
+        {
+            $storage = $this->getStorage(
+                new S3ValueClientStub($this->getS3Exception('AccessDenied'))
+            );
+
+            $failed = false;
+            try {
+                $storage->read(Helper::getPasteId());
+            } catch (S3Exception $e) {
+                $failed = true;
+            }
+
+            $this->assertTrue($failed);
+        }
+
+        public function testMissingPastesRemainMissing()
+        {
+            $storage = $this->getStorage(
+                new S3ValueClientStub($this->getS3Exception('NoSuchKey'))
+            );
+
+            $this->assertFalse($storage->read(Helper::getPasteId()));
+        }
+
+        public function testListErrorsArePropagated()
+        {
+            $storage = $this->getStorage(
+                new S3ListClientStub($this->getS3Exception('AccessDenied'))
+            );
+
+            foreach ([
+                function () use ($storage) {
+                    $storage->getAllPastes();
+                },
+                function () use ($storage) {
+                    $storage->readComments(Helper::getPasteId());
+                },
+                function () use ($storage) {
+                    $storage->purgeValues('traffic_limiter', time());
+                },
+                function () use ($storage) {
+                    $storage->purge(1);
+                },
+            ] as $operation) {
+                $failed = false;
+                try {
+                    $operation();
+                } catch (S3Exception $e) {
+                    $failed = true;
+                }
+                $this->assertTrue($failed);
+            }
+        }
+
+        public function testCommentReadErrorsArePropagated()
+        {
+            $storage = $this->getStorage(
+                new S3CommentReadClientStub($this->getS3Exception('AccessDenied'))
+            );
+
+            $failed = false;
+            try {
+                $storage->readComments(Helper::getPasteId());
+            } catch (S3Exception $e) {
+                $failed = true;
+            }
+
+            $this->assertTrue($failed);
+        }
+
+        public function testCommentsDeletedDuringReadAreIgnored()
+        {
+            $storage = $this->getStorage(
+                new S3CommentReadClientStub($this->getS3Exception('NoSuchKey'))
+            );
+
+            $this->assertSame([], $storage->readComments(Helper::getPasteId()));
         }
 
         private function getS3Exception($awsErrorCode)

--- a/tst/Data/S3DeleteTest.php
+++ b/tst/Data/S3DeleteTest.php
@@ -1,0 +1,105 @@
+<?php declare(strict_types=1);
+
+namespace Aws\S3\Exception {
+    if (!class_exists(S3Exception::class)) {
+        class S3Exception extends \Exception
+        {
+        }
+    }
+}
+
+namespace {
+    use Aws\S3\Exception\S3Exception;
+    use PHPUnit\Framework\TestCase;
+    use PrivateBin\Data\S3Storage;
+
+    class S3DeleteClientStub
+    {
+        public $deleted = [];
+
+        private $_comment;
+
+        private $_failKey;
+
+        public function __construct($pasteid, $failKey, $includeComment)
+        {
+            $this->_comment = $pasteid . '/discussion/' . $pasteid . '/' . Helper::getCommentId();
+            $this->_failKey = $failKey;
+            if (!$includeComment) {
+                $this->_comment = null;
+            }
+        }
+
+        public function listObjects($options)
+        {
+            return [
+                'Contents'    => $this->_comment === null ? [] : [['Key' => $this->_comment]],
+                'IsTruncated' => false,
+            ];
+        }
+
+        public function deleteObject($options)
+        {
+            if ($options['Key'] === $this->_failKey) {
+                $reflection = new \ReflectionClass(S3Exception::class);
+                throw $reflection->newInstanceWithoutConstructor();
+            }
+            $this->deleted[] = $options['Key'];
+        }
+    }
+
+    class S3DeleteTest extends TestCase
+    {
+        public function testCommentDeletionErrorsStopPasteDeletion()
+        {
+            $pasteid = Helper::getPasteId();
+            $comment = $pasteid . '/discussion/' . $pasteid . '/' . Helper::getCommentId();
+            $client  = new S3DeleteClientStub($pasteid, $comment, true);
+            $storage = $this->getStorage($client);
+
+            $failed = false;
+            try {
+                $storage->delete($pasteid);
+            } catch (S3Exception $e) {
+                $failed = true;
+            }
+
+            $this->assertTrue($failed);
+            $this->assertNotContains($pasteid, $client->deleted);
+        }
+
+        public function testPasteDeletionErrorsArePropagated()
+        {
+            $pasteid = Helper::getPasteId();
+            $client  = new S3DeleteClientStub($pasteid, $pasteid, false);
+            $storage = $this->getStorage($client);
+
+            $failed = false;
+            try {
+                $storage->delete($pasteid);
+            } catch (S3Exception $e) {
+                $failed = true;
+            }
+
+            $this->assertTrue($failed);
+        }
+
+        private function getStorage($client)
+        {
+            $reflection = new \ReflectionClass(S3Storage::class);
+            $storage    = $reflection->newInstanceWithoutConstructor();
+
+            foreach ([
+                '_bucket' => 'bucket',
+                '_client' => $client,
+                '_prefix' => '',
+            ] as $property => $value) {
+                $property = $reflection->getProperty($property);
+                $property->setAccessible(true);
+                $property->setValue($storage, $value);
+            }
+
+            return $storage;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- stop treating every S3 deletion/listing exception as an already-missing object
- stop paste deletion when discussion cleanup fails
- propagate paste deletion failures to model and administration callers
- distinguish a missing S3 value from access, connectivity, and service failures
- propagate operational paste-read, comment-read, enumeration, and purge failures
- continue ignoring only objects that disappear concurrently with a read or metadata scan
- add lightweight tests that work with or without the optional AWS SDK installed

## Reproduction

`S3Storage::delete()` caught all `S3Exception` instances around discussion listing, each comment deletion, and paste deletion. Access-denied responses, connectivity failures, and service outages were therefore silently treated as successful absence. A failed comment deletion was followed by deletion of the paste, potentially orphaning encrypted comments; a failed paste deletion returned normally and could be reported as success.

S3 object deletion is idempotent for a missing key, and listing an empty prefix returns an empty object list. Genuine SDK exceptions do not need to be converted into “already deleted.” The regressions inject failures for a comment key and the paste key. They verify that both exceptions propagate and that a comment failure prevents the paste delete request.

`getValue()` had the same broad exception handling and returned an empty value for every S3 failure. For the server salt, an access or service outage could therefore be mistaken for an uninitialized installation, generating a transient salt and invalid deletion tokens or unstable user icons. Value reads now return empty only for the SDK’s explicit `NoSuchKey` error; operational errors propagate. Regressions cover both `AccessDenied` and `NoSuchKey`.

Paste reads and list-based methods also collapsed all S3 failures into missing or empty results. During an outage this could hide a paste, omit all comments from a migration, report an empty administration listing, or report a successful no-op purge. Empty prefixes already produce empty SDK listings, so these broad catches were removed. Per-object races still skip explicit `NoSuchKey`/`NotFound` errors, while access and service failures stop the operation.

## Tests

- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit Data/S3DeleteTest.php`
  - 9 tests, 13 assertions passed
- broad PHP suite excluding environment-sensitive `ServerSaltTest`
  - 275 tests, 6,518 assertions passed
- PHP syntax checks for both changed files
- `git diff --check`

## Privacy and compatibility

Successful and already-missing S3 deletions remain idempotent, and missing pastes or persisted values retain their existing false/empty defaults. Operational S3 failures now reach existing caller error paths instead of producing false success, incomplete migrations, orphaned comments, or transient security state. No bucket payloads, credentials, or encrypted data are logged by this change.

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.