### PR TITLE
Render Persian pages right to left

### DIFF
--- a/lib/I18n.php
+++ b/lib/I18n.php
@@ -294,7 +294,7 @@ class I18n
      */
     public static function isRtl()
     {
-        return in_array(self::$_language, ['ar', 'he']);
+        return in_array(self::$_language, ['ar', 'fa', 'he']);
     }
 
     /**

--- a/tst/I18nTest.php
+++ b/tst/I18nTest.php
@@ -246,6 +246,19 @@ class I18nTest extends TestCase
         $this->assertEquals('Ctrl', I18n::getCopyHotkey(), 'returns Ctrl when user agent absent');
     }
 
+    public function testRightToLeftLanguages()
+    {
+        foreach (['ar', 'fa', 'he'] as $language) {
+            $_COOKIE['lang'] = $language;
+            I18n::loadTranslations();
+            $this->assertTrue(I18n::isRtl(), "$language is right-to-left");
+        }
+
+        $_COOKIE['lang'] = 'en';
+        I18n::loadTranslations();
+        $this->assertFalse(I18n::isRtl(), 'English is left-to-right');
+    }
+
     public function testMessageIdsExistInAllLanguages()
     {
         $messageIds = [];


### PR DESCRIPTION
## Summary

- recognize the shipped Persian (`fa`) locale as right-to-left
- add coverage for all shipped RTL locales and an LTR control

## Why

PrivateBin already marks Arabic and Hebrew as RTL, but omitted Persian. The
Bootstrap template uses this classification both to set `dir="rtl"` on the
document and to load Bootstrap's RTL stylesheet. Persian users therefore
received a left-to-right page layout despite the translated content using the
Persian/Arabic script.

W3C internationalization guidance identifies Persian as a right-to-left
language and recommends setting `dir="rtl"` at the HTML document level:
https://www.w3.org/International/quicktips/Overview

## Accessibility and compatibility

This changes only the `fa` locale. Arabic and Hebrew retain their existing RTL
behavior, while English and all other locales remain left-to-right.

## Tests

- regression before fix: Arabic passed, Persian failed RTL detection
- `I18nTest.php`: 19 tests, 5506 assertions
- `ViewTest.php`: 3 tests, 10 assertions
- broad PHP suite excluding the known root-permission-sensitive
  `ServerSaltTest`: 267 tests, 6509 assertions
- PHP syntax and diff checks

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.