### PR TITLE
Isolate malformed encrypted comments

### DIFF
--- a/js/privatebin.js
+++ b/js/privatebin.js
@@ -5503,12 +5503,15 @@ window.PrivateBin = (function () {
                             commentMessage.comment || '',
                             commentMessage.nickname || ''
                         ];
+                    }).catch(function (error) {
+                        console.warn('Could not decrypt comment.', error);
+                        return null;
                     })
                 );
             }
             return Promise.all(commentDecryptionPromises).then(function (plaintexts) {
                 for (let i = 0; i < paste.comments.length; ++i) {
-                    if (plaintexts[i][0].length === 0) {
+                    if (plaintexts[i] === null || plaintexts[i][0].length === 0) {
                         continue;
                     }
                     DiscussionViewer.addComment(
@@ -5529,6 +5532,18 @@ window.PrivateBin = (function () {
                 });
             });
         }
+
+        /**
+         * decrypt comments, exposed for unit testing
+         *
+         * @name PasteDecrypter.decryptComments
+         * @function
+         * @param {Paste} paste
+         * @param {string} key
+         * @param {string} password
+         * @return {Promise}
+         */
+        me.decryptComments = decryptComments;
 
         /**
          * show decrypted text in the display area, including discussion (if open)
@@ -6154,5 +6169,4 @@ if (typeof module === 'undefined' || !module.exports) {
         window.PrivateBin.Controller.init();
     });
 }
-
 

--- a/js/privatebin.js
+++ b/js/privatebin.js
@@ -5499,8 +5499,20 @@ window.PrivateBin = (function () {
                 commentDecryptionPromises.push(
                     commentPromise.then(function (commentJson) {
                         const commentMessage = JSON.parse(commentJson);
+                        if (
+                            commentMessage === null ||
+                            typeof commentMessage !== 'object' ||
+                            Array.isArray(commentMessage) ||
+                            typeof commentMessage.comment !== 'string' ||
+                            (
+                                Object.prototype.hasOwnProperty.call(commentMessage, 'nickname') &&
+                                typeof commentMessage.nickname !== 'string'
+                            )
+                        ) {
+                            throw new TypeError('Invalid decrypted comment.');
+                        }
                         return [
-                            commentMessage.comment || '',
+                            commentMessage.comment,
                             commentMessage.nickname || ''
                         ];
                     }).catch(function (error) {
@@ -6169,4 +6181,3 @@ if (typeof module === 'undefined' || !module.exports) {
         window.PrivateBin.Controller.init();
     });
 }
-

--- a/js/test/PasteDecrypter.js
+++ b/js/test/PasteDecrypter.js
@@ -1,0 +1,58 @@
+'use strict';
+require('../common');
+
+describe('PasteDecrypter', function () {
+    describe('decryptComments', function () {
+        it('skips malformed comments without rejecting the discussion', async function () {
+            const clean = globalThis.cleanup();
+            const added = [];
+
+            PrivateBin.CryptTool.decipher = async function (key, password, cipherData) {
+                if (cipherData[0] === 'valid') {
+                    return '{"comment":"visible","nickname":"author"}';
+                }
+                if (cipherData[0] === 'rejected') {
+                    throw new Error('decryption failed');
+                }
+                return 'not valid JSON';
+            };
+            PrivateBin.DiscussionViewer.prepareNewDiscussion = function () {};
+            PrivateBin.DiscussionViewer.addComment = function (comment, message, nickname) {
+                added.push([comment.id, message, nickname]);
+            };
+
+            const paste = {
+                comments: [
+                    {
+                        id: 'aaaaaaaaaaaaaaaa',
+                        parentid: 'bbbbbbbbbbbbbbbb',
+                        ct: 'valid',
+                        adata: [],
+                        meta: {created: 1}
+                    },
+                    {
+                        id: 'cccccccccccccccc',
+                        parentid: 'bbbbbbbbbbbbbbbb',
+                        ct: 'invalid',
+                        adata: [],
+                        meta: {created: 2}
+                    },
+                    {
+                        id: 'dddddddddddddddd',
+                        parentid: 'bbbbbbbbbbbbbbbb',
+                        ct: 'rejected',
+                        adata: [],
+                        meta: {created: 3}
+                    }
+                ]
+            };
+
+            await PrivateBin.PasteDecrypter.decryptComments(paste, 'key', 'password');
+
+            assert.deepStrictEqual(added, [
+                ['aaaaaaaaaaaaaaaa', 'visible', 'author']
+            ]);
+            clean();
+        });
+    });
+});

--- a/js/test/PasteDecrypter.js
+++ b/js/test/PasteDecrypter.js
@@ -14,6 +14,12 @@ describe('PasteDecrypter', function () {
                 if (cipherData[0] === 'rejected') {
                     throw new Error('decryption failed');
                 }
+                if (cipherData[0] === 'invalid-comment-type') {
+                    return '{"comment":{},"nickname":"author"}';
+                }
+                if (cipherData[0] === 'invalid-nickname-type') {
+                    return '{"comment":"hidden","nickname":[]}';
+                }
                 return 'not valid JSON';
             };
             PrivateBin.DiscussionViewer.prepareNewDiscussion = function () {};
@@ -43,6 +49,20 @@ describe('PasteDecrypter', function () {
                         ct: 'rejected',
                         adata: [],
                         meta: {created: 3}
+                    },
+                    {
+                        id: 'eeeeeeeeeeeeeeee',
+                        parentid: 'bbbbbbbbbbbbbbbb',
+                        ct: 'invalid-comment-type',
+                        adata: [],
+                        meta: {created: 4}
+                    },
+                    {
+                        id: 'ffffffffffffffff',
+                        parentid: 'bbbbbbbbbbbbbbbb',
+                        ct: 'invalid-nickname-type',
+                        adata: [],
+                        meta: {created: 5}
                     }
                 ]
             };

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -120,7 +120,7 @@ class Configuration
             'js/kjua-0.10.0.js'      => 'sha512-BYj4xggowR7QD150VLSTRlzH62YPfhpIM+b/1EUEr7RQpdWAGKulxWnOvjFx1FUlba4m6ihpNYuQab51H6XlYg==',
             'js/legacy.js'           => 'sha512-pRofxsrf5UItjiP22Dcjh3FAcBjF/n7h8U9/W5xqJk17U0N2U1oajhXypq/omo9jhwS1iVGOhWrRepoPeFns+w==',
             'js/prettify.js'         => 'sha512-puO0Ogy++IoA2Pb9IjSxV1n4+kQkKXYAEUtVzfZpQepyDPyXk8hokiYDS7ybMogYlyyEIwMLpZqVhCkARQWLMg==',
-            'js/privatebin.js'       => 'sha512-9jlPsG7yjibVZMw9G48OGeSOgt6ixiMQxG1IUHTHmK36PNuudwS6iRA1zGPzqizX6POeNKcKdd1MOPp7ih63Kg==',
+            'js/privatebin.js'       => 'sha512-kiye1GrwUFbTTTThCgdPkYnSDwUenMwa30mVLuqe0Img8aX/urJ0SaF4tgI7Er5jPFrXt/JIeFYNqg1X7TcGVg==',
             'js/purify-3.4.12.js'    => 'sha512-Akf6HnAJZm0sWWWI4gp2GYff0NDnHUB02XJE5S7Hdq/Z5xtMjkuFacsDA8ZtViv1gi+onBxMhEMIaGyQeGxBng==',
             'js/showdown-2.1.0.js'   => 'sha512-WYXZgkTR0u/Y9SVIA4nTTOih0kXMEd8RRV6MLFdL6YU8ymhR528NLlYQt1nlJQbYz4EW+ZsS0fx1awhiQJme1Q==',
             'js/zlib-1.3.2.js'       => 'sha512-RAhJgxg9siMIA8ky4c10Rc2zUgnK80olHB8Tt1IOYWY4Eh1WmrviQkDn+sgBlb38ZHq3tzufGC41kP360gmosQ==',

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -120,7 +120,7 @@ class Configuration
             'js/kjua-0.10.0.js'      => 'sha512-BYj4xggowR7QD150VLSTRlzH62YPfhpIM+b/1EUEr7RQpdWAGKulxWnOvjFx1FUlba4m6ihpNYuQab51H6XlYg==',
             'js/legacy.js'           => 'sha512-pRofxsrf5UItjiP22Dcjh3FAcBjF/n7h8U9/W5xqJk17U0N2U1oajhXypq/omo9jhwS1iVGOhWrRepoPeFns+w==',
             'js/prettify.js'         => 'sha512-puO0Ogy++IoA2Pb9IjSxV1n4+kQkKXYAEUtVzfZpQepyDPyXk8hokiYDS7ybMogYlyyEIwMLpZqVhCkARQWLMg==',
-            'js/privatebin.js'       => 'sha512-ah/QdETig/ovH1QPl9Ne+T3VvaP7Bj4Rd9Or9wqQgo5BHge9o02MxAlRGXUZpKviy/27OSzHgz2PwpnH/B2RZg==',
+            'js/privatebin.js'       => 'sha512-9jlPsG7yjibVZMw9G48OGeSOgt6ixiMQxG1IUHTHmK36PNuudwS6iRA1zGPzqizX6POeNKcKdd1MOPp7ih63Kg==',
             'js/purify-3.4.12.js'    => 'sha512-Akf6HnAJZm0sWWWI4gp2GYff0NDnHUB02XJE5S7Hdq/Z5xtMjkuFacsDA8ZtViv1gi+onBxMhEMIaGyQeGxBng==',
             'js/showdown-2.1.0.js'   => 'sha512-WYXZgkTR0u/Y9SVIA4nTTOih0kXMEd8RRV6MLFdL6YU8ymhR528NLlYQt1nlJQbYz4EW+ZsS0fx1awhiQJme1Q==',
             'js/zlib-1.3.2.js'       => 'sha512-RAhJgxg9siMIA8ky4c10Rc2zUgnK80olHB8Tt1IOYWY4Eh1WmrviQkDn+sgBlb38ZHq3tzufGC41kP360gmosQ==',


### PR DESCRIPTION
## What changed

- isolate comment decryption, parsing, and payload-validation failures to the affected comment
- skip malformed comments while continuing to render valid sibling comments and the paste
- require decrypted comment and optional nickname fields to be strings before rendering
- log skipped comment failures without exposing decrypted comment content
- add regression coverage for malformed JSON, rejected decryption promises, and invalid field types
- update the `privatebin.js` SRI hash

## Why

Comment decryption promises were combined with `Promise.all` without per-comment
error handling. One comment that could not be decrypted, did not contain valid
JSON, or contained incompatible field types rejected the discussion promise or
failed later during rendering. That kept the paste UI in its error state even
when the paste itself and every other comment were valid.

Comments are independently submitted, so one damaged or deliberately malformed
comment must not make the parent paste unavailable to all viewers.

## Impact

Valid comments render unchanged. A malformed encrypted comment is omitted and
reported in the browser console; no decrypted content is logged. Paste
encryption, storage, API formats, and backward compatibility are unchanged.

## Validation

- focused `PasteDecrypter` regression: passed
- complete Mocha frontend suite: passed
- ESLint: passed
- PHP suite excluding environment-sensitive `ServerSaltTest`: `266 tests, 6505 assertions`
- SRI verification through the PHP test bootstrap
- `git diff --check`

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.