### PR TITLE
Reject malformed decrypted attachment data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * FIXED: Gracefully handle YOURLS replies with a 200 status code but no shorturl, instead of raising a TypeError
 * FIXED: Return "Invalid data." instead of HTTP 500 on malformed v2 JSON payloads (#1883)
 * FIXED: Dead PATH validation guard in Controller, the check for a missing trailing directory separator never ran (#1887)
+* FIXED: Reject malformed decrypted attachment data without breaking the document view
 
 ## 2.0.5 (2026-07-11)
 * CHANGED: Show OS-specific copy hotkey hint (Cmd+c on Mac, Ctrl+c on others) (#1506)

--- a/js/privatebin.js
+++ b/js/privatebin.js
@@ -2884,9 +2884,24 @@ window.PrivateBin = (function () {
             if (!attachment) return;
 
             // data URI format: data:[<mimeType>][;base64],<data>
+            if (
+                typeof attachmentData !== 'string' ||
+                !/^data:[^,]*;base64,/i.test(attachmentData)
+            ) {
+                Alert.showError('Cannot process attachment data.');
+                return;
+            }
 
             const template = Model.getTemplate('attachment');
+            if (!template) {
+                Alert.showError('Cannot process attachment data.');
+                return;
+            }
             const attachmentLink = template.querySelector('a');
+            if (!attachmentLink) {
+                Alert.showError('Cannot process attachment data.');
+                return;
+            }
 
             // position in data URI string of where data begins
             const base64Start = attachmentData.indexOf(',') + 1;
@@ -2902,7 +2917,13 @@ window.PrivateBin = (function () {
 
             // extract data and convert to binary
             const rawData = attachmentData.substring(base64Start);
-            const decodedData = rawData.length > 0 ? atob(rawData) : '';
+            let decodedData;
+            try {
+                decodedData = rawData.length > 0 ? atob(rawData) : '';
+            } catch (error) {
+                Alert.showError('Cannot process attachment data.');
+                return;
+            }
 
             let blobUrl = getBlobUrl(decodedData, safeMimeType);
             attachmentLink.setAttribute('href', blobUrl);
@@ -6154,5 +6175,3 @@ if (typeof module === 'undefined' || !module.exports) {
         window.PrivateBin.Controller.init();
     });
 }
-
-

--- a/js/test/AttachmentViewer.js
+++ b/js/test/AttachmentViewer.js
@@ -157,6 +157,48 @@ describe('AttachmentViewer', function () {
                 }
             }
         );
+
+        it('rejects malformed attachment data without throwing', function () {
+            document.body.innerHTML = (
+                '<div id="status" class="hidden"></div>' +
+                '<div id="errormessage" class="hidden"></div>' +
+                '<div id="attachmentPreview" class="hidden"></div>' +
+                '<div id="attachment" class="hidden"></div>' +
+                '<div id="templates">' +
+                    '<div id="attachmenttemplate" class="attachment hidden">' +
+                        '<a class="alert-link">Download attachment</a>' +
+                    '</div>' +
+                '</div>'
+            );
+            PrivateBin.Alert.init();
+            PrivateBin.AttachmentViewer.init();
+            PrivateBin.Model.init();
+            global.atob = function (data) {
+                if (data === '%%%') {
+                    throw new DOMException('Invalid character');
+                }
+                return common.atob(data);
+            };
+
+            [
+                null,
+                {},
+                'not-a-data-url',
+                'data:text/plain;base64,%%%'
+            ].forEach(function (invalidData) {
+                assert.doesNotThrow(function () {
+                    PrivateBin.AttachmentViewer.setAttachment(invalidData, 'invalid.txt');
+                });
+            });
+
+            assert.strictEqual(document.getElementById('attachment').children.length, 0);
+            assert.ok(!document.getElementById('errormessage').classList.contains('hidden'));
+
+            assert.doesNotThrow(function () {
+                PrivateBin.AttachmentViewer.setAttachment('data:text/plain;base64,SGVsbG8');
+            });
+            assert.strictEqual(document.getElementById('attachment').children.length, 1);
+        });
     });
 
     describe('showAttachment()', function () {
@@ -204,5 +246,3 @@ describe('AttachmentViewer', function () {
         }
     }
 });
-
-

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -120,7 +120,7 @@ class Configuration
             'js/kjua-0.10.0.js'      => 'sha512-BYj4xggowR7QD150VLSTRlzH62YPfhpIM+b/1EUEr7RQpdWAGKulxWnOvjFx1FUlba4m6ihpNYuQab51H6XlYg==',
             'js/legacy.js'           => 'sha512-pRofxsrf5UItjiP22Dcjh3FAcBjF/n7h8U9/W5xqJk17U0N2U1oajhXypq/omo9jhwS1iVGOhWrRepoPeFns+w==',
             'js/prettify.js'         => 'sha512-puO0Ogy++IoA2Pb9IjSxV1n4+kQkKXYAEUtVzfZpQepyDPyXk8hokiYDS7ybMogYlyyEIwMLpZqVhCkARQWLMg==',
-            'js/privatebin.js'       => 'sha512-ah/QdETig/ovH1QPl9Ne+T3VvaP7Bj4Rd9Or9wqQgo5BHge9o02MxAlRGXUZpKviy/27OSzHgz2PwpnH/B2RZg==',
+            'js/privatebin.js'       => 'sha512-5ksYvrQ9tVfB6AG0Akda5WGTzPQuLQAN7oNyNPMO+8hZ2xsNbs8B4RaMWMirMgehyWvzuDVo4PtuKDo4kkbw6Q==',
             'js/purify-3.4.12.js'    => 'sha512-Akf6HnAJZm0sWWWI4gp2GYff0NDnHUB02XJE5S7Hdq/Z5xtMjkuFacsDA8ZtViv1gi+onBxMhEMIaGyQeGxBng==',
             'js/showdown-2.1.0.js'   => 'sha512-WYXZgkTR0u/Y9SVIA4nTTOih0kXMEd8RRV6MLFdL6YU8ymhR528NLlYQt1nlJQbYz4EW+ZsS0fx1awhiQJme1Q==',
             'js/zlib-1.3.2.js'       => 'sha512-RAhJgxg9siMIA8ky4c10Rc2zUgnK80olHB8Tt1IOYWY4Eh1WmrviQkDn+sgBlb38ZHq3tzufGC41kP360gmosQ==',


### PR DESCRIPTION
## Summary

- reject malformed decrypted attachment values without throwing from the view
- handle missing attachment templates and decode failures at the attachment boundary
- retain support for unpadded Base64 data URLs
- update the changelog and `privatebin.js` subresource-integrity hash

## Bug

Attachment fields are decrypted client-side and then passed directly to `AttachmentViewer.setAttachment()`. A non-string value, an invalid data URL, or malformed Base64 could throw while rendering and prevent an otherwise valid document from being displayed.

The viewer now reports and skips invalid attachment data. The regression also verifies that valid unpadded Base64 remains accepted for backward compatibility.

## Tests

- `npx mocha test/AttachmentViewer.js` (4 passing)
- `npm test -- --reporter dot` (127 passing)
- `npm run lint`
- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit --filter '/^(?!.*ServerSaltTest)/'` (266 tests, 6505 assertions)
- verified the configured SHA-512 integrity value matches `js/privatebin.js`

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.
