### PR TITLE
Keep callback errors from changing server results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * FIXED: Gracefully handle YOURLS replies with a 200 status code but no shorturl, instead of raising a TypeError
 * FIXED: Return "Invalid data." instead of HTTP 500 on malformed v2 JSON payloads (#1883)
 * FIXED: Dead PATH validation guard in Controller, the check for a missing trailing directory separator never ran (#1887)
+* FIXED: Keep UI callback errors from changing server request results
 
 ## 2.0.5 (2026-07-11)
 * CHANGED: Show OS-specific copy hotkey hint (Cmd+c on Mac, Ctrl+c on others) (#1506)

--- a/js/privatebin.js
+++ b/js/privatebin.js
@@ -4894,7 +4894,11 @@ window.PrivateBin = (function () {
             if (successFunc !== null) {
                 // add useful data to result
                 result.encryptionKey = symmetricKey;
-                successFunc(status, result);
+                try {
+                    successFunc(status, result);
+                } catch (error) {
+                    console.error('Server success callback failed:', error);
+                }
             }
         }
 
@@ -4909,7 +4913,11 @@ window.PrivateBin = (function () {
          */
         function fail(status, result) {
             if (failureFunc !== null) {
-                failureFunc(status, result);
+                try {
+                    failureFunc(status, result);
+                } catch (error) {
+                    console.error('Server failure callback failed:', error);
+                }
             }
         }
 
@@ -6154,5 +6162,4 @@ if (typeof module === 'undefined' || !module.exports) {
         window.PrivateBin.Controller.init();
     });
 }
-
 

--- a/js/test/ServerInteraction.js
+++ b/js/test/ServerInteraction.js
@@ -3,6 +3,76 @@ const common = require('../common');
 const fc = require('fast-check');
 
 describe('ServerInteraction', function () {
+    describe('run callbacks', function () {
+        let clean,
+            originalFetch,
+            originalConsoleError;
+
+        beforeEach(function () {
+            clean = globalThis.cleanup();
+            originalFetch = global.fetch;
+            originalConsoleError = console.error;
+            console.error = function () {};
+        });
+
+        afterEach(function () {
+            global.fetch = originalFetch;
+            console.error = originalConsoleError;
+            clean();
+        });
+
+        it('does not reclassify success callback errors as server failures', async function () {
+            let successCalls = 0,
+                failureCalls = 0;
+            global.fetch = async function () {
+                return {
+                    ok: true,
+                    json: async function () {
+                        return {status: 0};
+                    }
+                };
+            };
+            PrivateBin.ServerInteraction.prepare();
+            PrivateBin.ServerInteraction.setSuccess(function () {
+                ++successCalls;
+                throw new Error('render failed');
+            });
+            PrivateBin.ServerInteraction.setFailure(function () {
+                ++failureCalls;
+            });
+
+            PrivateBin.ServerInteraction.run();
+            await new Promise(resolve => setImmediate(resolve));
+
+            assert.strictEqual(successCalls, 1);
+            assert.strictEqual(failureCalls, 0);
+        });
+
+        it('does not invoke a throwing failure callback twice', async function () {
+            let failureCalls = 0;
+            global.fetch = async function () {
+                return {
+                    ok: true,
+                    json: async function () {
+                        return {status: 1, message: 'rejected'};
+                    }
+                };
+            };
+            PrivateBin.ServerInteraction.prepare();
+            PrivateBin.ServerInteraction.setFailure(function () {
+                ++failureCalls;
+                if (failureCalls === 1) {
+                    throw new Error('error rendering failure');
+                }
+            });
+
+            PrivateBin.ServerInteraction.run();
+            await new Promise(resolve => setImmediate(resolve));
+
+            assert.strictEqual(failureCalls, 1);
+        });
+    });
+
     describe('prepare', function () {
         afterEach(async function () {
             // pause to let async functions conclude

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -120,7 +120,7 @@ class Configuration
             'js/kjua-0.10.0.js'      => 'sha512-BYj4xggowR7QD150VLSTRlzH62YPfhpIM+b/1EUEr7RQpdWAGKulxWnOvjFx1FUlba4m6ihpNYuQab51H6XlYg==',
             'js/legacy.js'           => 'sha512-pRofxsrf5UItjiP22Dcjh3FAcBjF/n7h8U9/W5xqJk17U0N2U1oajhXypq/omo9jhwS1iVGOhWrRepoPeFns+w==',
             'js/prettify.js'         => 'sha512-puO0Ogy++IoA2Pb9IjSxV1n4+kQkKXYAEUtVzfZpQepyDPyXk8hokiYDS7ybMogYlyyEIwMLpZqVhCkARQWLMg==',
-            'js/privatebin.js'       => 'sha512-ah/QdETig/ovH1QPl9Ne+T3VvaP7Bj4Rd9Or9wqQgo5BHge9o02MxAlRGXUZpKviy/27OSzHgz2PwpnH/B2RZg==',
+            'js/privatebin.js'       => 'sha512-Mq6I4CEdxs7wTFSDh8wjm1cGWPKknCm4J/XZtErOCtLUhL1u1WLhHuxNkmPQDu18+H8tMALeKn3CLwsG2XNzVg==',
             'js/purify-3.4.12.js'    => 'sha512-Akf6HnAJZm0sWWWI4gp2GYff0NDnHUB02XJE5S7Hdq/Z5xtMjkuFacsDA8ZtViv1gi+onBxMhEMIaGyQeGxBng==',
             'js/showdown-2.1.0.js'   => 'sha512-WYXZgkTR0u/Y9SVIA4nTTOih0kXMEd8RRV6MLFdL6YU8ymhR528NLlYQt1nlJQbYz4EW+ZsS0fx1awhiQJme1Q==',
             'js/zlib-1.3.2.js'       => 'sha512-RAhJgxg9siMIA8ky4c10Rc2zUgnK80olHB8Tt1IOYWY4Eh1WmrviQkDn+sgBlb38ZHq3tzufGC41kP360gmosQ==',


### PR DESCRIPTION
## Summary

- contain exceptions thrown by ServerInteraction success callbacks
- contain exceptions thrown by failure callbacks
- log renderer/controller errors without reclassifying the server response
- add regressions for false failure delivery and duplicate failure delivery

## Reproduction

`ServerInteraction.run()` currently places response callbacks inside the same promise chain as fetch and JSON parsing.

- If a success callback throws after the server creates a paste, the trailing catch invokes the failure callback with `serverError`. The UI can report a failed creation and encourage a duplicate retry even though the first paste exists.
- If a failure callback throws while rendering an API rejection, the trailing catch invokes that same callback a second time as a server error.

The callback boundary now logs those application errors locally. Fetch failures, non-OK responses, invalid JSON, and API status handling are unchanged.

## Testing

- focused callback-boundary regressions (2 passing)
- `npm run lint`
- `npm test -- --reporter dot` (128 passing)
- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit --filter '/^(?!.*ServerSaltTest)/'` (266 tests, 6505 assertions)
- recomputed and verified the `js/privatebin.js` SHA-512 SRI hash

## Compatibility and privacy

Callbacks receive the same status and response objects in the same order. Only exceptions thrown by those callbacks stop feeding back into request classification. No request data, encrypted content, keys, credentials, or storage behavior changes.

This is complementary to #1944, which keeps callbacks attached to their dispatched requests; this patch keeps callback exceptions from changing those request results.

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.
