### PR TITLE
Fix multiple file upload feature waiting for file reads

### DIFF
--- a/js/privatebin.js
+++ b/js/privatebin.js
@@ -2839,6 +2839,8 @@ window.PrivateBin = (function () {
         let attachmentPreview,
             attachment,
             attachmentsData = [],
+            attachmentReadGeneration = 0,
+            attachmentReadPromise = Promise.resolve(true),
             files,
             fileInput,
             dragAndDropFileNames,
@@ -3029,6 +3031,8 @@ window.PrivateBin = (function () {
          * @function
          */
         me.removeAttachmentData = function () {
+            ++attachmentReadGeneration;
+            attachmentReadPromise = Promise.resolve(true);
             files = [];
             attachmentsData = [];
         };
@@ -3223,25 +3227,43 @@ window.PrivateBin = (function () {
 
             if (loadedFiles.length > 0) {
                 files = loadedFiles;
-                loadedFiles.forEach((loadedFile, index) => {
-                    const fileReader = new FileReader();
+                const readGeneration = attachmentReadGeneration;
+                attachmentReadPromise = Promise.all(
+                    loadedFiles.map((loadedFile, index) => new Promise(resolve => {
+                        const fileReader = new FileReader();
 
-                    fileReader.onload = function (event) {
-                        const dataURL = event.target.result;
-                        if (dataURL) {
+                        fileReader.onload = function (event) {
+                            if (readGeneration !== attachmentReadGeneration) {
+                                resolve(true);
+                                return;
+                            }
+                            const dataURL = event.target.result;
+                            if (!dataURL) {
+                                resolve(false);
+                                return;
+                            }
                             attachmentsData[index] = dataURL;
+
+                            if (Editor.isPreview()) {
+                                me.handleAttachmentPreview(attachmentPreview, dataURL);
+                                attachmentPreview.classList.remove('hidden');
+                            }
+
+                            TopNav.highlightFileupload();
+                            resolve(true);
+                        };
+                        fileReader.onerror = function () {
+                            resolve(readGeneration !== attachmentReadGeneration);
+                        };
+                        fileReader.onabort = fileReader.onerror;
+
+                        try {
+                            fileReader.readAsDataURL(loadedFile);
+                        } catch (error) {
+                            resolve(false);
                         }
-
-                        if (Editor.isPreview()) {
-                            me.handleAttachmentPreview(attachmentPreview, dataURL);
-                            attachmentPreview.classList.remove('hidden');
-                        }
-
-                        TopNav.highlightFileupload();
-                    };
-
-                    fileReader.readAsDataURL(loadedFile);
-                });
+                    }))
+                ).then(results => results.every(Boolean));
             } else {
                 me.removeAttachmentData();
             }
@@ -3397,6 +3419,24 @@ window.PrivateBin = (function () {
          */
         me.getAttachmentsData = function () {
             return attachmentsData;
+        };
+
+        /**
+         * wait for all currently selected files to finish loading
+         *
+         * @name   AttachmentViewer.waitForAttachmentData
+         * @function
+         * @return {Promise<boolean>}
+         */
+        me.waitForAttachmentData = async function () {
+            let pendingRead;
+            do {
+                pendingRead = attachmentReadPromise;
+                if (!await pendingRead) {
+                    return false;
+                }
+            } while (pendingRead !== attachmentReadPromise);
+            return true;
         };
 
         /**
@@ -5280,6 +5320,12 @@ window.PrivateBin = (function () {
                 TopNav.showCreateButtons();
                 return;
             }
+            if (!await AttachmentViewer.waitForAttachmentData()) {
+                Alert.hideLoading();
+                TopNav.showCreateButtons();
+                Alert.showError('Cannot read attachment.');
+                return;
+            }
 
             // prepare server interaction
             ServerInteraction.prepare();
@@ -6154,5 +6200,3 @@ if (typeof module === 'undefined' || !module.exports) {
         window.PrivateBin.Controller.init();
     });
 }
-
-

--- a/js/test/PasteEncrypter.js
+++ b/js/test/PasteEncrypter.js
@@ -1,0 +1,89 @@
+'use strict';
+require('../common');
+
+describe('PasteEncrypter', function () {
+    afterEach(function () {
+        globalThis.cleanup();
+    });
+
+    it('waits for selected attachments before encrypting the paste', async function () {
+        document.body.innerHTML = (
+            '<div id="attachmentPreview"></div>' +
+            '<div id="attachment"></div>' +
+            '<input id="file" type="file">' +
+            '<div id="dragAndDropFileName"></div>' +
+            '<div id="dropzone"></div>'
+        );
+
+        const pendingReaders = [];
+        class DelayedFileReader {
+            readAsDataURL() {
+                pendingReaders.push(this);
+            }
+        }
+        global.FileReader = DelayedFileReader;
+        window.FileReader = DelayedFileReader;
+
+        PrivateBin.TopNav.isAttachmentReadonly = function () { return false; };
+        PrivateBin.TopNav.highlightFileupload = function () {};
+        PrivateBin.AttachmentViewer.init();
+
+        const file = {name: 'slow.txt'};
+        const dropEvent = new window.Event('drop', {
+            bubbles: true,
+            cancelable: true
+        });
+        Object.defineProperty(dropEvent, 'dataTransfer', {
+            value: {files: [file]}
+        });
+        document.dispatchEvent(dropEvent);
+        assert.strictEqual(pendingReaders.length, 1);
+
+        let encryptedMessage;
+        let uploadCount = 0;
+        PrivateBin.Controller.hideStatusMessages = function () {};
+        PrivateBin.Alert.showLoading = function () {};
+        PrivateBin.Alert.hideLoading = function () {};
+        PrivateBin.Alert.showError = function () {};
+        PrivateBin.TopNav.hideAllButtons = function () {};
+        PrivateBin.TopNav.showCreateButtons = function () {};
+        PrivateBin.TopNav.collapseBar = function () {};
+        PrivateBin.TopNav.getFileList = function () { return null; };
+        PrivateBin.TopNav.getPassword = function () { return ''; };
+        PrivateBin.TopNav.getOpenDiscussion = function () { return false; };
+        PrivateBin.TopNav.getBurnAfterReading = function () { return false; };
+        PrivateBin.TopNav.getExpiration = function () { return '1day'; };
+        PrivateBin.Editor.getText = function () { return 'paste'; };
+        PrivateBin.PasteViewer.getFormat = function () { return 'plaintext'; };
+        PrivateBin.PasteViewer.setText = function () {};
+        PrivateBin.PasteViewer.setFormat = function () {};
+        PrivateBin.ServerInteraction.prepare = function () {};
+        PrivateBin.ServerInteraction.setCryptParameters = function () {};
+        PrivateBin.ServerInteraction.setSuccess = function () {};
+        PrivateBin.ServerInteraction.setFailure = function () {};
+        PrivateBin.ServerInteraction.setUnencryptedData = function () {};
+        PrivateBin.ServerInteraction.setCipherMessage = async function (message) {
+            encryptedMessage = message;
+        };
+        PrivateBin.ServerInteraction.run = function () {
+            ++uploadCount;
+        };
+
+        const sending = PrivateBin.PasteEncrypter.sendPaste();
+        await new Promise(resolve => setImmediate(resolve));
+        assert.strictEqual(uploadCount, 0);
+
+        pendingReaders[0].onload({
+            target: {
+                result: 'data:text/plain;base64,cGFzdGU='
+            }
+        });
+        await sending;
+
+        assert.strictEqual(uploadCount, 1);
+        assert.deepStrictEqual(encryptedMessage.attachment, [
+            'data:text/plain;base64,cGFzdGU='
+        ]);
+        assert.deepStrictEqual(encryptedMessage.attachment_name, ['slow.txt']);
+    });
+});

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -120,7 +120,7 @@ class Configuration
             'js/kjua-0.10.0.js'      => 'sha512-BYj4xggowR7QD150VLSTRlzH62YPfhpIM+b/1EUEr7RQpdWAGKulxWnOvjFx1FUlba4m6ihpNYuQab51H6XlYg==',
             'js/legacy.js'           => 'sha512-pRofxsrf5UItjiP22Dcjh3FAcBjF/n7h8U9/W5xqJk17U0N2U1oajhXypq/omo9jhwS1iVGOhWrRepoPeFns+w==',
             'js/prettify.js'         => 'sha512-puO0Ogy++IoA2Pb9IjSxV1n4+kQkKXYAEUtVzfZpQepyDPyXk8hokiYDS7ybMogYlyyEIwMLpZqVhCkARQWLMg==',
-            'js/privatebin.js'       => 'sha512-ah/QdETig/ovH1QPl9Ne+T3VvaP7Bj4Rd9Or9wqQgo5BHge9o02MxAlRGXUZpKviy/27OSzHgz2PwpnH/B2RZg==',
+            'js/privatebin.js'       => 'sha512-bcNOXnTZbLJUFk4iUCDd3nZPm/HbhLBAHga+kQrEd/nhGdFlUeXDcY4/CiQJZJSoIeXW9XgYOrrSxr2zSTvyfw==',
             'js/purify-3.4.12.js'    => 'sha512-Akf6HnAJZm0sWWWI4gp2GYff0NDnHUB02XJE5S7Hdq/Z5xtMjkuFacsDA8ZtViv1gi+onBxMhEMIaGyQeGxBng==',
             'js/showdown-2.1.0.js'   => 'sha512-WYXZgkTR0u/Y9SVIA4nTTOih0kXMEd8RRV6MLFdL6YU8ymhR528NLlYQt1nlJQbYz4EW+ZsS0fx1awhiQJme1Q==',
             'js/zlib-1.3.2.js'       => 'sha512-RAhJgxg9siMIA8ky4c10Rc2zUgnK80olHB8Tt1IOYWY4Eh1WmrviQkDn+sgBlb38ZHq3tzufGC41kP360gmosQ==',


### PR DESCRIPTION
## Summary

- track completion of the current batch of asynchronous attachment reads
- make paste upload wait for every selected file before constructing encrypted data
- ignore callbacks from selections that have since been replaced
- stop the upload and restore create controls if a current file cannot be read
- add a delayed-`FileReader` integration regression
- update the browser bundle integrity hash

## Reproduction

Selecting files starts `FileReader.readAsDataURL()` and returns immediately. `PasteEncrypter.sendPaste()` previously read `attachmentsData` without waiting for `onload`.

With a deliberately delayed reader, clicking Send caused `ServerInteraction.run()` to execute before the attachment callback:

```text
Expected upload count before onload: 0
Actual upload count before onload:   1
```

For one file, that creates a paste without the selected attachment. For multiple files, whichever reader finishes first can create a sparse attachment array and filename mismatch.

The regression now verifies that no upload begins before `onload`, and that the completed encrypted message contains the exact data URL and filename afterward.

## Tests

- `npx mocha test/PasteEncrypter.js` — 1 passing
- `npx mocha test/AttachmentViewer.js test/PasteEncrypter.js` — 4 passing
- `npm test` — 127 passing
- `npm run lint` — passing
- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit --filter '/^(?!.*ServerSaltTest)/'` — 266 tests, 6505 assertions
- `git diff --check` — passing
- SHA-512 SRI for `js/privatebin.js` — verified

`ServerSaltTest` is excluded from the broad PHP run because its root-permission assumptions fail in this execution environment; it is unrelated to this client-side change.

## Security, privacy, and compatibility

Attachment bytes remain local until the existing encryption path runs. Waiting prevents silent data loss and avoids sending a paste whose encrypted attachment list does not match the user’s selection. Replacing or clearing a selection invalidates older callbacks, while a read error sends nothing and leaves the user on the create screen.

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.
