### PR TITLE
Preserve zero in plural translations

### DIFF
--- a/js/privatebin.js
+++ b/js/privatebin.js
@@ -777,9 +777,12 @@ window.PrivateBin = (function () {
 
             // lookup plural translation
             if (usesPlurals && Array.isArray(translations[messageId])) {
-                let n = parseInt(args[1] || 1, 10),
-                    key = me.getPluralForm(n),
-                    maxKey = translations[messageId].length - 1;
+                let n = parseInt(args[1], 10);
+                if (isNaN(n)) {
+                    n = 1;
+                }
+                let key = me.getPluralForm(n);
+                const maxKey = translations[messageId].length - 1;
                 if (key > maxKey) {
                     key = maxKey;
                 }
@@ -6154,5 +6157,4 @@ if (typeof module === 'undefined' || !module.exports) {
         window.PrivateBin.Controller.init();
     });
 }
-
 

--- a/js/test/I18n.js
+++ b/js/test/I18n.js
@@ -50,6 +50,11 @@ describe('I18n', function () {
                 }
             ));
         });
+        it('preserves zero when selecting and formatting plural translations', () => {
+            const result = PrivateBin.I18n.translate(['%d item', '%d items'], 0);
+            PrivateBin.I18n.reset();
+            assert.strictEqual(result, '0 items');
+        });
         it('replaces %s in strings with first given parameter, encoding all, when no link is in the messageID', () => {
             fc.assert(fc.property(
                 fc.string(),

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -120,7 +120,7 @@ class Configuration
             'js/kjua-0.10.0.js'      => 'sha512-BYj4xggowR7QD150VLSTRlzH62YPfhpIM+b/1EUEr7RQpdWAGKulxWnOvjFx1FUlba4m6ihpNYuQab51H6XlYg==',
             'js/legacy.js'           => 'sha512-pRofxsrf5UItjiP22Dcjh3FAcBjF/n7h8U9/W5xqJk17U0N2U1oajhXypq/omo9jhwS1iVGOhWrRepoPeFns+w==',
             'js/prettify.js'         => 'sha512-puO0Ogy++IoA2Pb9IjSxV1n4+kQkKXYAEUtVzfZpQepyDPyXk8hokiYDS7ybMogYlyyEIwMLpZqVhCkARQWLMg==',
-            'js/privatebin.js'       => 'sha512-ah/QdETig/ovH1QPl9Ne+T3VvaP7Bj4Rd9Or9wqQgo5BHge9o02MxAlRGXUZpKviy/27OSzHgz2PwpnH/B2RZg==',
+            'js/privatebin.js'       => 'sha512-nlfZ52A/6ec7biujUc9efcMx8gozfws+ZtEs6U5XB+BYlV0RDigs6QO8xpCSgGAYqnTRy3TUQQPa3HYGx0ZpwQ==',
             'js/purify-3.4.12.js'    => 'sha512-Akf6HnAJZm0sWWWI4gp2GYff0NDnHUB02XJE5S7Hdq/Z5xtMjkuFacsDA8ZtViv1gi+onBxMhEMIaGyQeGxBng==',
             'js/showdown-2.1.0.js'   => 'sha512-WYXZgkTR0u/Y9SVIA4nTTOih0kXMEd8RRV6MLFdL6YU8ymhR528NLlYQt1nlJQbYz4EW+ZsS0fx1awhiQJme1Q==',
             'js/zlib-1.3.2.js'       => 'sha512-RAhJgxg9siMIA8ky4c10Rc2zUgnK80olHB8Tt1IOYWY4Eh1WmrviQkDn+sgBlb38ZHq3tzufGC41kP360gmosQ==',


### PR DESCRIPTION
## Summary

- preserve numeric zero when selecting a client-side plural form
- retain the existing fallback of one for missing or nonnumeric counts
- add a focused regression and refresh the JavaScript SRI hash

## Problem

The browser translator parsed plural counts with:

```js
parseInt(args[1] || 1, 10)
```

Because zero is falsy, every numeric `0` was replaced by `1` before plural selection and formatting. For example:

```js
I18n.translate(['%d item', '%d items'], 0)
```

returned `1 item` instead of `0 items`. This also made locale-specific zero categories unreachable through the translation function.

## Fix

Parse the supplied value directly. If parsing produces `NaN` because the count is missing or invalid, fall back to one as before. A legitimate zero now remains zero for both `getPluralForm()` and `%d` substitution.

## Verification

Before the fix, the new regression failed:

```text
Expected: 0 items
Actual:   1 item
```

After the fix:

- focused regression: 1 passing
- complete `I18n.js`: 9 passing
- complete JavaScript suite: 127 passing
- ESLint: pass
- PHP suite excluding the environment-sensitive `ServerSaltTest`: 266 tests, 6,505 assertions
- regenerated SHA-512 SRI verified against `js/privatebin.js`
- `git diff --check`: pass

The full JavaScript run emits pre-existing jsdom console traces from the Prompt property test, but exits successfully with all 127 tests passing.

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.
