### PR TITLE
Respect exact limiter intervals

### DIFF
--- a/lib/Data/GoogleCloudStorage.php
+++ b/lib/Data/GoogleCloudStorage.php
@@ -259,7 +259,7 @@ class GoogleCloudStorage extends AbstractData
                     continue;
                 }
                 $value = $object->info()['metadata']['value'] ?? '';
-                if (is_numeric($value) && intval($value) < $time) {
+                if (is_numeric($value) && intval($value) <= $time) {
                     try {
                         $object->delete();
                     } catch (NotFoundException $e) {

--- a/lib/Data/S3Storage.php
+++ b/lib/Data/S3Storage.php
@@ -333,7 +333,7 @@ class S3Storage extends AbstractData
                     'Key'    => $name,
                 ]);
                 $value = $head->get('Metadata')['value'] ?? '';
-                if (is_numeric($value) && intval($value) < $time) {
+                if (is_numeric($value) && intval($value) <= $time) {
                     try {
                         $this->_client->deleteObject([
                             'Bucket' => $this->_bucket,

--- a/lib/Persistence/PurgeLimiter.php
+++ b/lib/Persistence/PurgeLimiter.php
@@ -69,7 +69,7 @@ class PurgeLimiter extends AbstractPersistence
 
         $now  = time();
         $pl   = (int) self::$_store->getValue('purge_limiter');
-        if ($pl + self::$_limit >= $now) {
+        if ($pl + self::$_limit > $now) {
             return false;
         }
         $hasStored = self::$_store->setValue((string) $now, 'purge_limiter');

--- a/lib/Persistence/TrafficLimiter.php
+++ b/lib/Persistence/TrafficLimiter.php
@@ -203,7 +203,7 @@ class TrafficLimiter extends AbstractPersistence
         $now  = time();
         $tl   = (int) self::$_store->getValue('traffic_limiter', $hash);
         self::$_store->purgeValues('traffic_limiter', $now - self::$_limit);
-        if ($tl === 0 || ($tl + self::$_limit) < $now) {
+        if ($tl === 0 || ($tl + self::$_limit) <= $now) {
             if (!self::$_store->setValue((string) $now, 'traffic_limiter', $hash)) {
                 error_log('failed to store the traffic limiter, it probably contains outdated information');
             }

--- a/tst/Data/GoogleCloudStorageTest.php
+++ b/tst/Data/GoogleCloudStorageTest.php
@@ -153,7 +153,7 @@ class GoogleCloudStorageTest extends TestCase
 
         $this->_model->purgeValues('traffic_limiter', time() - 60);
         $this->assertEquals($storedExpired, $this->_model->getValue('traffic_limiter', $client));
-        $this->_model->purgeValues('traffic_limiter', time() + 60);
+        $this->_model->purgeValues('traffic_limiter', $expire);
         $this->assertEquals('', $this->_model->getValue('traffic_limiter', $client));
 
         $purgeAt = $expire + (15 * 60);

--- a/tst/Persistence/PurgeLimiterTest.php
+++ b/tst/Persistence/PurgeLimiterTest.php
@@ -34,7 +34,7 @@ class PurgeLimiterTest extends TestCase
 
         // try setting it
         $this->assertEquals(false, PurgeLimiter::canPurge());
-        sleep(2);
+        sleep(1);
         $this->assertEquals(true, PurgeLimiter::canPurge());
 
         // disable it

--- a/tst/Persistence/TrafficLimiterTest.php
+++ b/tst/Persistence/TrafficLimiterTest.php
@@ -44,7 +44,7 @@ class TrafficLimiterTest extends TestCase
         } catch (Exception $e) {
             $this->assertEquals($e->getMessage(), 'Please wait 4 seconds between each post.', 'second request is to fast, may not pass');
         }
-        sleep(4);
+        sleep(3);
         $this->assertTrue(TrafficLimiter::canPass(), 'third request waited long enough and may pass');
         $_SERVER['REMOTE_ADDR'] = '2001:1620:2057:dead:beef::cafe:babe';
         $this->assertTrue(TrafficLimiter::canPass(), 'fourth request has different ip and may pass');


### PR DESCRIPTION
## What changed

- allow paste creation exactly when the configured traffic-limit interval has elapsed
- allow purge execution exactly when the configured purge-limit interval has elapsed
- purge persisted S3 and Google Cloud limiter entries at the exact cutoff
- tighten both existing tests to exercise the exact boundary instead of one second beyond it

## Why

Both limiters used exclusive expiry comparisons. A configured interval of `N`
seconds therefore remained blocked when `last_action + N === now`, effectively
enforcing `N + 1` seconds because timestamps have one-second resolution.

The expiry boundary is now inclusive, matching the configured duration and the
user-facing promise that clients wait the stated number of seconds. Cloud
cleanup now follows the same inclusive boundary as the shared in-memory
implementation.

## Impact

No configuration, storage format, privacy, security, or compatibility behavior
changes outside the exact expiry second. Requests before the configured interval
remain blocked.

## Validation

- limiter tests, three consecutive runs: `4 tests, 24 assertions` per run
- Google Cloud storage tests: `6 tests, 73 assertions`
- PHP suite excluding the environment-sensitive `ServerSaltTest`: `266 tests, 6505 assertions`
- PHP syntax checks for the changed cloud backend files
- `git diff --check`

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.