### PR TITLE
Stop uploads after encryption failure

### DIFF
--- a/js/privatebin.js
+++ b/js/privatebin.js
@@ -5247,7 +5247,15 @@ window.PrivateBin = (function () {
                 cipherMessage['nickname'] = nickname;
             }
 
-            await ServerInteraction.setCipherMessage(cipherMessage).catch(Alert.showError);
+            try {
+                await ServerInteraction.setCipherMessage(cipherMessage);
+            } catch (error) {
+                Alert.hideLoading();
+                TopNav.showViewButtons();
+                Alert.showError(error);
+                Alert.setCustomHandler(null);
+                return;
+            }
             ServerInteraction.run();
         };
 
@@ -5371,7 +5379,14 @@ window.PrivateBin = (function () {
             }
 
             // encrypt message
-            await ServerInteraction.setCipherMessage(cipherMessage).catch(Alert.showError);
+            try {
+                await ServerInteraction.setCipherMessage(cipherMessage);
+            } catch (error) {
+                Alert.hideLoading();
+                TopNav.showCreateButtons();
+                Alert.showError(error);
+                return;
+            }
 
             // send data
             ServerInteraction.run();
@@ -6154,5 +6169,4 @@ if (typeof module === 'undefined' || !module.exports) {
         window.PrivateBin.Controller.init();
     });
 }
-
 

--- a/js/test/PasteEncrypterFailure.js
+++ b/js/test/PasteEncrypterFailure.js
@@ -1,0 +1,92 @@
+'use strict';
+require('../common');
+
+describe('PasteEncrypter encryption failures', function () {
+    afterEach(function () {
+        globalThis.cleanup();
+    });
+
+    function stubServerFailure(error) {
+        let uploadCount = 0;
+        PrivateBin.ServerInteraction.prepare = function () {};
+        PrivateBin.ServerInteraction.setCryptParameters = function () {};
+        PrivateBin.ServerInteraction.setSuccess = function () {};
+        PrivateBin.ServerInteraction.setFailure = function () {};
+        PrivateBin.ServerInteraction.setUnencryptedData = function () {};
+        PrivateBin.ServerInteraction.setCipherMessage = async function () {
+            throw error;
+        };
+        PrivateBin.ServerInteraction.run = function () {
+            ++uploadCount;
+        };
+        return function () {
+            return uploadCount;
+        };
+    }
+
+    it('does not upload a paste when encryption fails', async function () {
+        const error = new Error('encryption failed');
+        const getUploadCount = stubServerFailure(error);
+        let loadingHidden = 0;
+        let createButtonsShown = 0;
+        let shownError;
+
+        PrivateBin.Controller.hideStatusMessages = function () {};
+        PrivateBin.Alert.showLoading = function () {};
+        PrivateBin.Alert.hideLoading = function () { ++loadingHidden; };
+        PrivateBin.Alert.showError = function (value) { shownError = value; };
+        PrivateBin.TopNav.hideAllButtons = function () {};
+        PrivateBin.TopNav.showCreateButtons = function () { ++createButtonsShown; };
+        PrivateBin.TopNav.collapseBar = function () {};
+        PrivateBin.TopNav.getFileList = function () { return null; };
+        PrivateBin.TopNav.getPassword = function () { return ''; };
+        PrivateBin.TopNav.getOpenDiscussion = function () { return false; };
+        PrivateBin.TopNav.getBurnAfterReading = function () { return false; };
+        PrivateBin.TopNav.getExpiration = function () { return '1day'; };
+        PrivateBin.Editor.getText = function () { return 'paste'; };
+        PrivateBin.PasteViewer.getFormat = function () { return 'plaintext'; };
+        PrivateBin.PasteViewer.setText = function () {};
+        PrivateBin.PasteViewer.setFormat = function () {};
+        PrivateBin.AttachmentViewer.getAttachmentsData = function () { return []; };
+        PrivateBin.AttachmentViewer.getFiles = function () { return []; };
+        PrivateBin.AttachmentViewer.hasAttachment = function () { return false; };
+
+        await PrivateBin.PasteEncrypter.sendPaste();
+
+        assert.strictEqual(getUploadCount(), 0);
+        assert.strictEqual(loadingHidden, 1);
+        assert.strictEqual(createButtonsShown, 1);
+        assert.strictEqual(shownError, error);
+    });
+
+    it('does not upload a comment when encryption fails', async function () {
+        const error = new Error('encryption failed');
+        const getUploadCount = stubServerFailure(error);
+        let loadingHidden = 0;
+        let viewButtonsShown = 0;
+        let shownError;
+        let customHandler = null;
+
+        PrivateBin.DiscussionViewer.getReplyMessage = function () { return 'comment'; };
+        PrivateBin.DiscussionViewer.getReplyNickname = function () { return ''; };
+        PrivateBin.DiscussionViewer.getReplyCommentId = function () { return undefined; };
+        PrivateBin.Alert.hideMessages = function () {};
+        PrivateBin.Alert.showLoading = function () {};
+        PrivateBin.Alert.hideLoading = function () { ++loadingHidden; };
+        PrivateBin.Alert.showError = function (value) { shownError = value; };
+        PrivateBin.Alert.setCustomHandler = function (handler) { customHandler = handler; };
+        PrivateBin.TopNav.hideAllButtons = function () {};
+        PrivateBin.TopNav.showViewButtons = function () { ++viewButtonsShown; };
+        PrivateBin.Prompt.getPassword = function () { return ''; };
+        PrivateBin.Model.getPasteKey = function () { return 'key'; };
+        PrivateBin.Model.getPasteId = function () { return '0123456789abcdef'; };
+
+        await PrivateBin.PasteEncrypter.sendComment();
+
+        assert.strictEqual(getUploadCount(), 0);
+        assert.strictEqual(loadingHidden, 1);
+        assert.strictEqual(viewButtonsShown, 1);
+        assert.strictEqual(shownError, error);
+        assert.strictEqual(customHandler, null);
+    });
+});

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -120,7 +120,7 @@ class Configuration
             'js/kjua-0.10.0.js'      => 'sha512-BYj4xggowR7QD150VLSTRlzH62YPfhpIM+b/1EUEr7RQpdWAGKulxWnOvjFx1FUlba4m6ihpNYuQab51H6XlYg==',
             'js/legacy.js'           => 'sha512-pRofxsrf5UItjiP22Dcjh3FAcBjF/n7h8U9/W5xqJk17U0N2U1oajhXypq/omo9jhwS1iVGOhWrRepoPeFns+w==',
             'js/prettify.js'         => 'sha512-puO0Ogy++IoA2Pb9IjSxV1n4+kQkKXYAEUtVzfZpQepyDPyXk8hokiYDS7ybMogYlyyEIwMLpZqVhCkARQWLMg==',
