### PR TITLE
Make filesystem record creation atomic

### DIFF
--- a/lib/Data/Filesystem.php
+++ b/lib/Data/Filesystem.php
@@ -90,8 +90,12 @@ class Filesystem extends AbstractData
         if (is_file($file)) {
             return false;
         }
-        if (!is_dir($storagedir)) {
-            mkdir($storagedir, 0700, true);
+        if (
+            !is_dir($storagedir) &&
+            !@mkdir($storagedir, 0700, true) &&
+            !is_dir($storagedir)
+        ) {
+            return false;
         }
         return $this->_store($file, $paste);
     }
@@ -190,8 +194,12 @@ class Filesystem extends AbstractData
         if (is_file($file)) {
             return false;
         }
-        if (!is_dir($storagedir)) {
-            mkdir($storagedir, 0700, true);
+        if (
+            !is_dir($storagedir) &&
+            !@mkdir($storagedir, 0700, true) &&
+            !is_dir($storagedir)
+        ) {
+            return false;
         }
         return $this->_store($file, $comment);
     }
@@ -446,7 +454,8 @@ class Filesystem extends AbstractData
         try {
             return $this->_storeString(
                 $filename,
-                self::PROTECTION_LINE . PHP_EOL . Json::encode($data)
+                self::PROTECTION_LINE . PHP_EOL . Json::encode($data),
+                true
             );
         } catch (JsonException $e) {
             error_log('Error while trying to store data to the filesystem at path "' . $filename . '": ' . $e->getMessage());
@@ -460,15 +469,18 @@ class Filesystem extends AbstractData
      * @access public
      * @param  string $filename
      * @param  string $data
+     * @param  bool   $exclusive
      * @return bool
      */
-    private function _storeString($filename, $data)
+    private function _storeString($filename, $data, $exclusive = false)
     {
         // Create storage directory if it does not exist.
-        if (!is_dir($this->_path)) {
-            if (!@mkdir($this->_path, 0700)) {
-                return false;
-            }
+        if (
+            !is_dir($this->_path) &&
+            !@mkdir($this->_path, 0700) &&
+            !is_dir($this->_path)
+        ) {
+            return false;
         }
         $file = $this->_path . DIRECTORY_SEPARATOR . '.htaccess';
         if (!is_file($file)) {
@@ -487,6 +499,29 @@ class Filesystem extends AbstractData
             ) {
                 return false;
             }
+        }
+
+        if ($exclusive) {
+            $handle = @fopen($filename, 'x');
+            if ($handle === false) {
+                return false;
+            }
+            $length       = strlen($data);
+            $writtenBytes = 0;
+            while ($writtenBytes < $length) {
+                $written = @fwrite($handle, substr($data, $writtenBytes));
+                if ($written === false || $written === 0) {
+                    break;
+                }
+                $writtenBytes += $written;
+            }
+            $fileClosed = @fclose($handle);
+            if ($fileClosed === false || $writtenBytes < $length) {
+                @unlink($filename);
+                return false;
+            }
+            chmod($filename, 0640); // protect file from access by other users on the host
+            return true;
         }
 
         $fileCreated  = true;

--- a/tst/Data/FilesystemTest.php
+++ b/tst/Data/FilesystemTest.php
@@ -75,6 +75,23 @@ class FilesystemTest extends TestCase
         $this->assertEquals($original, $this->_model->read(Helper::getPasteId()));
     }
 
+    public function testStoreDoesNotOverwriteAnExistingPaste()
+    {
+        $id         = Helper::getPasteId();
+        $storageDir = $this->_path . DIRECTORY_SEPARATOR . substr($id, 0, 2) .
+            DIRECTORY_SEPARATOR . substr($id, 2, 2) . DIRECTORY_SEPARATOR;
+        mkdir($storageDir, 0700, true);
+        $filename = $storageDir . $id . '.php';
+        $store    = new ReflectionMethod(Filesystem::class, '_store');
+        $store->setAccessible(true);
+        $original    = Helper::getPaste(['expire_date' => 1344803344]);
+        $replacement = Helper::getPaste(['expire_date' => 2344803344]);
+
+        $this->assertTrue($store->invoke($this->_model, $filename, $original));
+        $this->assertFalse($store->invoke($this->_model, $filename, $replacement));
+        $this->assertEquals($original, $this->_model->read($id));
+    }
+
     /**
      * pastes a-g are expired and should get deleted, x never expires and y-z expire in an hour
      */


### PR DESCRIPTION
## Summary

- create filesystem paste and comment records with exclusive file creation
- prevent a creator that lost a collision race from overwriting the winner
- tolerate concurrent creation of the same storage directories without warnings
- preserve overwrite behavior for mutable persistence files such as limiters

## Why

`Filesystem::create()` checked for an existing file before calling the lower-level
writer, but that writer overwrote the destination when it already existed. Two
requests that passed the first check concurrently could therefore both report
success, with the later write replacing the first paste or comment record.

In a local synchronized reproduction, 31 of 40 processes reported successful
creation of the same paste ID before this change. After the fix, exactly one
process succeeds.

Paste IDs are derived from ciphertext, but records also contain independently
chosen authenticated metadata and server-generated state such as expiration and
deletion salt. Preserving the first record is therefore necessary for the
document-collision contract and predictable deletion behavior.

## Implementation

The immutable paste/comment storage path now opens its destination in exclusive
creation mode and handles partial writes. Existing mutable `_storeString()` users
retain their prior replace-in-place behavior.

## Tests

- regression before fix: the lower-level store returned success and replaced an
  existing record
- regression after fix: 1 test, 3 assertions
- `FilesystemTest.php`: 8 tests, 160 assertions
- `ModelTest.php`: 19 tests, 102 assertions
- broad PHP suite excluding the known root-permission-sensitive
  `ServerSaltTest`: 267 tests, 6508 assertions
- PHP syntax and diff checks
- 40-process synchronized reproduction: 31 successes before, 1 after

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.