### PR TITLE
Settle deferred translations after catalog failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * FIXED: Gracefully handle YOURLS replies with a 200 status code but no shorturl, instead of raising a TypeError
 * FIXED: Return "Invalid data." instead of HTTP 500 on malformed v2 JSON payloads (#1883)
 * FIXED: Dead PATH validation guard in Controller, the check for a missing trailing directory separator never ran (#1887)
+* FIXED: Settle deferred translations when a language download fails
 
 ## 2.0.5 (2026-07-11)
 * CHANGED: Show OS-specific copy hotkey hint (Cmd+c on Mac, Ctrl+c on others) (#1506)

--- a/js/privatebin.js
+++ b/js/privatebin.js
@@ -935,6 +935,7 @@ window.PrivateBin = (function () {
                 .catch(error => {
                     console.error(`Language \'${newLanguage}\' could not be loaded (${error.message}). Translation failed, fallback to English.`);
                     language = 'en';
+                    document.dispatchEvent(new CustomEvent(languageLoadedEvent));
                 });
         };
 
@@ -6154,5 +6155,3 @@ if (typeof module === 'undefined' || !module.exports) {
         window.PrivateBin.Controller.init();
     });
 }
-
-

--- a/js/test/I18n.js
+++ b/js/test/I18n.js
@@ -238,5 +238,45 @@ describe('I18n', function () {
             clean();
             return 'Never' === result && 'Never' === alias;
         });
+
+        it('settles deferred translations when a language download fails', async () => {
+            const clean = globalThis.cleanup();
+            const originalFetch = global.fetch;
+            const originalConsoleError = console.error;
+            const originalGetCookie = PrivateBin.Helper.getCookie;
+            let completionEvents = 0;
+            const countCompletion = function () {
+                ++completionEvents;
+            };
+            document.body.innerHTML = '<div id="translated"></div>';
+            const translated = document.getElementById('translated');
+            PrivateBin.Helper.getCookie = function () {
+                return 'de';
+            };
+            global.fetch = function () {
+                return Promise.reject(new Error('download failed'));
+            };
+            console.error = function () {};
+            document.addEventListener('languageLoaded', countCompletion);
+
+            try {
+                PrivateBin.I18n.reset();
+                PrivateBin.I18n.translate(translated, 'Never');
+                translated.textContent = 'waiting';
+                PrivateBin.I18n.loadTranslations();
+                await new Promise(resolve => setImmediate(resolve));
+
+                assert.strictEqual(PrivateBin.I18n.getLanguage(), 'en');
+                assert.strictEqual(completionEvents, 1);
+                assert.strictEqual(translated.textContent, 'Never');
+            } finally {
+                document.removeEventListener('languageLoaded', countCompletion);
+                global.fetch = originalFetch;
+                console.error = originalConsoleError;
+                PrivateBin.Helper.getCookie = originalGetCookie;
+                PrivateBin.I18n.reset();
+                clean();
+            }
+        });
     });
 });

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -120,7 +120,7 @@ class Configuration
             'js/kjua-0.10.0.js'      => 'sha512-BYj4xggowR7QD150VLSTRlzH62YPfhpIM+b/1EUEr7RQpdWAGKulxWnOvjFx1FUlba4m6ihpNYuQab51H6XlYg==',
             'js/legacy.js'           => 'sha512-pRofxsrf5UItjiP22Dcjh3FAcBjF/n7h8U9/W5xqJk17U0N2U1oajhXypq/omo9jhwS1iVGOhWrRepoPeFns+w==',
             'js/prettify.js'         => 'sha512-puO0Ogy++IoA2Pb9IjSxV1n4+kQkKXYAEUtVzfZpQepyDPyXk8hokiYDS7ybMogYlyyEIwMLpZqVhCkARQWLMg==',
-            'js/privatebin.js'       => 'sha512-ah/QdETig/ovH1QPl9Ne+T3VvaP7Bj4Rd9Or9wqQgo5BHge9o02MxAlRGXUZpKviy/27OSzHgz2PwpnH/B2RZg==',
+            'js/privatebin.js'       => 'sha512-T1Qv1GobDzQAHhzo2Rw8uqXdn1Oa6+6UPSG/Ng9b6gVclKm1mb05UWP30AsaeAStXya9flF19BXrfRsjWjn5cA==',
             'js/purify-3.4.12.js'    => 'sha512-Akf6HnAJZm0sWWWI4gp2GYff0NDnHUB02XJE5S7Hdq/Z5xtMjkuFacsDA8ZtViv1gi+onBxMhEMIaGyQeGxBng==',
             'js/showdown-2.1.0.js'   => 'sha512-WYXZgkTR0u/Y9SVIA4nTTOih0kXMEd8RRV6MLFdL6YU8ymhR528NLlYQt1nlJQbYz4EW+ZsS0fx1awhiQJme1Q==',
             'js/zlib-1.3.2.js'       => 'sha512-RAhJgxg9siMIA8ky4c10Rc2zUgnK80olHB8Tt1IOYWY4Eh1WmrviQkDn+sgBlb38ZHq3tzufGC41kP360gmosQ==',


### PR DESCRIPTION
## Summary

- emit language-load completion after a catalog request fails
- let elements deferred during loading settle to the existing English fallback
- add a deterministic rejected-fetch regression

## Reproduction

1. Select a supported non-English language.
2. Render an element while its catalog request is pending.
3. Let the catalog request fail.

I18n switches its internal language to English, but it never dispatches the completion event. Deferred elements remain subscribed and never complete their fallback update.

The regression deliberately changes a deferred element to `waiting` after its initial render. Without the fix, the request failure emits zero completion events and the element stays `waiting`; with the fix, one event is emitted and the element settles to `Never`.

## Testing

- focused rejected-catalog regression (1 passing)
- `npm run lint`
- `npm test -- --reporter dot` (127 passing)
- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit --filter '/^(?!.*ServerSaltTest)/'` (266 tests, 6505 assertions)
- recomputed and verified the `js/privatebin.js` SHA-512 SRI hash

## Privacy and compatibility

The existing English fallback and catalog request behavior are unchanged. The patch only signals that the asynchronous load attempt completed, allowing existing deferred rendering to finish; it adds no requests and exposes no user data.

This is complementary to #1955, which makes shipped catalogs selectable, but does not cover catalog transport failures.

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.
