### PR TITLE
Use viewed paste metadata in email notices

### DIFF
--- a/js/privatebin.js
+++ b/js/privatebin.js
@@ -4368,15 +4368,17 @@ window.PrivateBin = (function () {
          * @name   TopNav.showEmailbutton
          * @function
          * @param {number|undefined} optionalRemainingTimeInSeconds
+         * @param {bool|undefined} optionalBurnAfterReading
          */
-        me.showEmailButton = function (optionalRemainingTimeInSeconds) {
+        me.showEmailButton = function (optionalRemainingTimeInSeconds, optionalBurnAfterReading) {
             try {
                 // we cache expiration date in closure to avoid inaccurate expiration datetime
                 const expirationDate = Helper.calculateExpirationDate(
                     new Date(),
                     typeof optionalRemainingTimeInSeconds === 'number' ? optionalRemainingTimeInSeconds : TopNav.getExpiration()
                 );
-                const isBurnafterreading = TopNav.getBurnAfterReading();
+                const isBurnafterreading = typeof optionalBurnAfterReading === 'boolean' ?
+                    optionalBurnAfterReading : TopNav.getBurnAfterReading();
 
                 emailLink.classList.remove('hidden');
                 emailLink.removeEventListener('click', sendEmail);
@@ -5583,7 +5585,10 @@ window.PrivateBin = (function () {
                         TopNav.hideBurnAfterReadingButtons();
                     } else {
                         // we have to pass in remaining_time here
-                        TopNav.showEmailButton(paste.getTimeToLive());
+                        TopNav.showEmailButton(
+                            paste.getTimeToLive(),
+                            paste.isBurnAfterReadingEnabled()
+                        );
                     }
 
                     // only offer adding comments, after document was successfully decrypted
@@ -6154,5 +6159,4 @@ if (typeof module === 'undefined' || !module.exports) {
         window.PrivateBin.Controller.init();
     });
 }
-
 

--- a/js/test/emailTemplateTest.js
+++ b/js/test/emailTemplateTest.js
@@ -139,4 +139,30 @@ describe('Email - mail body content (short URL vs. fallback)', function () {
             restore();
         }
     });
+
+    it('Uses the viewed paste burn-after-reading state instead of the instance default', function () {
+        buildEmailDomNoShortUrl();
+        const burnAfterReading = document.createElement('input');
+        burnAfterReading.id = 'burnafterreading';
+        burnAfterReading.type = 'checkbox';
+        burnAfterReading.checked = true;
+        document.body.appendChild(burnAfterReading);
+        PrivateBin.TopNav.init();
+        PrivateBin.TopNav.showEmailButton(0, false);
+
+        const { getUrl, restore } = makeWindowOpenMock();
+        try {
+            document.getElementById('emaillink').click();
+            document.getElementById('emailconfirm-timezone-current').click();
+
+            const body = extractMailtoBody(getUrl());
+            assert.doesNotMatch(
+                body,
+                /only be accessed once/,
+                'email body must use the viewed paste metadata'
+            );
+        } finally {
+            restore();
+        }
+    });
 });

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -120,7 +120,7 @@ class Configuration
             'js/kjua-0.10.0.js'      => 'sha512-BYj4xggowR7QD150VLSTRlzH62YPfhpIM+b/1EUEr7RQpdWAGKulxWnOvjFx1FUlba4m6ihpNYuQab51H6XlYg==',
             'js/legacy.js'           => 'sha512-pRofxsrf5UItjiP22Dcjh3FAcBjF/n7h8U9/W5xqJk17U0N2U1oajhXypq/omo9jhwS1iVGOhWrRepoPeFns+w==',
             'js/prettify.js'         => 'sha512-puO0Ogy++IoA2Pb9IjSxV1n4+kQkKXYAEUtVzfZpQepyDPyXk8hokiYDS7ybMogYlyyEIwMLpZqVhCkARQWLMg==',
-            'js/privatebin.js'       => 'sha512-ah/QdETig/ovH1QPl9Ne+T3VvaP7Bj4Rd9Or9wqQgo5BHge9o02MxAlRGXUZpKviy/27OSzHgz2PwpnH/B2RZg==',
+            'js/privatebin.js'       => 'sha512-aHgGiaRuQizWq7l3SC1wxI2sOShdTZHt9IJNL/srxuHbAMXATPtCd5ztw2fV1GZER8ABxpovxMSrJSm8DLbAbA==',
             'js/purify-3.4.12.js'    => 'sha512-Akf6HnAJZm0sWWWI4gp2GYff0NDnHUB02XJE5S7Hdq/Z5xtMjkuFacsDA8ZtViv1gi+onBxMhEMIaGyQeGxBng==',
             'js/showdown-2.1.0.js'   => 'sha512-WYXZgkTR0u/Y9SVIA4nTTOih0kXMEd8RRV6MLFdL6YU8ymhR528NLlYQt1nlJQbYz4EW+ZsS0fx1awhiQJme1Q==',
             'js/zlib-1.3.2.js'       => 'sha512-RAhJgxg9siMIA8ky4c10Rc2zUgnK80olHB8Tt1IOYWY4Eh1WmrviQkDn+sgBlb38ZHq3tzufGC41kP360gmosQ==',


### PR DESCRIPTION
## Summary

- pass the decrypted paste's burn-after-reading state to the email share button
- keep creation-form behavior unchanged when no viewed-paste state is supplied
- cover instances whose default burn-after-reading setting differs from the viewed paste

## Reproduction

On an instance where burn-after-reading is enabled by default:

1. View a paste that was created without burn-after-reading.
2. Open the email share action.
3. The generated email incorrectly warns that the link can only be accessed once.

`showEmailButton()` read the creation-form checkbox, which reflects the instance default, instead of the metadata of the decrypted paste being viewed.

Fixes #1445.

## Testing

- `node_modules/.bin/mocha test/emailTemplateTest.js --reporter spec` (3 passing)
- `npm run lint`
- `npm test` (127 passing)
- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit --filter '/^(?!.*ServerSaltTest)/'` (266 tests, 6505 assertions)
- recomputed and verified the `js/privatebin.js` SHA-512 SRI hash

## Compatibility and privacy

The change only selects which already-decrypted boolean is used to compose the local `mailto:` body. It sends no new data to the server, does not alter encryption or storage, and preserves existing new-paste behavior through the optional fallback.

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.
