### PR TITLE
Reject oversized paste keys in URL fragments

### DIFF
--- a/js/privatebin.js
+++ b/js/privatebin.js
@@ -1522,7 +1522,11 @@ window.PrivateBin = (function () {
                 try {
                     // base58 encode strips NULL bytes at the beginning of the
                     // string, so we re-add them if necessary
-                    symmetricKey = CryptTool.base58decode(newKey).padStart(32, '\u0000');
+                    const decodedKey = CryptTool.base58decode(newKey);
+                    if (decodedKey.length > 32) {
+                        throw new Error('encryption key is too long');
+                    }
+                    symmetricKey = decodedKey.padStart(32, '\u0000');
                 } catch (e) {
                     throw 'encryption key of unsupported format given or incomplete, mangled URL';
                 }
@@ -6154,5 +6158,4 @@ if (typeof module === 'undefined' || !module.exports) {
         window.PrivateBin.Controller.init();
     });
 }
-
 

--- a/js/test/Model.js
+++ b/js/test/Model.js
@@ -213,6 +213,15 @@ describe('Model', function () {
                 }
             ));
         });
+        it('throws exception on keys longer than 32 bytes', () => {
+            const oversizedKey = PrivateBin.CryptTool.base58encode('x'.repeat(33)),
+                clean = globalThis.cleanup('', {
+                    url: 'https://example.com/?0123456789abcdef#' + oversizedKey
+                });
+            assert.throws(() => PrivateBin.Model.getPasteKey());
+            PrivateBin.Model.reset();
+            clean();
+        });
     });
 
     describe('getTemplate', function () {
@@ -254,4 +263,3 @@ describe('Model', function () {
         });
     });
 });
-

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -120,7 +120,7 @@ class Configuration
             'js/kjua-0.10.0.js'      => 'sha512-BYj4xggowR7QD150VLSTRlzH62YPfhpIM+b/1EUEr7RQpdWAGKulxWnOvjFx1FUlba4m6ihpNYuQab51H6XlYg==',
             'js/legacy.js'           => 'sha512-pRofxsrf5UItjiP22Dcjh3FAcBjF/n7h8U9/W5xqJk17U0N2U1oajhXypq/omo9jhwS1iVGOhWrRepoPeFns+w==',
             'js/prettify.js'         => 'sha512-puO0Ogy++IoA2Pb9IjSxV1n4+kQkKXYAEUtVzfZpQepyDPyXk8hokiYDS7ybMogYlyyEIwMLpZqVhCkARQWLMg==',
-            'js/privatebin.js'       => 'sha512-ah/QdETig/ovH1QPl9Ne+T3VvaP7Bj4Rd9Or9wqQgo5BHge9o02MxAlRGXUZpKviy/27OSzHgz2PwpnH/B2RZg==',
+            'js/privatebin.js'       => 'sha512-QekFOkBYgCygJhip7Xd+2QcOXw0yZHHVlN5bUcmeoeLcdA0msTISgpSiKSq0rl0O4uLZq4/p5OU/ghnriNCL4w==',
             'js/purify-3.4.12.js'    => 'sha512-Akf6HnAJZm0sWWWI4gp2GYff0NDnHUB02XJE5S7Hdq/Z5xtMjkuFacsDA8ZtViv1gi+onBxMhEMIaGyQeGxBng==',
             'js/showdown-2.1.0.js'   => 'sha512-WYXZgkTR0u/Y9SVIA4nTTOih0kXMEd8RRV6MLFdL6YU8ymhR528NLlYQt1nlJQbYz4EW+ZsS0fx1awhiQJme1Q==',
             'js/zlib-1.3.2.js'       => 'sha512-RAhJgxg9siMIA8ky4c10Rc2zUgnK80olHB8Tt1IOYWY4Eh1WmrviQkDn+sgBlb38ZHq3tzufGC41kP360gmosQ==',


### PR DESCRIPTION
## Summary

- reject base58 URL fragments that decode to more than PrivateBin's 32-byte symmetric key size
- preserve support for valid keys shortened by leading zero bytes
- add a deterministic regression for an oversized decoded key
- refresh the `privatebin.js` Subresource Integrity hash

## Rationale

PrivateBin generates 256-bit (32-byte) symmetric keys. The client previously accepted a base58 fragment decoding to any length, padding short values but also passing impossible oversized values into PBKDF2. Such malformed links entered the password/decryption flow and produced misleading failures instead of being rejected as structurally invalid URLs.

The check is performed after base58 decoding, so valid generated keys—including encodings shortened by leading zero bytes—remain compatible.

## Security and compatibility

This tightens validation at the client-only URL fragment boundary. It does not transmit the key, change key generation or derivation, alter valid links, or affect stored paste formats.

## Validation

- `npx mocha test/Model.js` — 11 passing
- `npx mocha --reporter dot` — 127 passing
- `npm run lint` — passed
- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit --filter '/^(?!.*ServerSaltTest)/'` — 266 tests, 6,505 assertions
- `git diff --check` — passed
- verified the configured SHA-512 SRI value against `js/privatebin.js`

The excluded `ServerSaltTest` cases depend on filesystem permission behavior unavailable when the test environment runs as root.

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.