### PR TITLE
Revoke removed attachment URLs

### DIFF
--- a/js/privatebin.js
+++ b/js/privatebin.js
@@ -2839,6 +2839,7 @@ window.PrivateBin = (function () {
         let attachmentPreview,
             attachment,
             attachmentsData = [],
+            blobUrls = new Set(),
             files,
             fileInput,
             dragAndDropFileNames,
@@ -2868,7 +2869,9 @@ window.PrivateBin = (function () {
             );
 
             // Get blob URL
-            return window.URL.createObjectURL(blob);
+            const blobUrl = window.URL.createObjectURL(blob);
+            blobUrls.add(blobUrl);
+            return blobUrl;
         }
 
         /**
@@ -3011,6 +3014,10 @@ window.PrivateBin = (function () {
             }
             me.hideAttachment();
             me.hideAttachmentPreview();
+            if (typeof window.URL.revokeObjectURL === 'function') {
+                blobUrls.forEach(blobUrl => window.URL.revokeObjectURL(blobUrl));
+            }
+            blobUrls.clear();
             attachment.innerHTML = '';
             if (attachmentPreview) {
                 attachmentPreview.innerHTML = '';
@@ -6154,5 +6161,4 @@ if (typeof module === 'undefined' || !module.exports) {
         window.PrivateBin.Controller.init();
     });
 }
-
 

--- a/js/test/AttachmentViewer.js
+++ b/js/test/AttachmentViewer.js
@@ -157,6 +157,47 @@ describe('AttachmentViewer', function () {
                 }
             }
         );
+
+        it('revokes attachment object URLs when removing them', function () {
+            const createdUrls = [];
+            const revokedUrls = [];
+            Object.defineProperty(window.URL, 'createObjectURL', {
+                value: function () {
+                    const url = 'blob:https://example.com/' + createdUrls.length;
+                    createdUrls.push(url);
+                    return url;
+                },
+                configurable: true
+            });
+            Object.defineProperty(window.URL, 'revokeObjectURL', {
+                value: function (url) {
+                    revokedUrls.push(url);
+                },
+                configurable: true
+            });
+            document.body.innerHTML = (
+                '<div id="attachmentPreview" class="col-md-12 text-center hidden"></div>' +
+                '<div id="attachment" class="hidden"></div>' +
+                '<div id="templates">' +
+                    '<div id="attachmenttemplate" role="alert" class="attachment hidden alert alert-info">' +
+                        '<span class="glyphicon glyphicon-download-alt" aria-hidden="true"></span>' +
+                        '<a class="alert-link">Download attachment</a>' +
+                    '</div>' +
+                '</div>'
+            );
+            PrivateBin.AttachmentViewer.init();
+            PrivateBin.Model.init();
+            global.atob = common.atob;
+
+            PrivateBin.AttachmentViewer.setAttachment(
+                'data:text/plain;base64,' + common.btoa('attachment'),
+                'attachment.txt'
+            );
+            assert.deepStrictEqual(createdUrls, ['blob:https://example.com/0']);
+
+            PrivateBin.AttachmentViewer.removeAttachment();
+            assert.deepStrictEqual(revokedUrls, createdUrls);
+        });
     });
 
     describe('showAttachment()', function () {
@@ -198,11 +239,10 @@ describe('AttachmentViewer', function () {
                 {
                     value: function (_blob) {
                         return 'blob:' + location.origin + '/1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed';
-                    }
+                    },
+                    configurable: true
                 }
             );
         }
     }
 });
-
-

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -120,7 +120,7 @@ class Configuration
             'js/kjua-0.10.0.js'      => 'sha512-BYj4xggowR7QD150VLSTRlzH62YPfhpIM+b/1EUEr7RQpdWAGKulxWnOvjFx1FUlba4m6ihpNYuQab51H6XlYg==',
             'js/legacy.js'           => 'sha512-pRofxsrf5UItjiP22Dcjh3FAcBjF/n7h8U9/W5xqJk17U0N2U1oajhXypq/omo9jhwS1iVGOhWrRepoPeFns+w==',
             'js/prettify.js'         => 'sha512-puO0Ogy++IoA2Pb9IjSxV1n4+kQkKXYAEUtVzfZpQepyDPyXk8hokiYDS7ybMogYlyyEIwMLpZqVhCkARQWLMg==',
-            'js/privatebin.js'       => 'sha512-ah/QdETig/ovH1QPl9Ne+T3VvaP7Bj4Rd9Or9wqQgo5BHge9o02MxAlRGXUZpKviy/27OSzHgz2PwpnH/B2RZg==',
+            'js/privatebin.js'       => 'sha512-flz3Q7Y9LxSrzcgCyL/6RGojqIsejKtsna0T6ldC/8lVDmNu+K/ylZZlngVKmQMeCGBxEvGjhUh5Wun+ng+66A==',
             'js/purify-3.4.12.js'    => 'sha512-Akf6HnAJZm0sWWWI4gp2GYff0NDnHUB02XJE5S7Hdq/Z5xtMjkuFacsDA8ZtViv1gi+onBxMhEMIaGyQeGxBng==',
             'js/showdown-2.1.0.js'   => 'sha512-WYXZgkTR0u/Y9SVIA4nTTOih0kXMEd8RRV6MLFdL6YU8ymhR528NLlYQt1nlJQbYz4EW+ZsS0fx1awhiQJme1Q==',
             'js/zlib-1.3.2.js'       => 'sha512-RAhJgxg9siMIA8ky4c10Rc2zUgnK80olHB8Tt1IOYWY4Eh1WmrviQkDn+sgBlb38ZHq3tzufGC41kP360gmosQ==',


### PR DESCRIPTION
## Summary

- track object URLs created for decrypted attachment downloads and previews
- revoke all tracked URLs when the attachment UI is removed
- retain a compatibility guard for environments without `URL.revokeObjectURL`
- add a regression that observes creation and cleanup
- update the browser bundle integrity hash

## Reproduction

`AttachmentViewer.setAttachment()` turns decrypted bytes into a `Blob` and calls `URL.createObjectURL()`. SVG attachments can create a second URL for the sanitized preview. `removeAttachment()` cleared the DOM but never revoked any of those URLs.

Because PrivateBin navigates between viewed and new pastes without a full page unload, repeatedly opening large attachments kept their backing blobs alive for the lifetime of the tab.

The regression records one created URL, calls `removeAttachment()`, and fails on the previous implementation because no URL is revoked:

```text
actual:   []
expected: ["blob:https://example.com/0"]
```

It passes after cleanup is tied to the existing removal lifecycle.

## Tests

- `npx mocha test/AttachmentViewer.js --grep 'revokes attachment object URLs'` — 1 passing
- `npx mocha test/AttachmentViewer.js` — 4 passing
- `npm test` — 127 passing
- `npm run lint` — passing
- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit --filter '/^(?!.*ServerSaltTest)/'` — 266 tests, 6505 assertions
- `git diff --check` — passing
- SHA-512 SRI for `js/privatebin.js` — verified

`ServerSaltTest` is excluded from the broad PHP run because its root-permission assumptions fail in this execution environment; it is unrelated to this client-side change.

## Security and compatibility

URLs remain valid for the full time their download/preview controls exist and are revoked only when those controls are removed. This does not alter decrypted bytes, MIME handling, attachment downloads, or network behavior. Browsers lacking `URL.revokeObjectURL` retain the previous behavior.

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.
