### PR TITLE
Load all shipped client translations

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -51,7 +51,7 @@ var a2zString    = ['a','b','c','d','e','f','g','h','i','j','k','l','m',
         })
     ),
     schemas = ['ftp','http','https'],
-    supportedLanguages = ['ar', 'bg', 'ca', 'co', 'cs', 'de', 'el', 'es', 'et', 'fi', 'fr', 'he', 'hu', 'id', 'it', 'ja', 'jbo', 'lt', 'no', 'nl', 'pl', 'pt', 'oc', 'ru', 'sk', 'sl', 'th', 'tr', 'uk', 'zh'],
+    supportedLanguages = ['ar', 'bg', 'ca', 'co', 'cs', 'de', 'el', 'es', 'et', 'fa', 'fi', 'fr', 'he', 'hi', 'hu', 'id', 'it', 'ja', 'jbo', 'ko', 'ku', 'la', 'lt', 'no', 'nl', 'pl', 'pt', 'oc', 'ro', 'ru', 'sk', 'sl', 'sv', 'th', 'tr', 'uk', 'zh'],
     mimeTypes = ['image/png', 'application/octet-stream'].concat(Object.keys(require('mime-db'))),
     formats = ['plaintext', 'markdown', 'syntaxhighlighting'];
 

--- a/js/privatebin.js
+++ b/js/privatebin.js
@@ -40,6 +40,7 @@ function draghover(element) {
     });
 }
 
