### PR TITLE
Propagate paste decompression failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * FIXED: Gracefully handle YOURLS replies with a 200 status code but no shorturl, instead of raising a TypeError
 * FIXED: Return "Invalid data." instead of HTTP 500 on malformed v2 JSON payloads (#1883)
 * FIXED: Dead PATH validation guard in Controller, the check for a missing trailing directory separator never ran (#1887)
+* FIXED: Propagate decompression errors and stop the loading indicator
 
 ## 2.0.5 (2026-07-11)
 * CHANGED: Show OS-specific copy hotkey hint (Cmd+c on Mac, Ctrl+c on others) (#1506)

--- a/js/privatebin.js
+++ b/js/privatebin.js
@@ -1311,8 +1311,8 @@ window.PrivateBin = (function () {
             try {
                 return await decompress(plaintext, spec[7], zlib);
             } catch (err) {
-                Alert.showError(err);
-                return err;
+                console.error(err);
+                throw err;
             }
         };
 
@@ -5595,6 +5595,7 @@ window.PrivateBin = (function () {
                 .catch((err) => {
                     // wait for the user to type in the password,
                     // then PasteDecrypter.run will be called again
+                    Alert.hideLoading();
                     Alert.showError(err);
                 });
         };
@@ -6154,5 +6155,4 @@ if (typeof module === 'undefined' || !module.exports) {
         window.PrivateBin.Controller.init();
     });
 }
-
 

--- a/js/test/CryptTool.js
+++ b/js/test/CryptTool.js
@@ -122,6 +122,44 @@ conseq_or_bottom inv (interp (nth_iterate sBody n) (MemElem mem))
             ),
             {numRuns: 3});
         });
