### PR TITLE
Validate decrypted paste bodies before rendering

### DIFF
--- a/js/privatebin.js
+++ b/js/privatebin.js
@@ -5457,7 +5457,18 @@ window.PrivateBin = (function () {
             }
 
             const pasteMessage = JSON.parse(pastePlain);
-            if (pasteMessage.hasOwnProperty('attachment') && pasteMessage.hasOwnProperty('attachment_name')) {
+            if (
+                pasteMessage === null ||
+                typeof pasteMessage !== 'object' ||
+                Array.isArray(pasteMessage) ||
+                typeof pasteMessage.paste !== 'string'
+            ) {
+                throw new TypeError('Invalid decrypted paste.');
+            }
+            if (
+                Object.prototype.hasOwnProperty.call(pasteMessage, 'attachment') &&
+                Object.prototype.hasOwnProperty.call(pasteMessage, 'attachment_name')
+            ) {
                 if (Array.isArray(pasteMessage.attachment) && Array.isArray(pasteMessage.attachment_name)) {
                     pasteMessage.attachment.forEach((attachment, key) => {
                         const attachment_name = pasteMessage.attachment_name[key];
@@ -6154,5 +6165,4 @@ if (typeof module === 'undefined' || !module.exports) {
         window.PrivateBin.Controller.init();
     });
 }
-
 

--- a/js/test/PasteDecrypterPaste.js
+++ b/js/test/PasteDecrypterPaste.js
@@ -1,0 +1,61 @@
+'use strict';
+require('../common');
+
+describe('PasteDecrypter paste validation', function () {
+    async function decrypt(message) {
+        const clean = globalThis.cleanup('', {
+            url: 'https://example.com/?0123456789abcdef#key'
+        });
+        let rendered = false,
+            shownError;
+
+        PrivateBin.CryptTool.decipher = async function () {
+            return message;
+        };
+        PrivateBin.Alert.hideMessages = function () {};
+        PrivateBin.Alert.setCustomHandler = function () {};
+        PrivateBin.Alert.showLoading = function () {};
+        PrivateBin.Alert.hideLoading = function () {};
+        PrivateBin.Alert.showError = function (error) { shownError = error; };
+        PrivateBin.Model.getPasteKey = function () { return 'key'; };
+        PrivateBin.Prompt.getPassword = function () { return ''; };
+        PrivateBin.TopNav.setRetryCallback = function () {};
+        PrivateBin.TopNav.showViewButtons = function () {};
+        PrivateBin.TopNav.showEmailButton = function () {};
+        PrivateBin.AttachmentViewer.removeAttachment = function () {};
+        PrivateBin.PasteStatus.showRemainingTime = function () {};
+        PrivateBin.CopyToClipboard.showKeyboardShortcutHint = function () {};
+        PrivateBin.PasteViewer.setFormat = function () {};
+        PrivateBin.PasteViewer.setText = function () { rendered = true; };
+        PrivateBin.PasteViewer.run = function () {};
+
+        const paste = {
+            getCipherData: function () { return []; },
+            getFormat: function () { return 'plaintext'; },
+            getTimeToLive: function () { return 0; },
+            isBurnAfterReadingEnabled: function () { return false; },
+            isDiscussionEnabled: function () { return false; }
+        };
+
+        PrivateBin.PasteDecrypter.run(paste);
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        clean();
+        return {rendered, shownError};
+    }
+
+    it('rejects a non-string paste body before rendering it', async function () {
+        const result = await decrypt('{"paste":{}}');
+
+        assert.strictEqual(result.rendered, false);
+        assert(result.shownError instanceof TypeError);
+        assert.strictEqual(result.shownError.message, 'Invalid decrypted paste.');
+    });
+
+    it('accepts paste objects that shadow hasOwnProperty', async function () {
+        const result = await decrypt('{"paste":"text","hasOwnProperty":null}');
+
+        assert.strictEqual(result.rendered, true);
+        assert.strictEqual(result.shownError, undefined);
+    });
+});

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -120,7 +120,7 @@ class Configuration
             'js/kjua-0.10.0.js'      => 'sha512-BYj4xggowR7QD150VLSTRlzH62YPfhpIM+b/1EUEr7RQpdWAGKulxWnOvjFx1FUlba4m6ihpNYuQab51H6XlYg==',
             'js/legacy.js'           => 'sha512-pRofxsrf5UItjiP22Dcjh3FAcBjF/n7h8U9/W5xqJk17U0N2U1oajhXypq/omo9jhwS1iVGOhWrRepoPeFns+w==',
             'js/prettify.js'         => 'sha512-puO0Ogy++IoA2Pb9IjSxV1n4+kQkKXYAEUtVzfZpQepyDPyXk8hokiYDS7ybMogYlyyEIwMLpZqVhCkARQWLMg==',
-            'js/privatebin.js'       => 'sha512-ah/QdETig/ovH1QPl9Ne+T3VvaP7Bj4Rd9Or9wqQgo5BHge9o02MxAlRGXUZpKviy/27OSzHgz2PwpnH/B2RZg==',
+            'js/privatebin.js'       => 'sha512-iEI8C2jHBmI0pfNk1mBavEBMPsS/2xjbHrBQRnyAaGq0FzH+t1HwCxGbioMaeHMprGHP2gDLB8E47DmZR9NV4w==',
             'js/purify-3.4.12.js'    => 'sha512-Akf6HnAJZm0sWWWI4gp2GYff0NDnHUB02XJE5S7Hdq/Z5xtMjkuFacsDA8ZtViv1gi+onBxMhEMIaGyQeGxBng==',
             'js/showdown-2.1.0.js'   => 'sha512-WYXZgkTR0u/Y9SVIA4nTTOih0kXMEd8RRV6MLFdL6YU8ymhR528NLlYQt1nlJQbYz4EW+ZsS0fx1awhiQJme1Q==',
             'js/zlib-1.3.2.js'       => 'sha512-RAhJgxg9siMIA8ky4c10Rc2zUgnK80olHB8Tt1IOYWY4Eh1WmrviQkDn+sgBlb38ZHq3tzufGC41kP360gmosQ==',


### PR DESCRIPTION
## Summary

- validate that decrypted paste payloads are plain JSON objects with a string `paste` body before rendering
- use prototype-safe own-property checks for optional attachment fields
- add regressions for non-string paste bodies and objects that shadow `hasOwnProperty`
- refresh the `privatebin.js` Subresource Integrity hash

## Rationale

Encrypted paste content is controlled by the paste creator. A payload could decrypt successfully to syntactically valid JSON while still containing an invalid body shape. Non-string bodies were passed into the renderer, and an object with its own `hasOwnProperty` field caused attachment detection to throw. The client now rejects malformed bodies at the decryption boundary while preserving valid paste and legacy attachment formats.

## Security and compatibility

This prevents malformed, creator-controlled plaintext from reaching rendering code. It does not inspect or expose plaintext to the server and does not alter cryptography, valid paste IDs, wire formats, or existing string paste bodies.

## Validation

- `npx mocha test/PasteDecrypterPaste.js` — 2 passing
- `npx mocha --reporter dot` — 128 passing
- `npm run lint` — passed
- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit --filter '/^(?!.*ServerSaltTest)/'` — 266 tests, 6,505 assertions
- `git diff --check` — passed
- verified the configured SHA-512 SRI value against `js/privatebin.js`

The excluded `ServerSaltTest` cases depend on filesystem permission behavior unavailable when the test environment runs as root.

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.