### PR TITLE
Allow clearing optional info text

### DIFF
--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -239,7 +239,10 @@ class Configuration
                             }
                         } elseif (is_int($val)) {
                             $result = (int) $config[$section][$key];
-                        } elseif (is_string($val) && !empty($config[$section][$key])) {
+                        } elseif (
+                            is_string($val) &&
+                            ($key === 'info' || !empty($config[$section][$key]))
+                        ) {
                             $result = (string) $config[$section][$key];
                         } elseif (is_array($val) && is_array($config[$section][$key])) {
                             $result = $config[$section][$key];

--- a/tst/ConfigurationTest.php
+++ b/tst/ConfigurationTest.php
@@ -71,6 +71,19 @@ class ConfigurationTest extends TestCase
         $this->assertEquals($this->_options, $conf->get(), 'returns correct defaults on empty file');
     }
 
+    public function testHandleEmptyInfo()
+    {
+        file_put_contents(
+            CONF,
+            '[main]' . PHP_EOL .
+            'info = ""' . PHP_EOL .
+            '[model]' . PHP_EOL .
+            '[model_options]'
+        );
+        $conf = new Configuration;
+        $this->assertSame('', $conf->getKey('info'), 'allows the optional info text to be cleared');
+    }
+
     public function testHandleInvalidSection()
     {
         file_put_contents(CONF, $this->_minimalConfig);


### PR DESCRIPTION
## Summary

- honor an explicitly empty optional `main.info` setting
- add a regression proving the configured value is not replaced by the default project link

## Problem

The sample configuration describes `info` as optional display text. However, setting:

```ini
[main]
info = ""
```

does not clear it. The string-merging logic treats every empty configured string as absent, so `Configuration::getKey('info')` silently returns the default:

```html
More information on the <a href='https://privatebin.info/'>project page</a>.
```

This prevents administrators from removing that optional suffix without replacing it with whitespace or modifying a template.

## Fix

Honor an empty string specifically for the `info` key. Empty-value behavior for security- and operation-sensitive string settings such as `cspheader`, formatter names, templates, compression, and SRI hashes is unchanged.

## Verification

Before the fix, the new regression failed with the default project link in place of the expected empty string.

After the fix:

- focused regression: 1 test, 1 assertion
- complete `ConfigurationTest`: 12 tests, 15 assertions
- PHP suite excluding the environment-sensitive `ServerSaltTest`: 267 tests, 6,506 assertions
- PHP syntax checks and `git diff --check`: pass

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.
