### PR TITLE
Keep in-flight server responses with their request

### DIFF
--- a/js/privatebin.js
+++ b/js/privatebin.js
@@ -4889,12 +4889,14 @@ window.PrivateBin = (function () {
          * @function
          * @param {int} status
          * @param {int} result - optional
+         * @param {function} callback
+         * @param {string} encryptionKey
          */
-        function success(status, result) {
-            if (successFunc !== null) {
+        function success(status, result, callback, encryptionKey) {
+            if (callback !== null) {
                 // add useful data to result
-                result.encryptionKey = symmetricKey;
-                successFunc(status, result);
+                result.encryptionKey = encryptionKey;
+                return callback(status, result);
             }
         }
 
@@ -4906,10 +4908,11 @@ window.PrivateBin = (function () {
          * @function
          * @param {int} status - internal code
          * @param {int} result - original error code
+         * @param {function} callback
          */
-        function fail(status, result) {
-            if (failureFunc !== null) {
-                failureFunc(status, result);
+        function fail(status, result, callback) {
+            if (callback !== null) {
+                return callback(status, result);
             }
         }
 
@@ -4924,7 +4927,10 @@ window.PrivateBin = (function () {
                 options = {
                     method: isPost ? 'POST' : 'GET',
                     headers: ajaxHeaders
-                };
+                },
+                requestSuccess = successFunc,
+                requestFailure = failureFunc,
+                requestKey = symmetricKey;
             if (isPost) {
                 options.body = JSON.stringify(data);
             }
@@ -4937,16 +4943,16 @@ window.PrivateBin = (function () {
                 })
                 .then(result => {
                     if (result.status === 0) {
-                        success(0, result);
+                        success(0, result, requestSuccess, requestKey);
                     } else if (result.status === 1) {
-                        fail(1, result);
+                        fail(1, result, requestFailure);
                     } else {
-                        fail(2, result);
+                        fail(2, result, requestFailure);
                     }
                 })
                 .catch(error => {
                     console.error(error);
-                    fail(3, error);
+                    fail(3, error, requestFailure);
                 });
         };
 
@@ -6154,5 +6160,3 @@ if (typeof module === 'undefined' || !module.exports) {
         window.PrivateBin.Controller.init();
     });
 }
-
-

--- a/js/test/ServerInteraction.js
+++ b/js/test/ServerInteraction.js
@@ -3,6 +3,96 @@ const common = require('../common');
 const fc = require('fast-check');
 
 describe('ServerInteraction', function () {
+    describe('run', function () {
+        let clean,
+            originalFetch,
+            requests;
+
+        beforeEach(function () {
+            clean = globalThis.cleanup();
+            originalFetch = global.fetch;
+            requests = [];
+            global.fetch = function (url) {
+                return new Promise(resolve => {
+                    requests.push({url, resolve});
+                });
+            };
+        });
+
+        afterEach(function () {
+            global.fetch = originalFetch;
+            clean();
+        });
+
+        it('keeps success callbacks and keys with their dispatched request', async function () {
+            const results = [];
+
+            PrivateBin.ServerInteraction.prepare();
+            PrivateBin.ServerInteraction.setUrl('https://example.com/first');
+            PrivateBin.ServerInteraction.setCryptParameters('', 'first-key');
+            PrivateBin.ServerInteraction.setSuccess(function (status, data) {
+                results.push(['first', status, data.id, data.encryptionKey]);
+            });
+            PrivateBin.ServerInteraction.run();
+
+            PrivateBin.ServerInteraction.prepare();
+            PrivateBin.ServerInteraction.setUrl('https://example.com/second');
+            PrivateBin.ServerInteraction.setCryptParameters('', 'second-key');
+            PrivateBin.ServerInteraction.setSuccess(function (status, data) {
+                results.push(['second', status, data.id, data.encryptionKey]);
+            });
+            PrivateBin.ServerInteraction.run();
+
+            requests[1].resolve({
+                ok: true,
+                json: async function () { return {status: 0, id: 'second-id'}; }
+            });
+            requests[0].resolve({
+                ok: true,
+                json: async function () { return {status: 0, id: 'first-id'}; }
+            });
+            await new Promise(resolve => setImmediate(resolve));
+
+            assert.deepStrictEqual(results, [
+                ['second', 0, 'second-id', 'second-key'],
+                ['first', 0, 'first-id', 'first-key']
+            ]);
+        });
+
+        it('keeps failure callbacks with their dispatched request', async function () {
+            const failures = [];
+
+            PrivateBin.ServerInteraction.prepare();
+            PrivateBin.ServerInteraction.setUrl('https://example.com/first');
+            PrivateBin.ServerInteraction.setFailure(function (status, data) {
+                failures.push(['first', status, data.message]);
+            });
+            PrivateBin.ServerInteraction.run();
+
+            PrivateBin.ServerInteraction.prepare();
+            PrivateBin.ServerInteraction.setUrl('https://example.com/second');
+            PrivateBin.ServerInteraction.setFailure(function (status, data) {
+                failures.push(['second', status, data.message]);
+            });
+            PrivateBin.ServerInteraction.run();
+
+            requests[0].resolve({
+                ok: true,
+                json: async function () { return {status: 1, message: 'first-error'}; }
+            });
+            requests[1].resolve({
+                ok: true,
+                json: async function () { return {status: 1, message: 'second-error'}; }
+            });
+            await new Promise(resolve => setImmediate(resolve));
+
+            assert.deepStrictEqual(failures, [
+                ['first', 1, 'first-error'],
+                ['second', 1, 'second-error']
+            ]);
+        });
+    });
+
     describe('prepare', function () {
         afterEach(async function () {
             // pause to let async functions conclude

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -120,7 +120,7 @@ class Configuration
             'js/kjua-0.10.0.js'      => 'sha512-BYj4xggowR7QD150VLSTRlzH62YPfhpIM+b/1EUEr7RQpdWAGKulxWnOvjFx1FUlba4m6ihpNYuQab51H6XlYg==',
             'js/legacy.js'           => 'sha512-pRofxsrf5UItjiP22Dcjh3FAcBjF/n7h8U9/W5xqJk17U0N2U1oajhXypq/omo9jhwS1iVGOhWrRepoPeFns+w==',
             'js/prettify.js'         => 'sha512-puO0Ogy++IoA2Pb9IjSxV1n4+kQkKXYAEUtVzfZpQepyDPyXk8hokiYDS7ybMogYlyyEIwMLpZqVhCkARQWLMg==',
-            'js/privatebin.js'       => 'sha512-ah/QdETig/ovH1QPl9Ne+T3VvaP7Bj4Rd9Or9wqQgo5BHge9o02MxAlRGXUZpKviy/27OSzHgz2PwpnH/B2RZg==',
+            'js/privatebin.js'       => 'sha512-oo8L7iXXWy5OgPfm/H5EdRFzORxtiy+fkyxs68/+ROcEdkIZbpYp7WDUfAhFc0TZEH+rIN9OcARD53jzmnqwnA==',
             'js/purify-3.4.12.js'    => 'sha512-Akf6HnAJZm0sWWWI4gp2GYff0NDnHUB02XJE5S7Hdq/Z5xtMjkuFacsDA8ZtViv1gi+onBxMhEMIaGyQeGxBng==',
             'js/showdown-2.1.0.js'   => 'sha512-WYXZgkTR0u/Y9SVIA4nTTOih0kXMEd8RRV6MLFdL6YU8ymhR528NLlYQt1nlJQbYz4EW+ZsS0fx1awhiQJme1Q==',
             'js/zlib-1.3.2.js'       => 'sha512-RAhJgxg9siMIA8ky4c10Rc2zUgnK80olHB8Tt1IOYWY4Eh1WmrviQkDn+sgBlb38ZHq3tzufGC41kP360gmosQ==',


### PR DESCRIPTION
## Summary

- snapshot success and failure handlers when a server request is dispatched
- keep the locally held encryption key associated with the request that generated it
- add deterministic regressions for overlapping success and failure responses
- refresh the `privatebin.js` Subresource Integrity hash

## Rationale

`ServerInteraction` stores callbacks and the symmetric key in shared module state. `run()` previously consulted that mutable state only after its fetch settled. If another request was prepared while the first remained in flight, the first response was delivered to the second request's callback and a successful response could receive the second request's key.

The request now captures those three values at dispatch time. Controlled tests resolve overlapping requests in different orders and verify that each result reaches its own callback with its own key.

## Security and compatibility

This prevents client-side cross-talk between concurrent requests, including accidental association of one response with another locally held key. It does not change request payloads, endpoints, encryption, response formats, or the rule that keys remain client-side.

## Validation

- `npx mocha test/ServerInteraction.js` — 3 passing
- `npx mocha --reporter dot` — 128 passing
- `npm run lint` — passed
- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit --filter '/^(?!.*ServerSaltTest)/'` — 266 tests, 6,505 assertions
- `git diff --check` — passed
- verified the configured SHA-512 SRI value against `js/privatebin.js`

The excluded `ServerSaltTest` cases depend on filesystem permission behavior unavailable when the test environment runs as root.

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.