### PR TITLE
Recover from cloned attachment retrieval errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 * FIXED: Gracefully handle YOURLS replies with a 200 status code but no shorturl, instead of raising a TypeError
 * FIXED: Return "Invalid data." instead of HTTP 500 on malformed v2 JSON payloads (#1883)
 * FIXED: Dead PATH validation guard in Controller, the check for a missing trailing directory separator never ran (#1887)
+* FIXED: Preserve cloned data URL attachments when creating a new document
+* FIXED: Restore the editor when a cloned blob attachment cannot be retrieved
 
 ## 2.0.5 (2026-07-11)
 * CHANGED: Show OS-specific copy hotkey hint (Cmd+c on Mac, Ctrl+c on others) (#1506)

--- a/js/privatebin.js
+++ b/js/privatebin.js
@@ -5324,50 +5324,57 @@ window.PrivateBin = (function () {
                 cipherMessage['attachment'] = attachments.map(attachment => attachment[0]);
                 cipherMessage['attachment_name'] = attachments.map(attachment => attachment[1]);
 
-                cipherMessage['attachment'] = await Promise.all(cipherMessage['attachment'].map(async (attachment, i) => {
-                    // we need to retrieve data from blob if browser already parsed it in memory
-                    if (typeof attachment === 'string' && attachment.startsWith('blob:')) {
-                        Alert.showStatus(
-                            [
-                                'Retrieving cloned file \'%s\' from memory...',
-                                cipherMessage['attachment_name'][i]
-                            ],
-                            'copy'
-                        );
-                        try {
-                            const response = await fetch(attachment, {
-                                method: 'GET',
-                                credentials: 'omit',
-                                signal: AbortSignal.timeout(10000)
-                            });
-                            if (!response.ok) {
-                                throw new Error('HTTP ' + response.status);
-                            }
-                            const blobData = await response.blob();
-                            if (blobData instanceof window.Blob) {
-                                const fileReading = new Promise(function (resolve, reject) {
-                                    const fileReader = new FileReader();
-                                    fileReader.onload = function (event) {
-                                        resolve(event.target.result);
-                                    };
-                                    fileReader.onerror = function (error) {
-                                        reject(error);
-                                    }
-                                    fileReader.readAsDataURL(blobData);
+                try {
+                    cipherMessage['attachment'] = await Promise.all(cipherMessage['attachment'].map(async (attachment, i) => {
+                        // we need to retrieve data from blob if browser already parsed it in memory
+                        if (typeof attachment === 'string' && attachment.startsWith('blob:')) {
+                            Alert.showStatus(
+                                [
+                                    'Retrieving cloned file \'%s\' from memory...',
+                                    cipherMessage['attachment_name'][i]
+                                ],
+                                'copy'
+                            );
+                            try {
+                                const response = await fetch(attachment, {
+                                    method: 'GET',
+                                    credentials: 'omit',
+                                    signal: AbortSignal.timeout(10000)
                                 });
+                                if (!response.ok) {
+                                    throw new Error('HTTP ' + response.status);
+                                }
+                                const blobData = await response.blob();
+                                if (blobData instanceof window.Blob) {
+                                    const fileReading = new Promise(function (resolve, reject) {
+                                        const fileReader = new FileReader();
+                                        fileReader.onload = function (event) {
+                                            resolve(event.target.result);
+                                        };
+                                        fileReader.onerror = function (error) {
+                                            reject(error);
+                                        }
+                                        fileReader.readAsDataURL(blobData);
+                                    });
 
-                                return await fileReading;
-                            } else {
-                                const error = 'Cannot process attachment data.';
-                                Alert.showError(error);
-                                throw new TypeError(error);
+                                    return await fileReading;
+                                } else {
+                                    const error = 'Cannot process attachment data.';
+                                    Alert.showError(error);
+                                    throw new TypeError(error);
+                                }
+                            } catch (error) {
+                                Alert.showError('Cannot retrieve attachment.');
+                                throw error;
                             }
-                        } catch (error) {
-                            Alert.showError('Cannot retrieve attachment.');
-                            throw error;
                         }
-                    }
-                }));
+                        return attachment;
+                    }));
+                } catch (error) {
+                    Alert.hideLoading();
+                    TopNav.showCreateButtons();
+                    return;
+                }
             }
 
             // encrypt message
@@ -6154,5 +6161,3 @@ if (typeof module === 'undefined' || !module.exports) {
         window.PrivateBin.Controller.init();
     });
 }
-
-

--- a/js/test/PasteEncrypter.js
+++ b/js/test/PasteEncrypter.js
@@ -1,0 +1,92 @@
+'use strict';
+require('../common');
+
+describe('PasteEncrypter', function () {
+    describe('sendPaste', function () {
+        let restores,
+            cipherMessage,
+            serverRuns,
+            loadingHides,
+            createButtonShows;
+
+        const stub = function (object, method, replacement) {
+            restores.push([object, method, object[method]]);
+            object[method] = replacement;
+        };
+
+        beforeEach(function () {
+            restores = [];
+            cipherMessage = undefined;
+            serverRuns = 0;
+            loadingHides = 0;
+            createButtonShows = 0;
+
+            stub(PrivateBin.Controller, 'hideStatusMessages', function () {});
+            stub(PrivateBin.TopNav, 'hideAllButtons', function () {});
+            stub(PrivateBin.TopNav, 'collapseBar', function () {});
+            stub(PrivateBin.TopNav, 'showCreateButtons', function () { ++createButtonShows; });
+            stub(PrivateBin.TopNav, 'getFileList', function () { return null; });
+            stub(PrivateBin.TopNav, 'getPassword', function () { return ''; });
+            stub(PrivateBin.TopNav, 'getOpenDiscussion', function () { return false; });
+            stub(PrivateBin.TopNav, 'getBurnAfterReading', function () { return false; });
+            stub(PrivateBin.TopNav, 'getExpiration', function () { return '5min'; });
+            stub(PrivateBin.Alert, 'showLoading', function () {});
+            stub(PrivateBin.Alert, 'hideLoading', function () { ++loadingHides; });
+            stub(PrivateBin.Alert, 'showStatus', function () {});
+            stub(PrivateBin.Alert, 'showError', function () {});
+            stub(PrivateBin.Editor, 'getText', function () { return ''; });
+            stub(PrivateBin.PasteViewer, 'getFormat', function () { return 'plaintext'; });
+            stub(PrivateBin.PasteViewer, 'setText', function () {});
+            stub(PrivateBin.PasteViewer, 'setFormat', function () {});
+            stub(PrivateBin.AttachmentViewer, 'getFiles', function () { return []; });
+            stub(PrivateBin.AttachmentViewer, 'hasAttachmentData', function () { return false; });
+            stub(PrivateBin.AttachmentViewer, 'getAttachmentsData', function () { return []; });
+            stub(PrivateBin.AttachmentViewer, 'hasAttachment', function () { return true; });
+            stub(PrivateBin.ServerInteraction, 'prepare', function () {});
+            stub(PrivateBin.ServerInteraction, 'setCryptParameters', function () {});
+            stub(PrivateBin.ServerInteraction, 'setSuccess', function () {});
+            stub(PrivateBin.ServerInteraction, 'setFailure', function () {});
+            stub(PrivateBin.ServerInteraction, 'setUnencryptedData', function () {});
+            stub(PrivateBin.ServerInteraction, 'setCipherMessage', function (message) {
+                cipherMessage = message;
+                return Promise.resolve();
+            });
+            stub(PrivateBin.ServerInteraction, 'run', function () { ++serverRuns; });
+        });
+
+        afterEach(function () {
+            restores.reverse().forEach(function (restore) {
+                restore[0][restore[1]] = restore[2];
+            });
+        });
+
+        it('preserves cloned attachments that are already data URLs', async () => {
+            const dataUrl = 'data:text/plain;base64,SGVsbG8=';
+            stub(PrivateBin.AttachmentViewer, 'getAttachments', function () {
+                return [[dataUrl, 'hello.txt']];
+            });
+
+            await PrivateBin.PasteEncrypter.sendPaste();
+
+            assert.deepStrictEqual(cipherMessage.attachment, [dataUrl]);
+            assert.deepStrictEqual(cipherMessage.attachment_name, ['hello.txt']);
+            assert.strictEqual(serverRuns, 1);
+        });
+
+        it('restores the editor when a cloned blob cannot be retrieved', async () => {
+            stub(PrivateBin.AttachmentViewer, 'getAttachments', function () {
+                return [['blob:https://example.com/missing', 'missing.txt']];
+            });
+            stub(globalThis, 'fetch', function () {
+                return Promise.resolve({ok: false, status: 404});
+            });
+
+            await PrivateBin.PasteEncrypter.sendPaste();
+
+            assert.strictEqual(cipherMessage, undefined);
+            assert.strictEqual(serverRuns, 0);
+            assert.strictEqual(loadingHides, 1);
+            assert.strictEqual(createButtonShows, 1);
+        });
+    });
+});

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -120,7 +120,7 @@ class Configuration
             'js/kjua-0.10.0.js'      => 'sha512-BYj4xggowR7QD150VLSTRlzH62YPfhpIM+b/1EUEr7RQpdWAGKulxWnOvjFx1FUlba4m6ihpNYuQab51H6XlYg==',
             'js/legacy.js'           => 'sha512-pRofxsrf5UItjiP22Dcjh3FAcBjF/n7h8U9/W5xqJk17U0N2U1oajhXypq/omo9jhwS1iVGOhWrRepoPeFns+w==',
             'js/prettify.js'         => 'sha512-puO0Ogy++IoA2Pb9IjSxV1n4+kQkKXYAEUtVzfZpQepyDPyXk8hokiYDS7ybMogYlyyEIwMLpZqVhCkARQWLMg==',
-            'js/privatebin.js'       => 'sha512-ah/QdETig/ovH1QPl9Ne+T3VvaP7Bj4Rd9Or9wqQgo5BHge9o02MxAlRGXUZpKviy/27OSzHgz2PwpnH/B2RZg==',
+            'js/privatebin.js'       => 'sha512-cioh1znmGBr4YpG1arBnOWOz0FkRjSXm0CvgDltiq5Ku+VKXR0ocdmZyt3b8XuA05DOB3UsqlURahysAUmFHpQ==',
             'js/purify-3.4.12.js'    => 'sha512-Akf6HnAJZm0sWWWI4gp2GYff0NDnHUB02XJE5S7Hdq/Z5xtMjkuFacsDA8ZtViv1gi+onBxMhEMIaGyQeGxBng==',
             'js/showdown-2.1.0.js'   => 'sha512-WYXZgkTR0u/Y9SVIA4nTTOih0kXMEd8RRV6MLFdL6YU8ymhR528NLlYQt1nlJQbYz4EW+ZsS0fx1awhiQJme1Q==',
             'js/zlib-1.3.2.js'       => 'sha512-RAhJgxg9siMIA8ky4c10Rc2zUgnK80olHB8Tt1IOYWY4Eh1WmrviQkDn+sgBlb38ZHq3tzufGC41kP360gmosQ==',


### PR DESCRIPTION
## Summary

- preserve cloned attachment values that do not require blob retrieval
- restore the compose controls when an in-memory cloned blob cannot be fetched
- add focused regressions for both paths
- update the changelog and `privatebin.js` subresource-integrity hash

## Bug

The cloned-attachment conversion maps blob URLs to data URLs before encryption. The mapper did not return non-blob values, replacing them with `undefined`. If fetching a blob URL failed, the rejection escaped `sendPaste()` while the loading indicator remained active and all create buttons stayed hidden.

The conversion now preserves values that are already usable and contains retrieval failures at the compose boundary so the user can retry or remove the attachment.

## Tests

- `npx mocha test/PasteEncrypter.js` (2 passing)
- `npm test -- --reporter dot` (128 passing)
- `npm run lint`
- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit --filter '/^(?!.*ServerSaltTest)/'` (266 tests, 6505 assertions)
- verified the configured SHA-512 integrity value matches `js/privatebin.js`

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.
