### PR TITLE
Collapse the Bootstrap 5 mobile navigation

### DIFF
--- a/js/privatebin.js
+++ b/js/privatebin.js
@@ -4501,15 +4501,12 @@ window.PrivateBin = (function () {
          * collapses the navigation bar, only if expanded
          *
          * @name   TopNav.collapseBar
-         * @function
-         */
+        * @function
+        */
         me.collapseBar = function () {
-            const navbar = document.getElementById('navbar');
-            if (navbar && navbar.getAttribute('aria-expanded') === 'true') {
-                const toggle = document.querySelector('.navbar-toggle');
-                if (toggle) {
-                    toggle.click();
-                }
+            const toggle = document.querySelector('.navbar-toggler, .navbar-toggle');
+            if (toggle && toggle.getAttribute('aria-expanded') === 'true') {
+                toggle.click();
             }
         };
 
@@ -6154,5 +6151,4 @@ if (typeof module === 'undefined' || !module.exports) {
         window.PrivateBin.Controller.init();
     });
 }
-
 

--- a/js/test/TopNav.js
+++ b/js/test/TopNav.js
@@ -347,6 +347,25 @@ describe('TopNav', function () {
                 assert.ok(result);
             }
         );
+
+        it('collapses the expanded Bootstrap 5 navigation', function () {
+            document.body.innerHTML = `
+                <nav>
+                    <button class="navbar-toggler" aria-expanded="true"
+                        data-bs-target="#navbar">Toggle navigation</button>
+                    <div id="navbar" class="collapse navbar-collapse show"></div>
+                </nav>
+            `;
+            const toggle = document.querySelector('.navbar-toggler');
+            let clicks = 0;
+            toggle.addEventListener('click', function () {
+                ++clicks;
+            });
+
+            PrivateBin.TopNav.collapseBar();
+
+            assert.strictEqual(clicks, 1);
+        });
     });
 
     describe('resetInput', function () {

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -120,7 +120,7 @@ class Configuration
             'js/kjua-0.10.0.js'      => 'sha512-BYj4xggowR7QD150VLSTRlzH62YPfhpIM+b/1EUEr7RQpdWAGKulxWnOvjFx1FUlba4m6ihpNYuQab51H6XlYg==',
             'js/legacy.js'           => 'sha512-pRofxsrf5UItjiP22Dcjh3FAcBjF/n7h8U9/W5xqJk17U0N2U1oajhXypq/omo9jhwS1iVGOhWrRepoPeFns+w==',
             'js/prettify.js'         => 'sha512-puO0Ogy++IoA2Pb9IjSxV1n4+kQkKXYAEUtVzfZpQepyDPyXk8hokiYDS7ybMogYlyyEIwMLpZqVhCkARQWLMg==',
-            'js/privatebin.js'       => 'sha512-ah/QdETig/ovH1QPl9Ne+T3VvaP7Bj4Rd9Or9wqQgo5BHge9o02MxAlRGXUZpKviy/27OSzHgz2PwpnH/B2RZg==',
+            'js/privatebin.js'       => 'sha512-eJzhfZhxiVz289ra3lY5bX34IxiB6ejR+x7Y+s7CSJ4Kz79Ef8HHbyWnzrU3ENkdz/5MqN9rHAaet7e76iE4sg==',
             'js/purify-3.4.12.js'    => 'sha512-Akf6HnAJZm0sWWWI4gp2GYff0NDnHUB02XJE5S7Hdq/Z5xtMjkuFacsDA8ZtViv1gi+onBxMhEMIaGyQeGxBng==',
             'js/showdown-2.1.0.js'   => 'sha512-WYXZgkTR0u/Y9SVIA4nTTOih0kXMEd8RRV6MLFdL6YU8ymhR528NLlYQt1nlJQbYz4EW+ZsS0fx1awhiQJme1Q==',
             'js/zlib-1.3.2.js'       => 'sha512-RAhJgxg9siMIA8ky4c10Rc2zUgnK80olHB8Tt1IOYWY4Eh1WmrviQkDn+sgBlb38ZHq3tzufGC41kP360gmosQ==',


### PR DESCRIPTION
## Summary

- read expanded state from the navigation toggle instead of the collapse container
- use the Bootstrap 5 `.navbar-toggler` selector while retaining legacy `.navbar-toggle` support
- add a regression based on the shipped Bootstrap 5 markup
- update the `privatebin.js` subresource-integrity hash

## Bug

`TopNav.collapseBar()` checked `aria-expanded` on `#navbar` and looked for `.navbar-toggle`. The shipped Bootstrap 5 template places `aria-expanded` on a `.navbar-toggler` button. The condition therefore never passed, leaving the expanded mobile navigation open when sending or cloning a paste.

The regression recorded zero toggle clicks before the fix and one afterward.

## Tests

- `npx mocha test/TopNav.js` (20 passing)
- `npm test -- --reporter dot` (127 passing)
- `npm run lint`
- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit --filter '/^(?!.*ServerSaltTest)/'` (266 tests, 6505 assertions)
- verified the configured SHA-512 integrity value matches `js/privatebin.js`

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.
