### PR TITLE
Bind every password reveal button

### DIFF
--- a/js/privatebin.js
+++ b/js/privatebin.js
@@ -5822,11 +5822,10 @@ window.PrivateBin = (function () {
          * @function
          */
         me.init = function () {
-            const revealButton = document.querySelector('.toggle-password');
-            if (!revealButton) {
-                return;
-            }
-            revealButton.addEventListener('click', handleRevealButtonClick);
+            document.querySelectorAll('.toggle-password')
+                .forEach(revealButton => {
+                    revealButton.addEventListener('click', handleRevealButtonClick);
+                });
         };
 
         return me;
@@ -6154,5 +6153,3 @@ if (typeof module === 'undefined' || !module.exports) {
         window.PrivateBin.Controller.init();
     });
 }
-
-

--- a/js/test/PasswordPeek.js
+++ b/js/test/PasswordPeek.js
@@ -1,0 +1,34 @@
+'use strict';
+require('../common');
+
+describe('PasswordPeek', function () {
+    afterEach(() => {
+        globalThis.cleanup();
+    });
+
+    it('binds every password reveal button', function () {
+        document.body.innerHTML = `
+            <div class="input-group">
+                <input id="decrypt-password" class="input-password" type="password">
+                <button class="toggle-password" type="button" title="Show password">
+                    <svg><use href="#eye"></use></svg>
+                </button>
+            </div>
+            <div class="input-group">
+                <input id="create-password" class="input-password" type="password">
+                <button class="toggle-password" type="button" title="Show password">
+                    <svg><use href="#eye"></use></svg>
+                </button>
+            </div>
+        `;
+
+        PrivateBin.PasswordPeek.init();
+
+        const revealButtons = document.querySelectorAll('.toggle-password');
+        revealButtons[0].click();
+        revealButtons[1].click();
+
+        assert.strictEqual(document.getElementById('decrypt-password').type, 'text');
+        assert.strictEqual(document.getElementById('create-password').type, 'text');
+    });
+});

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -120,7 +120,7 @@ class Configuration
             'js/kjua-0.10.0.js'      => 'sha512-BYj4xggowR7QD150VLSTRlzH62YPfhpIM+b/1EUEr7RQpdWAGKulxWnOvjFx1FUlba4m6ihpNYuQab51H6XlYg==',
             'js/legacy.js'           => 'sha512-pRofxsrf5UItjiP22Dcjh3FAcBjF/n7h8U9/W5xqJk17U0N2U1oajhXypq/omo9jhwS1iVGOhWrRepoPeFns+w==',
             'js/prettify.js'         => 'sha512-puO0Ogy++IoA2Pb9IjSxV1n4+kQkKXYAEUtVzfZpQepyDPyXk8hokiYDS7ybMogYlyyEIwMLpZqVhCkARQWLMg==',
-            'js/privatebin.js'       => 'sha512-ah/QdETig/ovH1QPl9Ne+T3VvaP7Bj4Rd9Or9wqQgo5BHge9o02MxAlRGXUZpKviy/27OSzHgz2PwpnH/B2RZg==',
+            'js/privatebin.js'       => 'sha512-LA/cpybvFXCj+mvQj1riDfzjdg9DOzK5hvzU7zeel5IgsVN7UD2XLM3cHIyYe4TaehoE4uHrzs60z/BZKDoCNA==',
             'js/purify-3.4.12.js'    => 'sha512-Akf6HnAJZm0sWWWI4gp2GYff0NDnHUB02XJE5S7Hdq/Z5xtMjkuFacsDA8ZtViv1gi+onBxMhEMIaGyQeGxBng==',
             'js/showdown-2.1.0.js'   => 'sha512-WYXZgkTR0u/Y9SVIA4nTTOih0kXMEd8RRV6MLFdL6YU8ymhR528NLlYQt1nlJQbYz4EW+ZsS0fx1awhiQJme1Q==',
             'js/zlib-1.3.2.js'       => 'sha512-RAhJgxg9siMIA8ky4c10Rc2zUgnK80olHB8Tt1IOYWY4Eh1WmrviQkDn+sgBlb38ZHq3tzufGC41kP360gmosQ==',


### PR DESCRIPTION
## Summary

- initialize every password reveal control instead of only the first one in the document
- cover the decrypt-password and create-password controls with a regression test
- update the `privatebin.js` subresource-integrity hash

## Bug

The Bootstrap 5 template renders one password reveal button in the decrypt modal and another beside the new-paste password input. `PasswordPeek.init()` used `querySelector()`, so only the first button received a click handler and the new-paste reveal control was inert.

## Tests

- `npx mocha test/PasswordPeek.js` (1 passing; regression failed before the fix)
- `npm test -- --reporter dot` (127 passing)
- `npm run lint`
- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit --filter '/^(?!.*ServerSaltTest)/'` (266 tests, 6505 assertions)
- verified the configured SHA-512 integrity value matches `js/privatebin.js`

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.
