### PR TITLE
Report clipboard write failures

### DIFF
--- a/js/privatebin.js
+++ b/js/privatebin.js
@@ -5627,9 +5627,7 @@ window.PrivateBin = (function () {
 
             copyButton.addEventListener('click', function () {
                 const text = PasteViewer.getText();
-                saveToClipboard(text);
-
-                showAlertMessage('Document copied to clipboard');
+                saveToClipboard(text, 'Document copied to clipboard');
             });
         }
 
@@ -5644,9 +5642,7 @@ window.PrivateBin = (function () {
             if (!copyLinkButton) return;
 
             copyLinkButton.addEventListener('click', function () {
-                saveToClipboard(url);
-
-                showAlertMessage('Link copied to clipboard');
+                saveToClipboard(url, 'Link copied to clipboard');
             });
         }
 
@@ -5661,9 +5657,7 @@ window.PrivateBin = (function () {
             document.addEventListener('copy', function () {
                 if (!isUserSelectedTextToCopy()) {
                     const text = PasteViewer.getText();
-                    saveToClipboard(text);
-
-                    showAlertMessage('Document copied to clipboard');
+                    saveToClipboard(text, 'Document copied to clipboard');
                 }
             });
         }
@@ -5694,10 +5688,18 @@ window.PrivateBin = (function () {
          * @name CopyToClipboard.saveToClipboard
          * @private
          * @param {string} text
+         * @param {string} successMessage
          * @function
+         * @return {Promise<void>}
          */
-        function saveToClipboard(text) {
-            navigator.clipboard.writeText(text);
+        async function saveToClipboard(text, successMessage) {
+            try {
+                await navigator.clipboard.writeText(text);
+                showAlertMessage(successMessage);
+            } catch (error) {
+                console.error('Clipboard error:', error);
+                Alert.showError('Could not copy to clipboard.');
+            }
         }
 
         /**
@@ -6154,5 +6156,4 @@ if (typeof module === 'undefined' || !module.exports) {
         window.PrivateBin.Controller.init();
     });
 }
-
 

--- a/js/test/CopyToClipboard.js
+++ b/js/test/CopyToClipboard.js
@@ -136,6 +136,42 @@ describe('CopyToClipboard', function () {
         );
     });
 
+    it('reports clipboard write failures without showing success', async function () {
+        common.enableClipboard();
+        const error = new Error('permission denied');
+        navigator.clipboard.writeText = function () {
+            return Promise.reject(error);
+        };
+        document.body.innerHTML = '<button id="copyLink"></button>';
+
+        let statusMessage;
+        let errorMessage;
+        const originalConsoleError = console.error;
+        let loggedError;
+        PrivateBin.Alert.showStatus = function (message) {
+            statusMessage = message;
+        };
+        PrivateBin.Alert.showError = function (message) {
+            errorMessage = message;
+        };
+        PrivateBin.CopyToClipboard.init();
+        PrivateBin.CopyToClipboard.setUrl('https://example.com/');
+
+        try {
+            console.error = function (label, value) {
+                loggedError = [label, value];
+            };
+            document.getElementById('copyLink').click();
+            await new Promise(resolve => setImmediate(resolve));
+
+            assert.strictEqual(statusMessage, undefined);
+            assert.strictEqual(errorMessage, 'Could not copy to clipboard.');
+            assert.deepStrictEqual(loggedError, ['Clipboard error:', error]);
+        } finally {
+            console.error = originalConsoleError;
+        }
+    });
+
     describe('Keyboard shortcut hint', function () {
         it('shows hint', () => {
             fc.assert(fc.property(fc.string(),

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -120,7 +120,7 @@ class Configuration
             'js/kjua-0.10.0.js'      => 'sha512-BYj4xggowR7QD150VLSTRlzH62YPfhpIM+b/1EUEr7RQpdWAGKulxWnOvjFx1FUlba4m6ihpNYuQab51H6XlYg==',
             'js/legacy.js'           => 'sha512-pRofxsrf5UItjiP22Dcjh3FAcBjF/n7h8U9/W5xqJk17U0N2U1oajhXypq/omo9jhwS1iVGOhWrRepoPeFns+w==',
             'js/prettify.js'         => 'sha512-puO0Ogy++IoA2Pb9IjSxV1n4+kQkKXYAEUtVzfZpQepyDPyXk8hokiYDS7ybMogYlyyEIwMLpZqVhCkARQWLMg==',
-            'js/privatebin.js'       => 'sha512-ah/QdETig/ovH1QPl9Ne+T3VvaP7Bj4Rd9Or9wqQgo5BHge9o02MxAlRGXUZpKviy/27OSzHgz2PwpnH/B2RZg==',
+            'js/privatebin.js'       => 'sha512-qZfRWXBN0MotHGqosuwrhJlLmIhw50KUSUc7IHGq39hcBY9HRhOXcoxApaytFV7Y5yr76QZXuEl8FvkBTEO7GQ==',
             'js/purify-3.4.12.js'    => 'sha512-Akf6HnAJZm0sWWWI4gp2GYff0NDnHUB02XJE5S7Hdq/Z5xtMjkuFacsDA8ZtViv1gi+onBxMhEMIaGyQeGxBng==',
             'js/showdown-2.1.0.js'   => 'sha512-WYXZgkTR0u/Y9SVIA4nTTOih0kXMEd8RRV6MLFdL6YU8ymhR528NLlYQt1nlJQbYz4EW+ZsS0fx1awhiQJme1Q==',
             'js/zlib-1.3.2.js'       => 'sha512-RAhJgxg9siMIA8ky4c10Rc2zUgnK80olHB8Tt1IOYWY4Eh1WmrviQkDn+sgBlb38ZHq3tzufGC41kP360gmosQ==',


### PR DESCRIPTION
## Summary

- await clipboard writes before displaying copy-success notifications
- report a clear UI error when the Clipboard API rejects or throws
- log the underlying error for browser diagnostics
- apply the same completion handling to document, link, and keyboard-copy paths
- add a rejected-write regression
- update the browser bundle integrity hash

## Reproduction

All copy handlers previously called `navigator.clipboard.writeText()` without awaiting its promise and immediately displayed a success message.

When `writeText()` rejects—for example because clipboard permission is denied—the previous implementation still reports:

```text
Link copied to clipboard
```

while nothing was copied, and the rejection is left unhandled.

The new regression forces a permission-style rejection and fails on the previous implementation because a success message is present. It now verifies that no success is shown, the user sees `Could not copy to clipboard.`, and the original error is logged.

## Tests

- `npx mocha test/CopyToClipboard.js --grep 'reports clipboard write failures'` — 1 passing
- `npx mocha test/CopyToClipboard.js` — 6 passing
- `npm test` — 127 passing
- `npm run lint` — passing
- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit --filter '/^(?!.*ServerSaltTest)/'` — 266 tests, 6505 assertions
- `git diff --check` — passing
- SHA-512 SRI for `js/privatebin.js` — verified

`ServerSaltTest` is excluded from the broad PHP run because its root-permission assumptions fail in this execution environment; it is unrelated to this client-side change.

## Security, privacy, and accessibility

Clipboard contents and permissions remain entirely browser-controlled. The UI no longer gives misleading success feedback when the requested write did not happen, including for keyboard-only users.

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.
