### PR TITLE
Prevent duplicate email handlers

### DIFF
--- a/js/privatebin.js
+++ b/js/privatebin.js
@@ -3813,6 +3813,8 @@ window.PrivateBin = (function () {
             downloadTextButton,
             qrCodeLink,
             emailLink,
+            emailLinkClickHandler = null,
+            emailModalEventController = null,
             sendButton,
             retryButton,
             pasteExpiration = null,
@@ -4192,6 +4194,13 @@ window.PrivateBin = (function () {
 
             const emailconfirmmodal = document.getElementById('emailconfirmmodal');
             if (expirationDate !== null) {
+                if (emailModalEventController !== null) {
+                    emailModalEventController.abort();
+                }
+                emailModalEventController = new window.AbortController();
+                const emailModalEventOptions = {
+                    signal: emailModalEventController.signal
+                };
                 const emailconfirmTimezoneCurrent = emailconfirmmodal.querySelector('#emailconfirm-timezone-current');
                 const emailconfirmTimezoneUtc = emailconfirmmodal.querySelector('#emailconfirm-timezone-utc');
                 let localeConfiguration = { dateStyle: 'long', timeStyle: 'long' };
@@ -4213,15 +4222,13 @@ window.PrivateBin = (function () {
 
                 emailconfirmmodal.addEventListener('shown.bs.modal', () => {
                     emailconfirmTimezoneUtc.focus();
-                });
+                }, emailModalEventOptions);
 
-                emailconfirmTimezoneCurrent.removeEventListener('click', sendEmailAndHideModal);
-                emailconfirmTimezoneCurrent.addEventListener('click', sendEmailAndHideModal);
-                emailconfirmTimezoneUtc.removeEventListener('click', sendEmailAndHideModal);
+                emailconfirmTimezoneCurrent.addEventListener('click', sendEmailAndHideModal, emailModalEventOptions);
                 emailconfirmTimezoneUtc.addEventListener('click', () => {
                     localeConfiguration.timeZone = 'UTC';
                     sendEmailAndHideModal();
-                });
+                }, emailModalEventOptions);
                 if (bootstrap5EmailConfirmModal) {
                     bootstrap5EmailConfirmModal.show();
                 }
@@ -4379,10 +4386,13 @@ window.PrivateBin = (function () {
                 const isBurnafterreading = TopNav.getBurnAfterReading();
 
                 emailLink.classList.remove('hidden');
-                emailLink.removeEventListener('click', sendEmail);
-                emailLink.addEventListener('click', () => {
+                if (emailLinkClickHandler !== null) {
+                    emailLink.removeEventListener('click', emailLinkClickHandler);
+                }
+                emailLinkClickHandler = () => {
                     sendEmail(expirationDate, isBurnafterreading);
-                });
+                };
+                emailLink.addEventListener('click', emailLinkClickHandler);
             } catch (error) {
                 console.error(error);
                 Alert.showError('Cannot calculate expiration date.');
@@ -4401,7 +4411,14 @@ window.PrivateBin = (function () {
             }
 
             emailLink.classList.add('hidden');
-            emailLink.removeEventListener('click', sendEmail);
+            if (emailLinkClickHandler !== null) {
+                emailLink.removeEventListener('click', emailLinkClickHandler);
+                emailLinkClickHandler = null;
+            }
+            if (emailModalEventController !== null) {
+                emailModalEventController.abort();
+                emailModalEventController = null;
+            }
         };
 
         /**
@@ -6154,5 +6171,4 @@ if (typeof module === 'undefined' || !module.exports) {
         window.PrivateBin.Controller.init();
     });
 }
-
 

--- a/js/test/emailTemplateTest.js
+++ b/js/test/emailTemplateTest.js
@@ -54,17 +54,20 @@ function buildEmailDomWithShortUrl() {
 function makeWindowOpenMock() {
     const originalOpen = window.open;
     let openedUrl = null;
+    let callCount = 0;
     let mockRestoreFn = null;
 
     if (typeof jest !== 'undefined' && typeof jest.spyOn === 'function') {
         const spy = jest.spyOn(window, 'open').mockImplementation((url) => {
             openedUrl = url;
+            ++callCount;
             return {};
         });
         mockRestoreFn = () => spy.mockRestore();
     } else {
         window.open = function (url) {
             openedUrl = url;
+            ++callCount;
             return {};
         };
         mockRestoreFn = () => { window.open = originalOpen; };
@@ -72,6 +75,7 @@ function makeWindowOpenMock() {
 
     return {
         getUrl: () => openedUrl,
+        getCallCount: () => callCount,
         restore: () => {
             if (mockRestoreFn) {
                 mockRestoreFn();
@@ -135,6 +139,33 @@ describe('Email - mail body content (short URL vs. fallback)', function () {
             const body = extractMailtoBody(openedUrl);
             assert.match(body, new RegExp(window.location.href), 'email body should include the fallback page URL');
             assert.doesNotMatch(body, /undefined/, 'email body must not contain "undefined"');
+        } finally {
+            restore();
+        }
+    });
+
+    it('keeps one active email action across repeated refreshes', function () {
+        buildEmailDomNoShortUrl();
+        PrivateBin.TopNav.init();
+
+        const emailBtn = document.getElementById('emaillink');
+        const timezoneCurrent = document.getElementById('emailconfirm-timezone-current');
+        const { getCallCount, restore } = makeWindowOpenMock();
+        try {
+            PrivateBin.TopNav.showEmailButton(60);
+            PrivateBin.TopNav.showEmailButton(120);
+            emailBtn.click();
+            timezoneCurrent.click();
+            assert.strictEqual(getCallCount(), 1);
+
+            emailBtn.click();
+            timezoneCurrent.click();
+            assert.strictEqual(getCallCount(), 2);
+
+            PrivateBin.TopNav.hideEmailButton();
+            emailBtn.click();
+            timezoneCurrent.click();
+            assert.strictEqual(getCallCount(), 2);
         } finally {
             restore();
         }

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -120,7 +120,7 @@ class Configuration
             'js/kjua-0.10.0.js'      => 'sha512-BYj4xggowR7QD150VLSTRlzH62YPfhpIM+b/1EUEr7RQpdWAGKulxWnOvjFx1FUlba4m6ihpNYuQab51H6XlYg==',
             'js/legacy.js'           => 'sha512-pRofxsrf5UItjiP22Dcjh3FAcBjF/n7h8U9/W5xqJk17U0N2U1oajhXypq/omo9jhwS1iVGOhWrRepoPeFns+w==',
             'js/prettify.js'         => 'sha512-puO0Ogy++IoA2Pb9IjSxV1n4+kQkKXYAEUtVzfZpQepyDPyXk8hokiYDS7ybMogYlyyEIwMLpZqVhCkARQWLMg==',
-            'js/privatebin.js'       => 'sha512-ah/QdETig/ovH1QPl9Ne+T3VvaP7Bj4Rd9Or9wqQgo5BHge9o02MxAlRGXUZpKviy/27OSzHgz2PwpnH/B2RZg==',
+            'js/privatebin.js'       => 'sha512-iXauzfbW8r3Kow/ej1PjCZy+MN0NDI/zZ+zXAzLWs1GDsqvPt8zW8Crehll6d4ujWP5Pyux5BoFBQuhXfF6Czg==',
             'js/purify-3.4.12.js'    => 'sha512-Akf6HnAJZm0sWWWI4gp2GYff0NDnHUB02XJE5S7Hdq/Z5xtMjkuFacsDA8ZtViv1gi+onBxMhEMIaGyQeGxBng==',
             'js/showdown-2.1.0.js'   => 'sha512-WYXZgkTR0u/Y9SVIA4nTTOih0kXMEd8RRV6MLFdL6YU8ymhR528NLlYQt1nlJQbYz4EW+ZsS0fx1awhiQJme1Q==',
             'js/zlib-1.3.2.js'       => 'sha512-RAhJgxg9siMIA8ky4c10Rc2zUgnK80olHB8Tt1IOYWY4Eh1WmrviQkDn+sgBlb38ZHq3tzufGC41kP360gmosQ==',


### PR DESCRIPTION
## Summary

- keep a stable reference to the active email-button click handler so refreshes replace it
- abort stale confirmation-modal listeners before registering the next interaction
- remove both button and modal listeners when the email control is hidden
- add a regression covering repeated refreshes, repeated sends, and cleanup
- update the browser bundle integrity hash

## Reproduction

`showEmailButton()` registered an anonymous wrapper but attempted to remove `sendEmail`, a different function reference. Every paste refresh therefore retained another click action. `sendEmail()` repeated the same pattern for the timezone controls by creating a new local callback before calling `removeEventListener()`.

Before this change, this sequence invokes `window.open()` twice instead of once:

1. call `showEmailButton()` twice, as repeated paste rendering can
2. click Email once
3. confirm the current timezone once

Subsequent interactions accumulate additional stale actions. The new regression reproduces `2 !== 1` on the previous implementation and passes after the fix.

## Tests

- `npx mocha test/emailTemplateTest.js --grep 'keeps one active email action'` — 1 passing
- `npx mocha test/emailTemplateTest.js` — 3 passing
- `npm test` — 127 passing
- `npm run lint` — passing
- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit --filter '/^(?!.*ServerSaltTest)/'` — 266 tests, 6505 assertions
- `git diff --check` — passing
- SHA-512 SRI for `js/privatebin.js` — verified

`ServerSaltTest` is excluded from the broad PHP run because its root-permission assumptions fail in this execution environment; it is unrelated to this client-side change.

## Compatibility and privacy

The current email interaction remains local and still opens the same `mailto:` URL. The change only retires stale event listeners; it adds no network requests and retains the existing expiration and burn-after-reading values for the latest render.

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.
