### PR TITLE
Show confirmation dialogs without Bootstrap JavaScript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * FIXED: Gracefully handle YOURLS replies with a 200 status code but no shorturl, instead of raising a TypeError
 * FIXED: Return "Invalid data." instead of HTTP 500 on malformed v2 JSON payloads (#1883)
 * FIXED: Dead PATH validation guard in Controller, the check for a missing trailing directory separator never ran (#1887)
+* FIXED: Password and load-confirmation modals work without Bootstrap JavaScript
 
 ## 2.0.5 (2026-07-11)
 * CHANGED: Show OS-specific copy hotkey hint (Cmd+c on Mac, Ctrl+c on others) (#1506)

--- a/js/privatebin.js
+++ b/js/privatebin.js
@@ -2174,6 +2174,9 @@ window.PrivateBin = (function () {
         let passwordDecrypt,
             passwordModal,
             bootstrap5PasswordModal = null,
+            loadConfirmOpenHandler = null,
+            loadConfirmCloseHandler = null,
+            loadConfirmShownHandler = null,
             password = '';
 
         /**
@@ -2211,24 +2214,52 @@ window.PrivateBin = (function () {
          */
         me.requestLoadConfirmation = function () {
             const loadconfirmmodal = document.getElementById('loadconfirmmodal');
+            const loadconfirmOpenNow = loadconfirmmodal.querySelector('#loadconfirm-open-now'),
+                loadconfirmClose = loadconfirmmodal.querySelector('.btn-close'),
+                hasBootstrapModal = typeof bootstrap !== 'undefined' &&
+                    bootstrap.Tooltip && typeof bootstrap.Modal === 'function',
+                hideFallbackModal = function () {
+                    loadconfirmmodal.classList.remove('show');
+                    loadconfirmmodal.style.display = 'none';
+                };
 
-            const loadconfirmOpenNow = loadconfirmmodal.querySelector('#loadconfirm-open-now');
-            loadconfirmOpenNow.removeEventListener('click', PasteDecrypter.run);
-            loadconfirmOpenNow.addEventListener('click', PasteDecrypter.run);
+            if (loadConfirmOpenHandler !== null) {
+                loadconfirmOpenNow.removeEventListener('click', loadConfirmOpenHandler);
+            }
+            loadConfirmOpenHandler = function (event) {
+                if (!hasBootstrapModal) {
+                    hideFallbackModal();
+                }
+                PasteDecrypter.run(event);
+            };
+            loadconfirmOpenNow.addEventListener('click', loadConfirmOpenHandler);
 
-            const loadconfirmClose = loadconfirmmodal.querySelector('.btn-close');
-            loadconfirmClose.removeEventListener('click', Controller.newPaste);
-            loadconfirmClose.addEventListener('click', Controller.newPaste);
+            if (loadConfirmCloseHandler !== null) {
+                loadconfirmClose.removeEventListener('click', loadConfirmCloseHandler);
+            }
+            loadConfirmCloseHandler = function (event) {
+                if (!hasBootstrapModal) {
+                    hideFallbackModal();
+                }
+                Controller.newPaste(event);
+            };
+            loadconfirmClose.addEventListener('click', loadConfirmCloseHandler);
 
-            loadconfirmmodal.addEventListener('shown.bs.modal', () => {
+            if (loadConfirmShownHandler !== null) {
+                loadconfirmmodal.removeEventListener('shown.bs.modal', loadConfirmShownHandler);
+            }
+            loadConfirmShownHandler = () => {
                 loadconfirmOpenNow.focus();
-            });
+            };
+            loadconfirmmodal.addEventListener('shown.bs.modal', loadConfirmShownHandler);
 
-            if (typeof bootstrap !== 'undefined' && bootstrap.Tooltip && typeof bootstrap.Modal === 'function') {
+            if (hasBootstrapModal) {
                 (new bootstrap.Modal(loadconfirmmodal)).show();
             } else {
                 // minimal fallback: make element visible
                 loadconfirmmodal.classList.add('show');
+                loadconfirmmodal.style.display = 'block';
+                loadconfirmOpenNow.focus();
             }
         };
 
@@ -2243,6 +2274,10 @@ window.PrivateBin = (function () {
             if (passwordModal !== null) {
                 if (bootstrap5PasswordModal) {
                     bootstrap5PasswordModal.show();
+                } else {
+                    passwordModal.classList.add('show');
+                    passwordModal.style.display = 'block';
+                    passwordDecrypt.focus();
                 }
                 return;
             }
@@ -6154,5 +6189,4 @@ if (typeof module === 'undefined' || !module.exports) {
         window.PrivateBin.Controller.init();
     });
 }
-
 

--- a/js/test/Prompt.js
+++ b/js/test/Prompt.js
@@ -3,6 +3,66 @@ require('../common');
 const fc = require('fast-check');
 
 describe('Prompt', function () {
+    describe('fallback modals without Bootstrap JavaScript', function () {
+        it('shows and hides the password prompt', function () {
+            const clean = globalThis.cleanup();
+            let decryptRuns = 0;
+            document.body.innerHTML =
+                '<div id="passwordmodal" class="modal fade" role="dialog">' +
+                    '<form id="passwordform">' +
+                        '<input id="passworddecrypt" type="password">' +
+                    '</form>' +
+                '</div>';
+            PrivateBin.PasteDecrypter.run = function () { ++decryptRuns; };
+
+            PrivateBin.Prompt.init();
+            PrivateBin.Prompt.requestPassword();
+
+            const modal = document.getElementById('passwordmodal');
+            assert.strictEqual(modal.style.display, 'block');
+            assert.ok(modal.classList.contains('show'));
+
+            document.getElementById('passwordform').dispatchEvent(
+                new Event('submit', {bubbles: true, cancelable: true})
+            );
+            assert.strictEqual(modal.style.display, 'none');
+            assert.ok(!modal.classList.contains('show'));
+            assert.strictEqual(decryptRuns, 1);
+            clean();
+        });
+
+        it('shows and dismisses the load confirmation prompt', function () {
+            const clean = globalThis.cleanup();
+            let decryptRuns = 0,
+                newPasteRuns = 0;
+            document.body.innerHTML =
+                '<div id="loadconfirmmodal" class="modal fade">' +
+                    '<button id="loadconfirm-open-now"></button>' +
+                    '<button class="btn-close"></button>' +
+                '</div>';
+            PrivateBin.PasteDecrypter.run = function () { ++decryptRuns; };
+            PrivateBin.Controller.newPaste = function () { ++newPasteRuns; };
+
+            PrivateBin.Prompt.requestLoadConfirmation();
+            PrivateBin.Prompt.requestLoadConfirmation();
+
+            const modal = document.getElementById('loadconfirmmodal');
+            assert.strictEqual(modal.style.display, 'block');
+            assert.ok(modal.classList.contains('show'));
+
+            document.getElementById('loadconfirm-open-now').click();
+            assert.strictEqual(modal.style.display, 'none');
+            assert.ok(!modal.classList.contains('show'));
+            assert.strictEqual(decryptRuns, 1);
+
+            PrivateBin.Prompt.requestLoadConfirmation();
+            document.querySelector('#loadconfirmmodal .btn-close').click();
+            assert.strictEqual(modal.style.display, 'none');
+            assert.strictEqual(newPasteRuns, 1);
+            clean();
+        });
+    });
+
     describe('requestPassword & getPassword', function () {
         this.timeout(30000);
 
@@ -12,6 +72,7 @@ describe('Prompt', function () {
                 function (password) {
                     password = password.replace(/\r+|\n+/g, '');
                     const clean = globalThis.cleanup('', {url: 'ftp://example.com/?0000000000000000'});
+                    PrivateBin.PasteDecrypter.run = function () {};
                     document.body.innerHTML = `
                         <div id="passwordmodal" class="modal fade" role="dialog">
                             <div class="modal-dialog">

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -120,7 +120,7 @@ class Configuration
             'js/kjua-0.10.0.js'      => 'sha512-BYj4xggowR7QD150VLSTRlzH62YPfhpIM+b/1EUEr7RQpdWAGKulxWnOvjFx1FUlba4m6ihpNYuQab51H6XlYg==',
             'js/legacy.js'           => 'sha512-pRofxsrf5UItjiP22Dcjh3FAcBjF/n7h8U9/W5xqJk17U0N2U1oajhXypq/omo9jhwS1iVGOhWrRepoPeFns+w==',
             'js/prettify.js'         => 'sha512-puO0Ogy++IoA2Pb9IjSxV1n4+kQkKXYAEUtVzfZpQepyDPyXk8hokiYDS7ybMogYlyyEIwMLpZqVhCkARQWLMg==',
-            'js/privatebin.js'       => 'sha512-ah/QdETig/ovH1QPl9Ne+T3VvaP7Bj4Rd9Or9wqQgo5BHge9o02MxAlRGXUZpKviy/27OSzHgz2PwpnH/B2RZg==',
+            'js/privatebin.js'       => 'sha512-MI13MS6h+lXbOsSQD1yXhMPMkS+ZSGUzc80bOgWEG7KybNOnFOl7rxFxIRVd7l9TuneakB2Hbu7nTQf9RE3Lpw==',
             'js/purify-3.4.12.js'    => 'sha512-Akf6HnAJZm0sWWWI4gp2GYff0NDnHUB02XJE5S7Hdq/Z5xtMjkuFacsDA8ZtViv1gi+onBxMhEMIaGyQeGxBng==',
             'js/showdown-2.1.0.js'   => 'sha512-WYXZgkTR0u/Y9SVIA4nTTOih0kXMEd8RRV6MLFdL6YU8ymhR528NLlYQt1nlJQbYz4EW+ZsS0fx1awhiQJme1Q==',
             'js/zlib-1.3.2.js'       => 'sha512-RAhJgxg9siMIA8ky4c10Rc2zUgnK80olHB8Tt1IOYWY4Eh1WmrviQkDn+sgBlb38ZHq3tzufGC41kP360gmosQ==',


### PR DESCRIPTION
## Summary

- make password prompts visible when Bootstrap JavaScript is unavailable
- complete the existing load-confirmation fallback by setting the required display state
- hide fallback dialogs after either action
- replace repeated confirmation handlers instead of accumulating them
- focus the password input or primary confirmation action when shown

## Reproduction

If `privatebin.js` loads but Bootstrap JavaScript does not:

- `Prompt.requestPassword()` leaves the password modal hidden, so an encrypted paste cannot be opened
- `Prompt.requestLoadConfirmation()` adds `.show`, but Bootstrap CSS still keeps `.modal` at `display: none`, so a burn-after-reading confirmation cannot be accepted

The existing submit path already supports hiding a non-Bootstrap password modal. This completes that graceful-degradation path for showing both dialogs and dismissing the load confirmation.

## Testing

- `node_modules/.bin/mocha test/Prompt.js --reporter spec` (3 passing)
- `npm run lint`
- `npm test -- --reporter dot` (128 passing)
- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit --filter '/^(?!.*ServerSaltTest)/'` (266 tests, 6505 assertions)
- recomputed and verified the `js/privatebin.js` SHA-512 SRI hash

## Accessibility, privacy, and compatibility

Fallback dialogs focus the same primary input/action expected from the Bootstrap modal lifecycle. Passwords remain browser-local and no network, encryption, or storage behavior changes. The normal Bootstrap path remains unchanged.

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.
