### PR TITLE
Expire pastes at their exact deadline

### DIFF
--- a/lib/Data/Database.php
+++ b/lib/Data/Database.php
@@ -437,7 +437,7 @@ class Database extends AbstractData
         try {
             $statement = $this->_db->prepare(
                 'SELECT "dataid" FROM "' . $this->_sanitizeIdentifier('paste') .
-                '" WHERE "expiredate" < ? AND "expiredate" != ? ' .
+                '" WHERE "expiredate" <= ? AND "expiredate" != ? ' .
                 ($this->_type === 'oci' ? 'FETCH NEXT ? ROWS ONLY' : 'LIMIT ?')
             );
             $statement->execute([time(), 0, $batchsize]);

--- a/lib/Data/Filesystem.php
+++ b/lib/Data/Filesystem.php
@@ -368,7 +368,7 @@ class Filesystem extends AbstractData
         shuffle($files);
         foreach ($files as $pasteid) {
             if ($this->exists($pasteid)) {
-                $data = $this->read($pasteid);
+                $data       = $this->read($pasteid);
                 $expireDate = $data['meta']['expire_date'] ?? 0;
                 if ($expireDate > 0 && $expireDate <= $time) {
                     $pastes[] = $pasteid;

--- a/lib/Data/Filesystem.php
+++ b/lib/Data/Filesystem.php
@@ -369,7 +369,8 @@ class Filesystem extends AbstractData
         foreach ($files as $pasteid) {
             if ($this->exists($pasteid)) {
                 $data = $this->read($pasteid);
-                if (($data['meta']['expire_date'] ?? $time) < $time) {
+                $expireDate = $data['meta']['expire_date'] ?? 0;
+                if ($expireDate > 0 && $expireDate <= $time) {
                     $pastes[] = $pasteid;
                     if (++$count >= $batchsize) {
                         break;

--- a/lib/Data/GoogleCloudStorage.php
+++ b/lib/Data/GoogleCloudStorage.php
@@ -343,7 +343,7 @@ class GoogleCloudStorage extends AbstractData
         try {
             foreach ($this->_bucket->objects(['prefix' => $prefix]) as $object) {
                 $expire_at = $object->info()['metadata']['expire_date'] ?? '';
-                if (is_numeric($expire_at) && intval($expire_at) < $now) {
+                if (is_numeric($expire_at) && intval($expire_at) <= $now) {
                     array_push($expired, basename($object->name()));
                 }
 

--- a/lib/Data/S3Storage.php
+++ b/lib/Data/S3Storage.php
@@ -433,7 +433,7 @@ class S3Storage extends AbstractData
                     'Key'    => $object['Key'],
                 ]);
                 $expire_at = $head->get('Metadata')['expire_date'] ?? '';
-                if (is_numeric($expire_at) && intval($expire_at) < $now) {
+                if (is_numeric($expire_at) && intval($expire_at) <= $now) {
                     array_push($expired, $object['Key']);
                 }
 

--- a/lib/Model/Paste.php
+++ b/lib/Model/Paste.php
@@ -60,7 +60,7 @@ class Paste extends AbstractModel
         // check if paste has expired and delete it if necessary.
         if (array_key_exists('expire_date', $data['meta'])) {
             $now = time();
-            if ($data['meta']['expire_date'] < $now) {
+            if ($data['meta']['expire_date'] <= $now) {
                 $this->delete();
                 throw new TranslatedException(Controller::GENERIC_ERROR, 63);
             }

--- a/tst/ModelTest.php
+++ b/tst/ModelTest.php
@@ -3,6 +3,7 @@
 use Jdenticon\Identicon;
 use PHPUnit\Framework\TestCase;
 use PrivateBin\Configuration;
+use PrivateBin\Data\AbstractData;
 use PrivateBin\Data\Database;
 use PrivateBin\Model;
 use PrivateBin\Model\Comment;
@@ -364,6 +365,28 @@ class ModelTest extends TestCase
 
         $paste = $paste->get();
         $this->assertEquals((float) 300, (float) $paste['meta']['time_to_live'], 'remaining time is set correctly', 1.0);
+    }
+
+    public function testPasteExpiresAtExactExpirationTime()
+    {
+        $store = $this->createMock(AbstractData::class);
+        $store->expects($this->once())
+            ->method('read')
+            ->willReturnCallback(function () {
+                $second = time();
+                while (time() === $second) {
+                    usleep(1000);
+                }
+                return Helper::getPaste(['expire_date' => time()]);
+            });
+        $store->expects($this->once())->method('delete');
+
+        $paste = new Paste(new Configuration, $store);
+        $paste->setId(Helper::getPasteId());
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(63);
+        $paste->get();
     }
 
     public function testPurge()


### PR DESCRIPTION
## What changed

- treat a paste as expired when its expiration timestamp equals the current time
- apply the same inclusive boundary to database, filesystem, S3, and Google Cloud purge scans
- preserve missing filesystem expiration metadata as a non-expiring paste
- add a deterministic regression test for retrieval at the exact deadline

## Why

Expiration checks used `< now`, so a paste remained readable with a
`time_to_live` of zero and was not purgeable until the following second. Since
expiration timestamps have one-second resolution, this effectively extended
every configured lifetime by one second.

The checks now use `<= now`, making the stored deadline the first instant at
which the paste is unavailable and eligible for cleanup.

## Impact

The change is consistent across all supported storage backends. It does not
alter stored data, encryption, deletion tokens, or non-expiring paste behavior.

## Validation

- `ModelTest.php`: 20 tests, 105 assertions
- `Data/DatabaseTest.php`: 19 tests, 94 assertions
- `Data/FilesystemTest.php`: 7 tests, 157 assertions
- `Data/GoogleCloudStorageTest.php`: 6 tests, 73 assertions
- PHP suite excluding environment-sensitive `ServerSaltTest`: 267 tests, 6508 assertions
- PHP syntax checks for every changed PHP file
- `git diff --check`

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.