### PR TITLE
Order same-second comments consistently across storage backends

### DIFF
--- a/lib/Data/AbstractData.php
+++ b/lib/Data/AbstractData.php
@@ -195,4 +195,17 @@ abstract class AbstractData
         }
         return $created;
     }
+
+    /**
+     * Sort comments chronologically, including collision suffixes.
+     *
+     * @access protected
+     * @param  array $comments
+     * @return array
+     */
+    protected function sortComments(array $comments)
+    {
+        ksort($comments, SORT_NATURAL);
+        return $comments;
+    }
 }

--- a/lib/Data/Database.php
+++ b/lib/Data/Database.php
@@ -325,9 +325,8 @@ class Database extends AbstractData
                     $comments[$i]['meta']['icon'] = $row['vizhash'];
                 }
             }
-            ksort($comments);
         }
-        return $comments;
+        return $this->sortComments($comments);
     }
 
     /**

--- a/lib/Data/Filesystem.php
+++ b/lib/Data/Filesystem.php
@@ -228,11 +228,8 @@ class Filesystem extends AbstractData
                     $comments[$key] = $comment;
                 }
             }
-
-            // Sort comments by date, oldest first.
-            ksort($comments);
         }
-        return $comments;
+        return $this->sortComments($comments);
     }
 
     /**

--- a/lib/Data/GoogleCloudStorage.php
+++ b/lib/Data/GoogleCloudStorage.php
@@ -233,7 +233,7 @@ class GoogleCloudStorage extends AbstractData
         } catch (NotFoundException $e) {
             // no comments found
         }
-        return $comments;
+        return $this->sortComments($comments);
     }
 
     /**

--- a/lib/Data/S3Storage.php
+++ b/lib/Data/S3Storage.php
@@ -299,7 +299,7 @@ class S3Storage extends AbstractData
         } catch (S3Exception $e) {
             // no comments found
         }
-        return $comments;
+        return $this->sortComments($comments);
     }
 
     /**

--- a/tst/Data/DatabaseTest.php
+++ b/tst/Data/DatabaseTest.php
@@ -109,6 +109,35 @@ class DatabaseTest extends TestCase
         $this->assertEquals($original, $this->_model->read(Helper::getPasteId()));
     }
 
+    public function testCommentsWithSameTimestampRemainInInsertionOrder()
+    {
+        $pasteid = Helper::getPasteId();
+        $paste   = Helper::getPaste();
+        $this->_model->delete($pasteid);
+        $this->assertTrue($this->_model->create($pasteid, $paste));
+
+        $expectedIds = [];
+        for ($i = 1; $i <= 12; ++$i) {
+            $comment                    = Helper::getComment();
+            $comment['meta']['created'] = 1735689600;
+            $commentid                  = sprintf('%016x', $i);
+            $expectedIds[]              = $commentid;
+            $this->assertTrue(
+                $this->_model->createComment($pasteid, $pasteid, $commentid, $comment)
+            );
+        }
+
+        $actualIds = array_values(
+            array_map(
+                function ($comment) {
+                    return $comment['id'];
+                },
+                $this->_model->readComments($pasteid)
+            )
+        );
+        $this->assertSame($expectedIds, $actualIds);
+    }
+
     /**
      * pastes a-g are expired and should get deleted, x never expires and y-z expire in an hour
      */


### PR DESCRIPTION
## Summary

- centralize chronological comment sorting in the shared storage base class
- use natural ordering for timestamp collision suffixes, so `.10` follows `.9` instead of `.1`
- apply the same ordering contract to filesystem, database, S3, and Google Cloud storage reads
- add a regression with 12 comments sharing one creation timestamp

## Rationale

When comments share a one-second creation timestamp, `getOpenSlot()` assigns keys such as `timestamp.1`, `timestamp.2`, and eventually `timestamp.10`. The filesystem and database backends used ordinary key sorting, which placed `.10` before `.2`. S3 and Google Cloud returned their collected comments without an explicit chronological sort.

The shared natural sort preserves numeric timestamp order and correctly orders collision suffixes across every backend.

## Security and compatibility

This changes only the order of comments returned by storage backends. Comment contents, identifiers, parent relationships, timestamps, encrypted payloads, and stored formats are unchanged.

## Validation

- `php ... /usr/bin/phpunit Data/DatabaseTest.php` — 20 tests, 108 assertions
- `php ... /usr/bin/phpunit Data/FilesystemTest.php` — 7 tests, 157 assertions
- `php ... /usr/bin/phpunit Data/GoogleCloudStorageTest.php` — 6 tests, 73 assertions
- broad PHP suite excluding environment-sensitive `ServerSaltTest` — 267 tests, 6,519 assertions
- `php -l` on all changed PHP files — passed
- `git diff --check` — passed

The repository does not contain a dedicated S3 storage test suite; S3 uses the same tested shared sorter as the other three backends. The excluded `ServerSaltTest` cases depend on filesystem permission behavior unavailable when the test environment runs as root.

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.