### PR TITLE
Update discussion avatar titles after translations load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 * FIXED: Gracefully handle YOURLS replies with a 200 status code but no shorturl, instead of raising a TypeError
 * FIXED: Return "Invalid data." instead of HTTP 500 on malformed v2 JSON payloads (#1883)
 * FIXED: Dead PATH validation guard in Controller, the check for a missing trailing directory separator never ran (#1887)
+* FIXED: Release deferred translation listeners after the pending language loads
+* FIXED: Add descriptive titles to discussion avatars in the active language
 
 ## 2.0.5 (2026-07-11)
 * CHANGED: Show OS-specific copy hotkey hint (Cmd+c on Mac, Ctrl+c on others) (#1506)

--- a/js/privatebin.js
+++ b/js/privatebin.js
@@ -43,6 +43,14 @@ function draghover(element) {
 window.PrivateBin = (function () {
 
     /**
+     * event dispatched after an asynchronous language load
+     *
+     * @private
+     * @readonly
+     */
+    const languageLoadedEvent = 'languageLoaded';
+
+    /**
      * zlib library interface
      *
      * @private
@@ -650,16 +658,6 @@ window.PrivateBin = (function () {
         const me = {};
 
         /**
-         * const for string of loaded language
-         *
-         * @name I18n.languageLoadedEvent
-         * @private
-         * @prop   {string}
-         * @readonly
-         */
-        const languageLoadedEvent = 'languageLoaded';
-
-        /**
          * supported languages, minus the built in 'en'
          *
          * @name I18n.supportedLanguages
@@ -758,7 +756,7 @@ window.PrivateBin = (function () {
                     document.addEventListener(languageLoadedEvent, function () {
                         // re-execute this function
                         me.translate.apply(this, orgArguments);
-                    });
+                    }, {once: true});
 
                     // and fall back to English for now until the real language
                     // file is loaded
@@ -3623,8 +3621,15 @@ window.PrivateBin = (function () {
             const icon = comment.getIcon();
             if (icon) {
                 const image = document.createElement('img');
+                const updateImageTitle = function () {
+                    image.setAttribute('title', I18n._('Avatar generated from IP address'));
+                };
                 image.setAttribute('src', icon);
                 image.setAttribute('class', 'vizhash');
+                updateImageTitle();
+                if (I18n.getLanguage() === null) {
+                    document.addEventListener(languageLoadedEvent, updateImageTitle, {once: true});
+                }
                 const nickSpan = commentEntry.querySelector('span.nickname');
                 if (nickSpan) {
                     nickSpan.prepend(' ');
@@ -5518,15 +5523,6 @@ window.PrivateBin = (function () {
                     );
                 }
 
-                document.addEventListener(I18n.languageLoadedEvent, function () {
-                    const commentContainer = document.getElementById('commentcontainer');
-                    if (!commentContainer) {
-                        return;
-                    }
-
-                    commentContainer.querySelectorAll('img.vizhash')
-                        .forEach(img => img.setAttribute('title', I18n._('Avatar generated from IP address')));
-                });
             });
         }
 
@@ -6154,5 +6150,4 @@ if (typeof module === 'undefined' || !module.exports) {
         window.PrivateBin.Controller.init();
     });
 }
-
 

--- a/js/test/DiscussionViewer.js
+++ b/js/test/DiscussionViewer.js
@@ -6,6 +6,48 @@ describe('DiscussionViewer', function () {
     describe('handleNotification, prepareNewDiscussion, addComment, finishDiscussion, getReplyMessage, getReplyNickname, getReplyCommentId & highlightComment', function () {
         this.timeout(30000);
 
+        it('adds and refreshes descriptive avatar titles once', () => {
+            const clean = globalThis.cleanup();
+            document.body.innerHTML =
+                '<div id="discussion"><div id="commentcontainer"></div></div>' +
+                '<div id="templates">' +
+                    '<article id="commenttemplate" class="comment">' +
+                        '<span class="nickname"></span>' +
+                        '<span class="commentdate"></span>' +
+                        '<div class="commentdata"></div>' +
+                        '<button>Reply</button>' +
+                    '</article>' +
+                '</div>';
+            const comment = {
+                id: 'avatar',
+                parentid: '',
+                getCreated: function () { return 0; },
+                getIcon: function () { return 'data:image/png;base64,AA=='; }
+            };
+
+            PrivateBin.Model.reset();
+            PrivateBin.Model.init();
+            PrivateBin.DiscussionViewer.init();
+            PrivateBin.I18n.reset();
+            PrivateBin.DiscussionViewer.addComment(comment, 'text', 'nickname');
+
+            const image = document.querySelector('img.vizhash');
+            assert.strictEqual(image.getAttribute('title'), 'Avatar generated from IP address');
+
+            PrivateBin.I18n.reset('de', {
+                'Avatar generated from IP address': 'Aus IP-Adresse erzeugter Avatar'
+            });
+            document.dispatchEvent(new CustomEvent('languageLoaded'));
+            assert.strictEqual(image.getAttribute('title'), 'Aus IP-Adresse erzeugter Avatar');
+
+            image.setAttribute('title', 'unchanged');
+            document.dispatchEvent(new CustomEvent('languageLoaded'));
+            assert.strictEqual(image.getAttribute('title'), 'unchanged');
+
+            PrivateBin.I18n.reset();
+            clean();
+        });
+
         it('displays & hides comments as requested', () => {
             fc.assert(fc.property(
                 fc.array(

--- a/js/test/I18n.js
+++ b/js/test/I18n.js
@@ -9,6 +9,25 @@ describe('I18n', function () {
             PrivateBin.I18n.reset();
         });
 
+        it('updates elements only for the pending language load', () => {
+            const clean = globalThis.cleanup();
+            document.body.innerHTML = '<div id="i18n"></div>';
+            const element = document.getElementById('i18n');
+
+            PrivateBin.I18n.reset();
+            PrivateBin.I18n.translate(element, 'Never');
+            PrivateBin.I18n.reset('de', {'Never': 'Niemals'});
+            document.dispatchEvent(new CustomEvent('languageLoaded'));
+            assert.strictEqual(element.textContent, 'Niemals');
+
+            element.textContent = 'unchanged';
+            document.dispatchEvent(new CustomEvent('languageLoaded'));
+            assert.strictEqual(element.textContent, 'unchanged');
+
+            PrivateBin.I18n.reset();
+            clean();
+        });
+
         it('returns message ID unchanged if no translation found', () => {
             fc.assert(fc.property(
                 fc.string(),

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -120,7 +120,7 @@ class Configuration
             'js/kjua-0.10.0.js'      => 'sha512-BYj4xggowR7QD150VLSTRlzH62YPfhpIM+b/1EUEr7RQpdWAGKulxWnOvjFx1FUlba4m6ihpNYuQab51H6XlYg==',
             'js/legacy.js'           => 'sha512-pRofxsrf5UItjiP22Dcjh3FAcBjF/n7h8U9/W5xqJk17U0N2U1oajhXypq/omo9jhwS1iVGOhWrRepoPeFns+w==',
             'js/prettify.js'         => 'sha512-puO0Ogy++IoA2Pb9IjSxV1n4+kQkKXYAEUtVzfZpQepyDPyXk8hokiYDS7ybMogYlyyEIwMLpZqVhCkARQWLMg==',
-            'js/privatebin.js'       => 'sha512-ah/QdETig/ovH1QPl9Ne+T3VvaP7Bj4Rd9Or9wqQgo5BHge9o02MxAlRGXUZpKviy/27OSzHgz2PwpnH/B2RZg==',
+            'js/privatebin.js'       => 'sha512-qqozwISNV4rR9qr546tWcG+ZHauJTylvAyV4WBd4g8PvH1/WeU4AYiHlgUanWFtJ7W8qOWreW9yttX0CRiGe2w==',
             'js/purify-3.4.12.js'    => 'sha512-Akf6HnAJZm0sWWWI4gp2GYff0NDnHUB02XJE5S7Hdq/Z5xtMjkuFacsDA8ZtViv1gi+onBxMhEMIaGyQeGxBng==',
             'js/showdown-2.1.0.js'   => 'sha512-WYXZgkTR0u/Y9SVIA4nTTOih0kXMEd8RRV6MLFdL6YU8ymhR528NLlYQt1nlJQbYz4EW+ZsS0fx1awhiQJme1Q==',
             'js/zlib-1.3.2.js'       => 'sha512-RAhJgxg9siMIA8ky4c10Rc2zUgnK80olHB8Tt1IOYWY4Eh1WmrviQkDn+sgBlb38ZHq3tzufGC41kP360gmosQ==',


### PR DESCRIPTION
## Summary

- share the internal language-loaded event with discussion rendering
- add the intended descriptive title when a discussion avatar is created
- refresh that title if the selected catalog is still loading
- release deferred element and avatar translation listeners after the pending load
- remove the post-decryption listener that used an undefined event-name property

## Reproduction

Discussion avatar images currently receive no descriptive title:

- if the catalog already loaded before comments render, the later listener misses the event
- if comments render first, the listener is registered using `I18n.languageLoadedEvent`, which is undefined because the event constant is private to the I18n closure

Deferred element translations also retain their listeners after the pending catalog completes, keeping stale elements reachable and rerunning them on later events.

## Testing

- focused deferred-element and discussion-avatar regressions (2 passing)
- `npm run lint`
- `npm test -- --reporter dot` (128 passing)
- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit --filter '/^(?!.*ServerSaltTest)/'` (266 tests, 6505 assertions)
- recomputed and verified the `js/privatebin.js` SHA-512 SRI hash

## Accessibility, privacy, and compatibility

The patch restores the existing localized avatar description and updates it once when a pending catalog arrives. It does not expose the IP address or alter avatar generation, encryption, network requests, or stored data.

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.
