### PR TITLE
Make GCS record creation conditional

### DIFF
--- a/lib/Data/GoogleCloudStorage.php
+++ b/lib/Data/GoogleCloudStorage.php
@@ -12,6 +12,7 @@
 namespace PrivateBin\Data;
 
 use Exception;
+use Google\Cloud\Core\Exception\FailedPreconditionException;
 use Google\Cloud\Core\Exception\NotFoundException;
 use Google\Cloud\Storage\Bucket;
 use Google\Cloud\Storage\StorageClient;
@@ -114,9 +115,10 @@ class GoogleCloudStorage extends AbstractData
         }
         try {
             $data = [
-                'name'          => $key,
-                'chunkSize'     => 262144,
-                'metadata'      => [
+                'name'              => $key,
+                'chunkSize'         => 262144,
+                'ifGenerationMatch' => 0,
+                'metadata'          => [
                     'content-type' => 'application/json',
                     'metadata'     => $metadata,
                 ],
@@ -125,6 +127,8 @@ class GoogleCloudStorage extends AbstractData
                 $data['predefinedAcl'] = 'private';
             }
             $this->_bucket->upload(Json::encode($payload), $data);
+        } catch (FailedPreconditionException $e) {
+            return false;
         } catch (Exception $e) {
             error_log('failed to upload ' . $key . ' to ' . $this->_bucket->name() . ', ' .
                 trim(preg_replace('/\s\s+/', ' ', $e->getMessage())));

--- a/tst/Bootstrap.php
+++ b/tst/Bootstrap.php
@@ -1,6 +1,7 @@
 <?php declare(strict_types=1);
 
 use Google\Cloud\Core\Exception\BadRequestException;
+use Google\Cloud\Core\Exception\FailedPreconditionException;
 use Google\Cloud\Core\Exception\NotFoundException;
 use Google\Cloud\Storage\Bucket;
 use Google\Cloud\Storage\Connection\ConnectionInterface;
@@ -411,6 +412,12 @@ class BucketStub extends Bucket
     {
         if (!is_string($data) || !array_key_exists('name', $options)) {
             throw new BadMethodCallException('not supported by this stub');
+        }
+        if (
+            ($options['ifGenerationMatch'] ?? null) === 0 &&
+            array_key_exists($options['name'], $this->_objects)
+        ) {
+            throw new FailedPreconditionException('object already exists');
         }
 
         $name                             = $options['name'];

--- a/tst/Data/GoogleCloudStorageTest.php
+++ b/tst/Data/GoogleCloudStorageTest.php
@@ -78,6 +78,19 @@ class GoogleCloudStorageTest extends TestCase
         $this->assertFalse($this->_model->read(Helper::getPasteId()), 'paste can no longer be found');
     }
 
+    public function testUploadDoesNotOverwriteAnExistingPaste()
+    {
+        $key         = 'pastes/' . Helper::getPasteId();
+        $upload      = new ReflectionMethod(GoogleCloudStorage::class, '_upload');
+        $original    = Helper::getPaste(['expire_date' => 1344803344]);
+        $replacement = Helper::getPaste(['expire_date' => 2344803344]);
+        $upload->setAccessible(true);
+
+        $this->assertTrue($upload->invokeArgs($this->_model, [$key, &$original]));
+        $this->assertFalse($upload->invokeArgs($this->_model, [$key, &$replacement]));
+        $this->assertEquals($original, $this->_model->read(Helper::getPasteId()));
+    }
+
     /**
      * pastes a-g are expired and should get deleted, x never expires and y-z expire in an hour
      */


### PR DESCRIPTION
## Summary

- upload GCS paste and comment objects with `ifGenerationMatch = 0`
- let Google Cloud Storage atomically reject a write when a live object already
  exists at the key
- treat the resulting precondition failure as the normal collision result
- teach the GCS test stub to enforce the same precondition

## Why

The backend checked `exists()` before uploading, but that check and the upload
were separate requests. Concurrent creators could both observe a missing key and
then upload to it, with the later request replacing the first paste or comment
while both reported success.

Records sharing a ciphertext-derived ID can still differ in authenticated
metadata and server-generated state such as expiration and deletion salt, so
preserving the first successful creation is part of the storage collision
contract.

Google documents a zero-valued generation-match precondition as the way to make
an upload succeed only when no live object exists:
https://cloud.google.com/storage/docs/request-preconditions

## Scope

This PR changes only Google Cloud Storage. S3Storage has the same check/write
shape, but it explicitly supports S3-compatible Ceph/RadosGW deployments, whose
documented PutObject compatibility does not clearly guarantee AWS's conditional
write header. That backend needs separate compatibility validation.

## Tests

- regression before fix: the lower-level upload returned success and replaced
  an existing GCS object
- focused regression after fix: 1 test, 3 assertions
- `GoogleCloudStorageTest.php`: 7 tests, 76 assertions
- broad PHP suite excluding the known root-permission-sensitive
  `ServerSaltTest`: 267 tests, 6508 assertions
- PHP syntax and diff checks

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.