+
+        it('rejects decompression failures', async function () {
+            const clean = globalThis.cleanup();
+            Object.defineProperty(window, 'crypto', {
+                value: new WebCrypto(),
+                configurable: true,
+                enumerable: true,
+                writable: false
+            });
+            PrivateBin.Controller.initZlib();
+            global.atob = common.atob;
+            global.btoa = common.btoa;
+
+            const cipherMessage = await PrivateBin.CryptTool.cipher(
+                    'key', 'password', 'message', []
+                ),
+                runtimeZlib = await global.zlib,
+                originalInflate = runtimeZlib.inflate,
+                originalConsoleError = console.error;
+            runtimeZlib.inflate = function () {
+                throw new Error('forced decompression failure');
+            };
+            PrivateBin.Alert.showError = function () {};
+            console.error = function () {};
+
+            try {
+                await assert.rejects(
+                    PrivateBin.CryptTool.decipher(
+                        'key', 'password', cipherMessage
+                    ),
+                    /forced decompression failure/
+                );
+            } finally {
+                runtimeZlib.inflate = originalInflate;
+                console.error = originalConsoleError;
+                clean();
+            }
+        });
     });
 
     describe('getSymmetricKey', function () {

--- a/js/test/PasteDecrypter.js
+++ b/js/test/PasteDecrypter.js
@@ -1,0 +1,51 @@
+'use strict';
+require('../common');
+
+describe('PasteDecrypter', function () {
+    it('stops loading after a decryption failure', async function () {
+        const clean = globalThis.cleanup();
+        const expectedError = new Error('decryption failed');
+        let loadingHidden = false,
+            shownError;
+
+        PrivateBin.Alert.hideMessages = function () {};
+        PrivateBin.Alert.setCustomHandler = function () {};
+        PrivateBin.Alert.showLoading = function () {};
+        PrivateBin.Alert.hideLoading = function () {
+            loadingHidden = true;
+        };
+        PrivateBin.Alert.showError = function (error) {
+            shownError = error;
+        };
+        PrivateBin.Model.getPasteKey = function () {
+            return 'key';
+        };
+        PrivateBin.Prompt.getPassword = function () {
+            return '';
+        };
+        PrivateBin.TopNav.setRetryCallback = function () {};
+        PrivateBin.AttachmentViewer.removeAttachment = function () {};
+        PrivateBin.PasteStatus.showRemainingTime = function () {};
+        PrivateBin.CopyToClipboard.showKeyboardShortcutHint = function () {};
+        PrivateBin.CryptTool.decipher = async function () {
+            throw expectedError;
+        };
+
+        try {
+            PrivateBin.PasteDecrypter.run({
+                getCipherData: function () {
+                    return [];
+                },
+                isDiscussionEnabled: function () {
+                    return false;
+                }
+            });
+            await new Promise(resolve => setTimeout(resolve, 0));
+
+            assert.strictEqual(shownError, expectedError);
+            assert.strictEqual(loadingHidden, true);
+        } finally {
+            clean();
+        }
+    });
+});

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -120,7 +120,7 @@ class Configuration
             'js/kjua-0.10.0.js'      => 'sha512-BYj4xggowR7QD150VLSTRlzH62YPfhpIM+b/1EUEr7RQpdWAGKulxWnOvjFx1FUlba4m6ihpNYuQab51H6XlYg==',
             'js/legacy.js'           => 'sha512-pRofxsrf5UItjiP22Dcjh3FAcBjF/n7h8U9/W5xqJk17U0N2U1oajhXypq/omo9jhwS1iVGOhWrRepoPeFns+w==',
             'js/prettify.js'         => 'sha512-puO0Ogy++IoA2Pb9IjSxV1n4+kQkKXYAEUtVzfZpQepyDPyXk8hokiYDS7ybMogYlyyEIwMLpZqVhCkARQWLMg==',
-            'js/privatebin.js'       => 'sha512-ah/QdETig/ovH1QPl9Ne+T3VvaP7Bj4Rd9Or9wqQgo5BHge9o02MxAlRGXUZpKviy/27OSzHgz2PwpnH/B2RZg==',
+            'js/privatebin.js'       => 'sha512-0iCpu+30FeVj7Gb6XgQv/wSaANQbGrqAXsNPH17SYz8ONVSRiTfwkZFkrsFtsHXXNoUY8fAD7u9g6yir+DcqCQ==',
             'js/purify-3.4.12.js'    => 'sha512-Akf6HnAJZm0sWWWI4gp2GYff0NDnHUB02XJE5S7Hdq/Z5xtMjkuFacsDA8ZtViv1gi+onBxMhEMIaGyQeGxBng==',
             'js/showdown-2.1.0.js'   => 'sha512-WYXZgkTR0u/Y9SVIA4nTTOih0kXMEd8RRV6MLFdL6YU8ymhR528NLlYQt1nlJQbYz4EW+ZsS0fx1awhiQJme1Q==',
             'js/zlib-1.3.2.js'       => 'sha512-RAhJgxg9siMIA8ky4c10Rc2zUgnK80olHB8Tt1IOYWY4Eh1WmrviQkDn+sgBlb38ZHq3tzufGC41kP360gmosQ==',


### PR DESCRIPTION
## Summary

- reject decompression failures instead of returning an `Error` object as plaintext
- preserve the original inflate error for the controller
- clear the loading indicator when paste decryption rejects
- add regressions for both the cryptographic boundary and UI cleanup

## Reproduction

When authenticated decryption succeeds but zlib inflation fails, `CryptTool.decipher()` currently catches the failure, displays it, and returns the `Error` object. The paste controller then treats that object as plaintext, attempts `JSON.parse()`, reports a secondary parse error, and leaves the loading indicator active.

The regression creates a valid encrypted message, forces the runtime inflater to fail during decryption, and verifies that the original error rejects. A controller-level regression verifies that any rejected decryption clears the loading state before displaying the error.

## Testing

- focused decompression and `PasteDecrypter` regressions (2 passing)
- `npm run lint`
- `npm test -- --reporter dot` (128 passing)
- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit --filter '/^(?!.*ServerSaltTest)/'` (266 tests, 6505 assertions)
- recomputed and verified the `js/privatebin.js` SHA-512 SRI hash

## Security and compatibility

Successful paste and comment decryption is unchanged. Only an already-failed decompression path changes: callers now receive the original rejection rather than a non-string pseudo-plaintext value. No ciphertext, key, password, network, or storage behavior is modified.

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.
