### PR TITLE
Use Hindi singular form for zero

### DIFF
--- a/lib/I18n.php
+++ b/lib/I18n.php
@@ -361,6 +361,7 @@ class I18n
             case 'co':
             case 'fa':
             case 'fr':
+            case 'hi':
             case 'oc':
             case 'tr':
             case 'zh':

--- a/tst/I18nTest.php
+++ b/tst/I18nTest.php
@@ -110,6 +110,16 @@ class I18nTest extends TestCase
         $this->assertEquals('2 小时', I18n::_('%d hours', 2), '2 hours in Chinese');
     }
 
+    public function testBrowserLanguageHiDetection()
+    {
+        $_SERVER['HTTP_ACCEPT_LANGUAGE'] = 'hi';
+        I18n::loadTranslations();
+        $this->assertEquals('hi', I18n::getLanguage(), 'browser language hi');
+        $this->assertEquals('0 hour (singular)', I18n::_('%d hours', 0), '0 hours in Hindi');
+        $this->assertEquals('1 hour (singular)', I18n::_('%d hours', 1), '1 hour in Hindi');
+        $this->assertEquals('2 hours (1st plural)', I18n::_('%d hours', 2), '2 hours in Hindi');
+    }
+
     public function testBrowserLanguagePlDetection()
     {
         $_SERVER['HTTP_ACCEPT_LANGUAGE'] = 'pl;q=0.8,en-GB;q=0.6,en-US;q=0.4,en;q=0.2';


### PR DESCRIPTION
## Summary

- select Hindi's singular translation entry for both 0 and 1
- add coverage for the Hindi 0, 1, and 2 cardinal forms

## Problem

PrivateBin did not route Hindi through its `0/1` plural rule. As a result, a zero count selected the plural entry:

```text
0 hours (1st plural)
```

Unicode CLDR defines Hindi cardinal `one` for 0 and 1 (`i = 0 or n = 1`) and `other` for 2 and above:
https://unicode.org/cldr/charts/49/supplemental/language_plural_rules.html

The shipped Hindi translation already represents that structure, but the runtime selected the wrong index for zero.

## Fix

Add `hi` to the existing language group that selects translation index 0 for values up to 1 and index 1 above 1. No other locale behavior changes.

## Verification

Before the fix, the new regression failed:

```text
Expected: 0 hour (singular)
Actual:   0 hours (1st plural)
```

After the fix:

- focused regression: 1 test, 4 assertions
- complete `I18nTest`: 19 tests, 5,506 assertions
- PHP suite excluding the environment-sensitive `ServerSaltTest`: 267 tests, 6,509 assertions
- PHP syntax checks and `git diff --check`: pass

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.