-            'js/privatebin.js'       => 'sha512-ah/QdETig/ovH1QPl9Ne+T3VvaP7Bj4Rd9Or9wqQgo5BHge9o02MxAlRGXUZpKviy/27OSzHgz2PwpnH/B2RZg==',
+            'js/privatebin.js'       => 'sha512-D8VNzISH2iCyZoaQ10YMLDxSPLiF1NDz06w2IgmccxOyeRIhVp/hcMwdmg/Al70ttlZpTL5Hx50d+a76DYBbfg==',
             'js/purify-3.4.12.js'    => 'sha512-Akf6HnAJZm0sWWWI4gp2GYff0NDnHUB02XJE5S7Hdq/Z5xtMjkuFacsDA8ZtViv1gi+onBxMhEMIaGyQeGxBng==',
             'js/showdown-2.1.0.js'   => 'sha512-WYXZgkTR0u/Y9SVIA4nTTOih0kXMEd8RRV6MLFdL6YU8ymhR528NLlYQt1nlJQbYz4EW+ZsS0fx1awhiQJme1Q==',
             'js/zlib-1.3.2.js'       => 'sha512-RAhJgxg9siMIA8ky4c10Rc2zUgnK80olHB8Tt1IOYWY4Eh1WmrviQkDn+sgBlb38ZHq3tzufGC41kP360gmosQ==',


### PR DESCRIPTION
## Summary

- make failed paste encryption a terminal path before upload
- make failed comment encryption a terminal path before upload
- restore the appropriate create/view controls and loading state
- reset comment-specific alert routing after displaying the error
- add regressions for both send paths
- update the browser bundle integrity hash

## Reproduction

Both send methods previously used:

```js
await ServerInteraction.setCipherMessage(message).catch(Alert.showError);
ServerInteraction.run();
```

Handling the rejection converted it to a fulfilled promise, so `run()` always executed. At that point `ServerInteraction` can contain unencrypted metadata but no completed `v`/`ct` payload.

The regressions force `setCipherMessage()` to reject and count transport calls. On the previous implementation:

```text
paste upload count:   1 (expected 0)
comment upload count: 1 (expected 0)
```

Both remain zero after this change, while the original error is displayed and controls are restored.

## Tests

- `npx mocha test/PasteEncrypterFailure.js` — 2 passing
- `npm test` — 128 passing
- `npm run lint` — passing
- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit --filter '/^(?!.*ServerSaltTest)/'` — 266 tests, 6505 assertions
- `git diff --check` — passing
- SHA-512 SRI for `js/privatebin.js` — verified

`ServerSaltTest` is excluded from the broad PHP run because its root-permission assumptions fail in this execution environment; it is unrelated to this client-side change.

## Security and privacy

No request is made after encryption fails. In particular, partially prepared unencrypted metadata is not sent to the server. Successful encryption and upload behavior is unchanged.

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.
