### PR TITLE
Reject valued short-form paste IDs

### DIFF
--- a/lib/Request.php
+++ b/lib/Request.php
@@ -85,7 +85,7 @@ class Request
         foreach ($_GET as $key => $value) {
             // only return if value is empty and key is 16 hex chars
             $key = (string) $key;
-            if (empty($value) && Paste::isValidId($key)) {
+            if ($value === '' && Paste::isValidId($key)) {
                 return $key;
             }
         }

--- a/tst/ControllerTest.php
+++ b/tst/ControllerTest.php
@@ -679,6 +679,25 @@ class ControllerTest extends TestCase
     /**
      * @runInSeparateProcess
      */
+    public function testReadRejectsNonemptyShortFormValue()
+    {
+        $paste = Helper::getPaste();
+        $this->_data->create(Helper::getPasteId(), $paste);
+        $_SERVER['QUERY_STRING']                  = Helper::getPasteId() . '=0';
+        $_GET[Helper::getPasteId()]               = '0';
+        $_SERVER['HTTP_X_REQUESTED_WITH']         = 'JSONHttpRequest';
+        ob_start();
+        new Controller;
+        $content = ob_get_contents();
+        ob_end_clean();
+        $response = json_decode($content, true);
+        $this->assertEquals(1, $response['status'], 'outputs error status');
+        $this->assertEquals('Invalid document ID.', $response['message'], 'outputs error message');
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
     public function testReadNonexisting()
     {
         $_SERVER['QUERY_STRING']          = Helper::getPasteId();


### PR DESCRIPTION
## Summary

- require short-form paste IDs to have a truly empty query value
- reject malformed forms such as `?5b65a01b43987bc2=0` instead of returning that paste
- keep the supported `?5b65a01b43987bc2` form unchanged

## Why

The server used PHP's `empty()` when parsing short-form paste IDs. As a result,
the string `"0"` (and empty array values) was accepted as if it were an empty
query value. The browser parser already requires strict equality with an empty
string, so malformed URLs could select a paste on the JSON API even though the
client would reject the same URL.

## Tests

- regression confirmed before the fix: expected error status, received success
- `phpunit RequestTest.php` (15 tests, 56 assertions)
- focused controller regression (1 test, 2 assertions)
- PHP suite excluding the known root-permission-sensitive `ServerSaltTest`
  (269 tests, 6511 assertions)
- PHP syntax checks for changed files

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.