### PR TITLE
Prevent duplicate URL shortener requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * FIXED: Gracefully handle YOURLS replies with a 200 status code but no shorturl, instead of raising a TypeError
 * FIXED: Return "Invalid data." instead of HTTP 500 on malformed v2 JSON payloads (#1883)
 * FIXED: Dead PATH validation guard in Controller, the check for a missing trailing directory separator never ran (#1887)
+* FIXED: Prevent duplicate URL-shortener requests and allow retrying invalid responses
 
 ## 2.0.5 (2026-07-11)
 * CHANGED: Show OS-specific copy hotkey hint (Cmd+c on Mac, Ctrl+c on others) (#1506)

--- a/js/privatebin.js
+++ b/js/privatebin.js
@@ -1944,21 +1944,28 @@ window.PrivateBin = (function () {
             if (shortenButton.classList.contains('buttondisabled')) {
                 return;
             }
-            fetch(`${shortenButton.dataset.shortener}${encodeURIComponent(pasteUrl.href)}`, {
-                method: 'GET',
-                headers: { 'Accept': 'text/html, application/xhtml+xml, application/xml, application/json' },
-                credentials: 'omit',
-                signal: AbortSignal.timeout(10000)
-            })
+            shortenButton.classList.add('buttondisabled');
+            Promise.resolve()
+                .then(() => fetch(`${shortenButton.dataset.shortener}${encodeURIComponent(pasteUrl.href)}`, {
+                    method: 'GET',
+                    headers: { 'Accept': 'text/html, application/xhtml+xml, application/xml, application/json' },
+                    credentials: 'omit',
+                    signal: AbortSignal.timeout(10000)
+                }))
                 .then(response => {
                     if (!response.ok) {
                         throw new Error('HTTP ' + response.status);
                     }
                     return response.text();
                 })
-                .then(data => PasteStatus.extractUrl(data))
+                .then(data => {
+                    if (!PasteStatus.extractUrl(data)) {
+                        shortenButton.classList.remove('buttondisabled');
+                    }
+                })
                 .catch(error => {
                     console.error('Shortener error:', error);
+                    shortenButton.classList.remove('buttondisabled');
                     // we don't know why it failed, could be CORS of the external
                     // server not setup properly, in which case we follow old
                     // behavior to open it in new tab
@@ -2056,6 +2063,7 @@ window.PrivateBin = (function () {
          * @name   PasteStatus.extractUrl
          * @function
          * @param  {string} response
+         * @return {boolean} whether a URL was extracted
          */
         me.extractUrl = function (response) {
             if (typeof response === 'object') {
@@ -2087,10 +2095,11 @@ window.PrivateBin = (function () {
                     // we pre-select the link so that the user only has to [Ctrl]+[c] the link
                     Helper.selectText(pasteUrl);
                     CopyToClipboard.setUrl(shortUrl);
-                    return;
+                    return true;
                 }
             }
             Alert.showError('Cannot parse response from URL shortener.');
+            return false;
         };
 
         /**
@@ -6154,5 +6163,4 @@ if (typeof module === 'undefined' || !module.exports) {
         window.PrivateBin.Controller.init();
     });
 }
-
 

--- a/js/test/PasteStatus.js
+++ b/js/test/PasteStatus.js
@@ -234,6 +234,86 @@ describe('PasteStatus', function () {
         });
     });
 
+    describe('URL shortener requests', function () {
+        it('ignores repeated clicks while a request is pending', async function () {
+            const clean = globalThis.cleanup();
+            const originalFetch = global.fetch;
+            let resolveFetch,
+                fetchCount = 0;
+            global.fetch = function () {
+                ++fetchCount;
+                return new Promise(resolve => {
+                    resolveFetch = resolve;
+                });
+            };
+            document.body.innerHTML =
+                '<div id="pastelink"></div>' +
+                '<div id="pastesuccess"></div>' +
+                '<button id="shortenbutton" data-shortener="https://short.example/?url="></button>';
+            PrivateBin.PasteStatus.init();
+            PrivateBin.PasteStatus.createPasteNotification(
+                'https://example.com/?0123456789abcdef#key',
+                ''
+            );
+
+            const shortenButton = document.getElementById('shortenbutton');
+            shortenButton.click();
+            shortenButton.click();
+            await Promise.resolve();
+
+            assert.strictEqual(fetchCount, 1);
+            assert.ok(shortenButton.classList.contains('buttondisabled'));
+
+            resolveFetch({
+                ok: true,
+                text: async function () {
+                    return 'https://short.example/a';
+                }
+            });
+            await new Promise(resolve => setTimeout(resolve, 0));
+
+            assert.strictEqual(
+                document.getElementById('pasteurl').href,
+                'https://short.example/a'
+            );
+            assert.ok(shortenButton.classList.contains('buttondisabled'));
+            global.fetch = originalFetch;
+            clean();
+        });
+
+        it('allows retrying after an invalid shortener response', async function () {
+            const clean = globalThis.cleanup();
+            const originalFetch = global.fetch;
+            let shownError;
+            global.fetch = async function () {
+                return {
+                    ok: true,
+                    text: async function () { return 'missing URL'; }
+                };
+            };
+            PrivateBin.Alert.showError = function (error) {
+                shownError = error;
+            };
+            document.body.innerHTML =
+                '<div id="pastelink"></div>' +
+                '<button id="shortenbutton" data-shortener="https://short.example/?url="></button>';
+            PrivateBin.PasteStatus.init();
+            PrivateBin.PasteStatus.createPasteNotification(
+                'https://example.com/?0123456789abcdef#key',
+                ''
+            );
+
+            const shortenButton = document.getElementById('shortenbutton');
+            shortenButton.click();
+            await new Promise(resolve => setTimeout(resolve, 0));
+
+            assert.ok(!shortenButton.classList.contains('buttondisabled'));
+            assert.strictEqual(shownError, 'Cannot parse response from URL shortener.');
+            global.fetch = originalFetch;
+            clean();
+        });
+    });
+
     describe('showRemainingTime', function () {
         this.timeout(30000);
 

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -120,7 +120,7 @@ class Configuration
             'js/kjua-0.10.0.js'      => 'sha512-BYj4xggowR7QD150VLSTRlzH62YPfhpIM+b/1EUEr7RQpdWAGKulxWnOvjFx1FUlba4m6ihpNYuQab51H6XlYg==',
             'js/legacy.js'           => 'sha512-pRofxsrf5UItjiP22Dcjh3FAcBjF/n7h8U9/W5xqJk17U0N2U1oajhXypq/omo9jhwS1iVGOhWrRepoPeFns+w==',
             'js/prettify.js'         => 'sha512-puO0Ogy++IoA2Pb9IjSxV1n4+kQkKXYAEUtVzfZpQepyDPyXk8hokiYDS7ybMogYlyyEIwMLpZqVhCkARQWLMg==',
-            'js/privatebin.js'       => 'sha512-ah/QdETig/ovH1QPl9Ne+T3VvaP7Bj4Rd9Or9wqQgo5BHge9o02MxAlRGXUZpKviy/27OSzHgz2PwpnH/B2RZg==',
+            'js/privatebin.js'       => 'sha512-sKAoIfuy4NwMsST1xLCOKI0bsgb8JX11mLw3iUNwswsznfCy7iDH3aMI2yIDJJ5TPB2/RXN+HSA0F2vU8oDxWA==',
             'js/purify-3.4.12.js'    => 'sha512-Akf6HnAJZm0sWWWI4gp2GYff0NDnHUB02XJE5S7Hdq/Z5xtMjkuFacsDA8ZtViv1gi+onBxMhEMIaGyQeGxBng==',
             'js/showdown-2.1.0.js'   => 'sha512-WYXZgkTR0u/Y9SVIA4nTTOih0kXMEd8RRV6MLFdL6YU8ymhR528NLlYQt1nlJQbYz4EW+ZsS0fx1awhiQJme1Q==',
             'js/zlib-1.3.2.js'       => 'sha512-RAhJgxg9siMIA8ky4c10Rc2zUgnK80olHB8Tt1IOYWY4Eh1WmrviQkDn+sgBlb38ZHq3tzufGC41kP360gmosQ==',


### PR DESCRIPTION
## Summary

- disable the URL-shortener action as soon as a request starts
- ignore repeated clicks while that request is pending
- restore the action after transport failures or invalid responses so users can retry
- report whether a short URL was successfully extracted

## Reproduction

1. Create a paste with URL shortening enabled.
2. Click the shortening action twice before the first request completes.
3. Two requests are sent to the external shortener and their responses race to update the displayed link.

This can create multiple external short links for one paste and leaves the visible result dependent on response order.

## Testing

- `node_modules/.bin/mocha test/PasteStatus.js --grep 'URL shortener requests' --reporter spec` (2 passing)
- `npm run lint`
- `npm test -- --reporter dot` (128 passing)
- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit --filter '/^(?!.*ServerSaltTest)/'` (266 tests, 6505 assertions)
- recomputed and verified the `js/privatebin.js` SHA-512 SRI hash

## Security and compatibility

Requests still use the existing endpoint, headers, timeout, and credential policy. The change only serializes the existing user action and preserves retry behavior after failures; it does not expose new data or change generated paste URLs.

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.
