### PR TITLE
Match the deletion token query exactly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * FIXED: Gracefully handle YOURLS replies with a 200 status code but no shorturl, instead of raising a TypeError
 * FIXED: Return "Invalid data." instead of HTTP 500 on malformed v2 JSON payloads (#1883)
 * FIXED: Dead PATH validation guard in Controller, the check for a missing trailing directory separator never ran (#1887)
+* FIXED: Only treat an exact deletetoken query parameter as a deletion response
 
 ## 2.0.5 (2026-07-11)
 * CHANGED: Show OS-specific copy hotkey hint (Cmd+c on Mac, Ctrl+c on others) (#1506)

--- a/js/privatebin.js
+++ b/js/privatebin.js
@@ -1489,7 +1489,7 @@ window.PrivateBin = (function () {
          * @return {bool}
          */
         me.hasDeleteToken = function () {
-            return window.location.search.indexOf('deletetoken') !== -1;
+            return (new URL(window.location)).searchParams.has('deletetoken');
         };
 
         /**
@@ -6154,5 +6154,4 @@ if (typeof module === 'undefined' || !module.exports) {
         window.PrivateBin.Controller.init();
     });
 }
-
 

--- a/js/test/Model.js
+++ b/js/test/Model.js
@@ -124,6 +124,22 @@ describe('Model', function () {
         });
     });
 
+    describe('hasDeleteToken', function () {
+        it('only recognizes an exact query parameter name', () => {
+            const cases = [
+                ['https://example.com/?abcdefghijklmnop&deletetoken=secret', true],
+                ['https://example.com/?abcdefghijklmnop&redirect=deletetoken', false],
+                ['https://example.com/?abcdefghijklmnop&notdeletetoken=secret', false]
+            ];
+
+            cases.forEach(function (testCase) {
+                const clean = globalThis.cleanup('', {url: testCase[0]});
+                assert.strictEqual(PrivateBin.Model.hasDeleteToken(), testCase[1]);
+                clean();
+            });
+        });
+    });
+
     describe('getPasteKey', function () {
         this.timeout(30000);
         beforeEach(function () {
@@ -254,4 +270,3 @@ describe('Model', function () {
         });
     });
 });
-

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -120,7 +120,7 @@ class Configuration
             'js/kjua-0.10.0.js'      => 'sha512-BYj4xggowR7QD150VLSTRlzH62YPfhpIM+b/1EUEr7RQpdWAGKulxWnOvjFx1FUlba4m6ihpNYuQab51H6XlYg==',
             'js/legacy.js'           => 'sha512-pRofxsrf5UItjiP22Dcjh3FAcBjF/n7h8U9/W5xqJk17U0N2U1oajhXypq/omo9jhwS1iVGOhWrRepoPeFns+w==',
             'js/prettify.js'         => 'sha512-puO0Ogy++IoA2Pb9IjSxV1n4+kQkKXYAEUtVzfZpQepyDPyXk8hokiYDS7ybMogYlyyEIwMLpZqVhCkARQWLMg==',
-            'js/privatebin.js'       => 'sha512-ah/QdETig/ovH1QPl9Ne+T3VvaP7Bj4Rd9Or9wqQgo5BHge9o02MxAlRGXUZpKviy/27OSzHgz2PwpnH/B2RZg==',
+            'js/privatebin.js'       => 'sha512-Sxh60qX9Famu7J9aeVygqc3sMIE5pMxjykHKc27KsSxQhwZHx3y3EovlsGNoahLt1rPGm/YZ4ABchZdTd+LeMw==',
             'js/purify-3.4.12.js'    => 'sha512-Akf6HnAJZm0sWWWI4gp2GYff0NDnHUB02XJE5S7Hdq/Z5xtMjkuFacsDA8ZtViv1gi+onBxMhEMIaGyQeGxBng==',
             'js/showdown-2.1.0.js'   => 'sha512-WYXZgkTR0u/Y9SVIA4nTTOih0kXMEd8RRV6MLFdL6YU8ymhR528NLlYQt1nlJQbYz4EW+ZsS0fx1awhiQJme1Q==',
             'js/zlib-1.3.2.js'       => 'sha512-RAhJgxg9siMIA8ky4c10Rc2zUgnK80olHB8Tt1IOYWY4Eh1WmrviQkDn+sgBlb38ZHq3tzufGC41kP360gmosQ==',


### PR DESCRIPTION
## Summary

- detect deletion responses using an exact `deletetoken` query parameter
- add regression coverage for misleading parameter names and values
- update the changelog and `privatebin.js` subresource-integrity hash

## Bug

`Model.hasDeleteToken()` searched the raw query string for the substring `deletetoken`. URLs such as `?redirect=deletetoken` or `?notdeletetoken=secret` were therefore treated as successful deletion responses, causing controller initialization to return early instead of showing or creating a paste.

Using `URL.searchParams.has()` restricts that state to the actual parameter name while preserving valid deletion URLs.

## Tests

- `npx mocha test/Model.js` (11 passing)
- `npm test -- --reporter dot` (127 passing)
- `npm run lint`
- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit --filter '/^(?!.*ServerSaltTest)/'` (266 tests, 6505 assertions)
- verified the configured SHA-512 integrity value matches `js/privatebin.js`

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.
