### PR TITLE
Reject oversized ciphertext before format validation

### DIFF
--- a/lib/Controller.php
+++ b/lib/Controller.php
@@ -284,19 +284,19 @@ class Controller
             !empty($data['pasteid']) &&
             array_key_exists('parentid', $data) &&
             !empty($data['parentid']);
-        if (!FormatV2::isValid($data, $isComment)) {
-            $this->_json_error(I18n::_('Invalid data.'));
-            return;
-        }
         $sizelimit = $this->_conf->getKey('sizelimit');
         // Ensure content is not too big.
-        if (strlen($data['ct']) > $sizelimit) {
+        if (is_string($data['ct']) && strlen($data['ct']) > $sizelimit) {
             $this->_json_error(
                 I18n::_(
                     'Document is limited to %s of encrypted data.',
                     Filter::formatHumanReadableSize($sizelimit)
                 )
             );
+            return;
+        }
+        if (!FormatV2::isValid($data, $isComment)) {
+            $this->_json_error(I18n::_('Invalid data.'));
             return;
         }
 

--- a/tst/ControllerTest.php
+++ b/tst/ControllerTest.php
@@ -254,6 +254,32 @@ class ControllerTest extends TestCase
     /**
      * @runInSeparateProcess
      */
+    public function testCreateRejectsCompressibleOversizeBeforeFormatValidation()
+    {
+        $options                      = parse_ini_file(CONF, true);
+        $options['main']['sizelimit'] = 10;
+        $options['traffic']['limit']  = 0;
+        Helper::createIniFile(CONF, $options);
+        $paste       = Helper::getPastePost();
+        $paste['ct'] = str_repeat('A', 1000);
+        $file        = Helper::createTempFile();
+        file_put_contents($file, json_encode($paste));
+        Request::setInputStream($file);
+        $_SERVER['HTTP_X_REQUESTED_WITH'] = 'JSONHttpRequest';
+        $_SERVER['REQUEST_METHOD']        = 'POST';
+        $_SERVER['REMOTE_ADDR']           = '::1';
+        ob_start();
+        new Controller;
+        $content = ob_get_contents();
+        ob_end_clean();
+        $response = json_decode($content, true);
+        $this->assertEquals(1, $response['status'], 'outputs error status');
+        $this->assertStringContainsString('Document is limited to', $response['message']);
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
     public function testCreateProxyHeader()
     {
         $options                      = parse_ini_file(CONF, true);


### PR DESCRIPTION
## Summary

- enforce the configured ciphertext size limit before Format V2 validation
- avoid base64 decoding and compression/entropy analysis for already-oversized strings
- retain normal format validation for malformed non-string ciphertext fields

## Reproduction

`Controller::_create()` called `FormatV2::isValid()` before checking `sizelimit`. That validator base64-decodes ciphertext and compresses the decoded bytes for its entropy check. An oversized request therefore consumed memory and CPU in the expensive validation path before PrivateBin rejected it.

A highly compressible oversized ciphertext also failed the entropy check first and returned “Invalid data.” instead of the configured “Document is limited…” response. The regression submits 1,000 base64 characters against a 10-byte configured limit and reproduces that ordering.

The controller now checks string ciphertext length first. Non-string fields bypass `strlen()` and continue to Format V2 validation, preserving the controlled invalid-data behavior without a type error.

## Tests

- focused normal and compressible oversize cases
  - 2 tests, 4 assertions passed
- complete `ControllerTest`
  - 37 tests, 106 assertions passed
- broad PHP suite excluding environment-sensitive `ServerSaltTest`
  - 269 tests, 6,511 assertions passed
- PHP syntax checks for both changed files
- `git diff --check`

## Security and compatibility

Valid in-limit requests and existing size-limit configuration are unchanged. Oversized strings are rejected earlier, reducing avoidable CPU and memory work from untrusted request bodies. Error responses contain no submitted ciphertext.

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.