### PR TITLE
Scroll highlighted comments into view

### DIFF
--- a/js/privatebin.js
+++ b/js/privatebin.js
@@ -3742,7 +3742,13 @@ window.PrivateBin = (function () {
                 }, 300);
             }
 
-            if (('checkVisibility' in comment ? comment.checkVisibility() : comment.offsetParent !== null) === false) {
+            const bounds = comment.getBoundingClientRect();
+            if (
+                bounds.top < 0 ||
+                bounds.left < 0 ||
+                bounds.bottom > window.innerHeight ||
+                bounds.right > window.innerWidth
+            ) {
                 if (typeof comment.scrollIntoView === 'function') {
                     comment.scrollIntoView({ block: 'center' });
                 }
@@ -6154,5 +6160,4 @@ if (typeof module === 'undefined' || !module.exports) {
         window.PrivateBin.Controller.init();
     });
 }
-
 

--- a/js/test/DiscussionViewer.js
+++ b/js/test/DiscussionViewer.js
@@ -129,5 +129,42 @@ describe('DiscussionViewer', function () {
                 }
             ));
         });
+
+        it('scrolls a highlighted comment into the viewport', function () {
+            document.body.innerHTML = '<article id="comment_target"></article>';
+            const comment = document.getElementById('comment_target');
+            let scrolls = 0;
+
+            comment.checkVisibility = function () {
+                return true;
+            };
+            comment.getBoundingClientRect = function () {
+                return {
+                    top: window.innerHeight + 10,
+                    bottom: window.innerHeight + 30,
+                    left: 0,
+                    right: 100
+                };
+            };
+            comment.scrollIntoView = function () {
+                ++scrolls;
+            };
+
+            PrivateBin.DiscussionViewer.highlightComment('target', false);
+
+            assert.strictEqual(scrolls, 1);
+
+            comment.getBoundingClientRect = function () {
+                return {
+                    top: 10,
+                    bottom: 30,
+                    left: 10,
+                    right: 110
+                };
+            };
+            PrivateBin.DiscussionViewer.highlightComment('target', false);
+
+            assert.strictEqual(scrolls, 1);
+        });
     });
 });

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -120,7 +120,7 @@ class Configuration
             'js/kjua-0.10.0.js'      => 'sha512-BYj4xggowR7QD150VLSTRlzH62YPfhpIM+b/1EUEr7RQpdWAGKulxWnOvjFx1FUlba4m6ihpNYuQab51H6XlYg==',
             'js/legacy.js'           => 'sha512-pRofxsrf5UItjiP22Dcjh3FAcBjF/n7h8U9/W5xqJk17U0N2U1oajhXypq/omo9jhwS1iVGOhWrRepoPeFns+w==',
             'js/prettify.js'         => 'sha512-puO0Ogy++IoA2Pb9IjSxV1n4+kQkKXYAEUtVzfZpQepyDPyXk8hokiYDS7ybMogYlyyEIwMLpZqVhCkARQWLMg==',
-            'js/privatebin.js'       => 'sha512-ah/QdETig/ovH1QPl9Ne+T3VvaP7Bj4Rd9Or9wqQgo5BHge9o02MxAlRGXUZpKviy/27OSzHgz2PwpnH/B2RZg==',
+            'js/privatebin.js'       => 'sha512-MI11NZkZRkZ7wMfbpcI3/vVljSMQNJ/R9SuMBn74J1+OdVoAT2/7O9Iar0srMzL0J7IJoFOojHqY/kdl+IMejQ==',
             'js/purify-3.4.12.js'    => 'sha512-Akf6HnAJZm0sWWWI4gp2GYff0NDnHUB02XJE5S7Hdq/Z5xtMjkuFacsDA8ZtViv1gi+onBxMhEMIaGyQeGxBng==',
             'js/showdown-2.1.0.js'   => 'sha512-WYXZgkTR0u/Y9SVIA4nTTOih0kXMEd8RRV6MLFdL6YU8ymhR528NLlYQt1nlJQbYz4EW+ZsS0fx1awhiQJme1Q==',
             'js/zlib-1.3.2.js'       => 'sha512-RAhJgxg9siMIA8ky4c10Rc2zUgnK80olHB8Tt1IOYWY4Eh1WmrviQkDn+sgBlb38ZHq3tzufGC41kP360gmosQ==',


### PR DESCRIPTION
## Summary

- determine highlighted-comment visibility from its viewport bounds
- scroll comments that are above, below, or horizontally outside the viewport
- avoid scrolling comments that are already visible
- update the `privatebin.js` subresource-integrity hash

## Bug

`DiscussionViewer.highlightComment()` used `checkVisibility()` (or `offsetParent`) to decide whether scrolling was needed. Those APIs indicate whether an element is rendered by CSS, not whether it is currently inside the viewport. Consequently, a newly posted or highlighted comment below the fold remained off-screen.

The regression places a rendered comment below the viewport; it recorded zero scroll calls before the fix and one afterward.

## Tests

- `npx mocha test/DiscussionViewer.js` (2 passing)
- `npm test -- --reporter dot` (127 passing)
- `npm run lint`
- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit --filter '/^(?!.*ServerSaltTest)/'` (266 tests, 6505 assertions)
- verified the configured SHA-512 integrity value matches `js/privatebin.js`

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.