+
 window.PrivateBin = (function () {
 
     /**
@@ -667,7 +668,7 @@ window.PrivateBin = (function () {
          * @prop   {string[]}
          * @readonly
          */
-        const supportedLanguages = ['ar', 'bg', 'ca', 'co', 'cs', 'de', 'el', 'es', 'et', 'fa', 'fi', 'fr', 'he', 'hu', 'id', 'it', 'ja', 'jbo', 'lt', 'no', 'nl', 'pl', 'pt', 'oc', 'ro', 'ru', 'sk', 'sl', 'sv', 'th', 'tr', 'uk', 'zh'];
+        const supportedLanguages = ['ar', 'bg', 'ca', 'co', 'cs', 'de', 'el', 'es', 'et', 'fa', 'fi', 'fr', 'he', 'hi', 'hu', 'id', 'it', 'ja', 'jbo', 'ko', 'ku', 'la', 'lt', 'no', 'nl', 'pl', 'pt', 'oc', 'ro', 'ru', 'sk', 'sl', 'sv', 'th', 'tr', 'uk', 'zh'];
 
         /**
          * built in language
@@ -854,6 +855,7 @@ window.PrivateBin = (function () {
                 case 'co':
                 case 'fa':
                 case 'fr':
+                case 'hi':
                 case 'oc':
                 case 'tr':
                 case 'zh':
@@ -863,6 +865,7 @@ window.PrivateBin = (function () {
                 case 'id':
                 case 'ja':
                 case 'jbo':
+                case 'ko':
                 case 'th':
                     return 0;
                 case 'lt':
@@ -6154,5 +6157,3 @@ if (typeof module === 'undefined' || !module.exports) {
         window.PrivateBin.Controller.init();
     });
 }
-
-

--- a/js/test/I18n.js
+++ b/js/test/I18n.js
@@ -183,6 +183,18 @@ describe('I18n', function () {
                 }
             ));
         });
+
+        it('uses the shipped plural forms for Hindi and Korean', () => {
+            PrivateBin.I18n.reset('hi');
+            assert.strictEqual(PrivateBin.I18n.getPluralForm(0), 0);
+            assert.strictEqual(PrivateBin.I18n.getPluralForm(1), 0);
+            assert.strictEqual(PrivateBin.I18n.getPluralForm(2), 1);
+
+            PrivateBin.I18n.reset('ko');
+            assert.strictEqual(PrivateBin.I18n.getPluralForm(0), 0);
+            assert.strictEqual(PrivateBin.I18n.getPluralForm(1), 0);
+            assert.strictEqual(PrivateBin.I18n.getPluralForm(2), 0);
+        });
     });
 
     // loading of JSON via AJAX needs to be tested in the browser, this just mocks it
@@ -191,6 +203,29 @@ describe('I18n', function () {
         this.timeout(30000);
         before(function () {
             PrivateBin.I18n.reset();
+        });
+
+        it('loads every translation exposed by the server', async () => {
+            const originalFetch = global.fetch;
+            global.fetch = () => Promise.resolve({
+                ok: true,
+                json: () => Promise.resolve({})
+            });
+            try {
+                for (const language of ['hi', 'ko', 'ku', 'la']) {
+                    globalThis.cleanup('', {
+                        url: 'https://privatebin.net/'
+                    });
+                    document.cookie = 'lang=' + language;
+                    PrivateBin.I18n.reset();
+                    PrivateBin.I18n.loadTranslations();
+                    await new Promise(resolve => setImmediate(resolve));
+                    assert.strictEqual(PrivateBin.I18n.getLanguage(), language);
+                }
+            } finally {
+                global.fetch = originalFetch;
+                globalThis.cleanup();
+            }
         });
 
         it('downloads and handles any supported language', () => {

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -120,7 +120,7 @@ class Configuration
             'js/kjua-0.10.0.js'      => 'sha512-BYj4xggowR7QD150VLSTRlzH62YPfhpIM+b/1EUEr7RQpdWAGKulxWnOvjFx1FUlba4m6ihpNYuQab51H6XlYg==',
             'js/legacy.js'           => 'sha512-pRofxsrf5UItjiP22Dcjh3FAcBjF/n7h8U9/W5xqJk17U0N2U1oajhXypq/omo9jhwS1iVGOhWrRepoPeFns+w==',
             'js/prettify.js'         => 'sha512-puO0Ogy++IoA2Pb9IjSxV1n4+kQkKXYAEUtVzfZpQepyDPyXk8hokiYDS7ybMogYlyyEIwMLpZqVhCkARQWLMg==',
-            'js/privatebin.js'       => 'sha512-ah/QdETig/ovH1QPl9Ne+T3VvaP7Bj4Rd9Or9wqQgo5BHge9o02MxAlRGXUZpKviy/27OSzHgz2PwpnH/B2RZg==',
+            'js/privatebin.js'       => 'sha512-B0TZOXJRD1AuPuNyeb11hhDHfA3miNFElTaDZGYDS4+oH8ZzHgJvMrHUqqU9cNKzuy5P7pyhNpT7impAxF7tRQ==',
             'js/purify-3.4.12.js'    => 'sha512-Akf6HnAJZm0sWWWI4gp2GYff0NDnHUB02XJE5S7Hdq/Z5xtMjkuFacsDA8ZtViv1gi+onBxMhEMIaGyQeGxBng==',
             'js/showdown-2.1.0.js'   => 'sha512-WYXZgkTR0u/Y9SVIA4nTTOih0kXMEd8RRV6MLFdL6YU8ymhR528NLlYQt1nlJQbYz4EW+ZsS0fx1awhiQJme1Q==',
             'js/zlib-1.3.2.js'       => 'sha512-RAhJgxg9siMIA8ky4c10Rc2zUgnK80olHB8Tt1IOYWY4Eh1WmrviQkDn+sgBlb38ZHq3tzufGC41kP360gmosQ==',


### PR DESCRIPTION
## Summary

- allow the client to load the Hindi, Korean, Kurdish, and Latin catalogs already exposed by the server
- apply the shipped Hindi and Korean plural-form rules after those catalogs load
- synchronize the JavaScript test language generator with every shipped catalog
- update the browser bundle integrity hash

## Reproduction

Before this change, selecting any of `hi`, `ko`, `ku`, or `la` caused `I18n.loadTranslations()` to reject the language and fall back to English. Hindi also routed zero to the plural entry, while Korean routed non-one values away from its sole plural form.

The new focused regressions fail twice on the previous implementation:

```text
Language 'hi' is not supported. Translation failed, fallback to English.
0 passing
2 failing
```

They pass after this change.

## Tests

- `npx mocha test/I18n.js --grep 'loads every translation exposed|uses the shipped plural forms'` — 2 passing
- `npm test` — 128 passing
- `npm run lint` — passing
- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit --filter '/^(?!.*ServerSaltTest)/'` — 266 tests, 6505 assertions
- `git diff --check` — passing
- SHA-512 SRI for `js/privatebin.js` — verified

`ServerSaltTest` is excluded from the broad PHP run because its root-permission assumptions fail in this execution environment; it is unrelated to this client-side change.

## Security and compatibility

Translation files continue to be fetched from the same local `i18n/` path and processed by the existing loader. This only makes already-shipped, server-selectable catalogs reachable in the browser. English fallback behavior for genuinely unsupported codes is unchanged.

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.
