### PR TITLE
Propagate Google Cloud read failures

### DIFF
--- a/lib/Data/GoogleCloudStorage.php
+++ b/lib/Data/GoogleCloudStorage.php
@@ -159,7 +159,10 @@ class GoogleCloudStorage extends AbstractData
         } catch (Exception $e) {
             error_log('failed to read ' . $pasteid . ' from ' . $this->_bucket->name() . ', ' .
                 trim(preg_replace('/\s\s+/', ' ', $e->getMessage())));
-            return false;
+            if ($e instanceof JsonException) {
+                return false;
+            }
+            throw $e;
         }
     }
 

--- a/tst/Data/GoogleCloudStorageTest.php
+++ b/tst/Data/GoogleCloudStorageTest.php
@@ -1,6 +1,8 @@
 <?php declare(strict_types=1);
 
 use Google\Auth\HttpHandler\HttpHandlerFactory;
+use Google\Cloud\Storage\Bucket;
+use Google\Cloud\Storage\StorageObject;
 use GuzzleHttp\Client;
 use PHPUnit\Framework\TestCase;
 use PrivateBin\Data\GoogleCloudStorage;
@@ -118,6 +120,23 @@ class GoogleCloudStorageTest extends TestCase
         $this->assertFalse($this->_model->exists(Helper::getPasteId()), 'paste does not yet exist');
         $this->assertFalse($this->_model->create(Helper::getPasteId(), $paste), 'unable to store broken paste');
         $this->assertFalse($this->_model->exists(Helper::getPasteId()), 'paste does still not exist');
+    }
+
+    public function testReadPropagatesOperationalErrors()
+    {
+        $object = $this->createMock(StorageObject::class);
+        $object->method('downloadAsString')->willThrowException(new RuntimeException('service unavailable'));
+        $bucket = $this->createMock(Bucket::class);
+        $bucket->method('object')->willReturn($object);
+        $bucket->method('name')->willReturn('test-bucket');
+
+        $property = new ReflectionProperty($this->_model, '_bucket');
+        $property->setAccessible(true);
+        $property->setValue($this->_model, $bucket);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('service unavailable');
+        $this->_model->read(Helper::getPasteId());
     }
 
     public function testCommentErrorDetection()


### PR DESCRIPTION
## Summary

- distinguish missing Google Cloud objects from operational read failures
- keep missing and corrupt objects on their existing false-result paths
- add a mocked service-outage regression

## Problem

`GoogleCloudStorage::read()` catches `NotFoundException` and returns `false`, which is the storage contract for a missing paste. It also caught every other exception and returned the same value.

Consequently, authorization failures, network outages, and Google Cloud service errors were converted into “Document does not exist, has expired or has been deleted.” This hides an operational incident as data absence and differs from the backend's other operations and the equivalent S3 error handling.

## Fix

Continue returning `false` for:

- an explicit `NotFoundException`
- invalid stored JSON after logging the decode failure

After logging any other operational exception, rethrow it so the existing application/runtime error path can report an actual backend failure instead of a false missing-paste result.

## Verification

Before the fix, a mocked `RuntimeException('service unavailable')` was swallowed and the regression failed because no exception was thrown.

After the fix:

- focused operational-error regression: 1 test, 2 assertions
- complete `GoogleCloudStorageTest`: 7 tests, 75 assertions
- PHP suite excluding the environment-sensitive `ServerSaltTest`: 267 tests, 6,507 assertions
- PHP syntax checks and `git diff --check`: pass

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.
