### PR TITLE
Restore warning and error alert severity

### DIFF
--- a/js/privatebin.js
+++ b/js/privatebin.js
@@ -1770,6 +1770,40 @@ window.PrivateBin = (function () {
         };
 
         /**
+         * switch the shared warning/error element to the requested severity
+         *
+         * @param {bool} isWarning
+         */
+        function setErrorSeverity(isWarning) {
+            if (errorMessage.classList.contains('alert')) {
+                errorMessage.classList.toggle('alert-warning', isWarning);
+                errorMessage.classList.toggle('alert-danger', !isWarning);
+            }
+
+            const glyphIcon = errorMessage.querySelector(':first-child');
+            if (!glyphIcon) {
+                return;
+            }
+            const bootstrapIcon = glyphIcon.querySelector('use');
+            if (bootstrapIcon) {
+                const href = bootstrapIcon.getAttribute('href');
+                if (href) {
+                    bootstrapIcon.setAttribute(
+                        'href',
+                        href.replace(
+                            /#[^#]*$/,
+                            isWarning ? '#exclamation-circle' : '#exclamation-triangle'
+                        )
+                    );
+                }
+                return;
+            }
+
+            glyphIcon.classList.remove(currentIcon[isWarning ? 3 : 2]);
+            glyphIcon.classList.add(currentIcon[isWarning ? 2 : 3]);
+        }
+
+        /**
          * display a warning message
          *
          * This automatically passes the text to I18n for translation.
@@ -1781,11 +1815,7 @@ window.PrivateBin = (function () {
          *                                    leave previous icon
          */
         me.showWarning = function (message, icon) {
-            const glyphIcon = errorMessage.querySelector(':first-child');
-            if (glyphIcon) {
-                glyphIcon.classList.remove(currentIcon[3]);
-                glyphIcon.classList.add(currentIcon[2]);
-            }
+            setErrorSeverity(true);
             handleNotification(2, errorMessage, message, icon);
         };
 
@@ -1801,6 +1831,7 @@ window.PrivateBin = (function () {
          *                                    leave previous icon
          */
         me.showError = function (message, icon) {
+            setErrorSeverity(false);
             handleNotification(3, errorMessage, message, icon);
         };
 
@@ -6154,5 +6185,4 @@ if (typeof module === 'undefined' || !module.exports) {
         window.PrivateBin.Controller.init();
     });
 }
-
 

--- a/js/test/Alert.js
+++ b/js/test/Alert.js
@@ -93,7 +93,7 @@ describe('Alert', function () {
                 function (message) {
                     message = message.join('');
                     const expected = '<div id="errormessage" role="alert" ' +
-                        'class="statusmessage alert alert-danger"><span ' +
+                        'class="statusmessage alert alert-warning"><span ' +
                         'class="glyphicon glyphicon-warning-sign" ' +
                         'aria-hidden="true"></span> <span>' + message + '</span></div>';
                     document.body.innerHTML =
@@ -116,7 +116,7 @@ describe('Alert', function () {
                     icon = icon.join('');
                     message = message.join('');
                     const expected = '<div id="errormessage" role="alert" ' +
-                        'class="statusmessage alert alert-danger"><span ' +
+                        'class="statusmessage alert alert-warning"><span ' +
                         'class="glyphicon glyphicon-' + icon +
                         '" aria-hidden="true"></span> <span>' + message + '</span></div>';
                     document.body.innerHTML =
@@ -194,6 +194,33 @@ describe('Alert', function () {
                     return expected === result;
                 }
             ));
+        });
+    });
+
+    describe('warning and error severity', function () {
+        it('updates Bootstrap 5 severity styling and icons', function () {
+            document.body.innerHTML = `
+                <div id="errormessage" role="alert" class="hidden alert alert-danger">
+                    <svg aria-hidden="true">
+                        <use href="img/bootstrap-icons.svg#exclamation-triangle"></use>
+                    </svg>
+                </div>
+            `;
+            PrivateBin.Alert.init();
+
+            PrivateBin.Alert.showWarning('Warning');
+
+            const errorMessage = document.getElementById('errormessage');
+            const icon = errorMessage.querySelector('use');
+            assert.ok(errorMessage.classList.contains('alert-warning'));
+            assert.ok(!errorMessage.classList.contains('alert-danger'));
+            assert.strictEqual(icon.getAttribute('href'), 'img/bootstrap-icons.svg#exclamation-circle');
+
+            PrivateBin.Alert.showError('Error');
+
+            assert.ok(errorMessage.classList.contains('alert-danger'));
+            assert.ok(!errorMessage.classList.contains('alert-warning'));
+            assert.strictEqual(icon.getAttribute('href'), 'img/bootstrap-icons.svg#exclamation-triangle');
         });
     });
 

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -120,7 +120,7 @@ class Configuration
             'js/kjua-0.10.0.js'      => 'sha512-BYj4xggowR7QD150VLSTRlzH62YPfhpIM+b/1EUEr7RQpdWAGKulxWnOvjFx1FUlba4m6ihpNYuQab51H6XlYg==',
             'js/legacy.js'           => 'sha512-pRofxsrf5UItjiP22Dcjh3FAcBjF/n7h8U9/W5xqJk17U0N2U1oajhXypq/omo9jhwS1iVGOhWrRepoPeFns+w==',
             'js/prettify.js'         => 'sha512-puO0Ogy++IoA2Pb9IjSxV1n4+kQkKXYAEUtVzfZpQepyDPyXk8hokiYDS7ybMogYlyyEIwMLpZqVhCkARQWLMg==',
-            'js/privatebin.js'       => 'sha512-ah/QdETig/ovH1QPl9Ne+T3VvaP7Bj4Rd9Or9wqQgo5BHge9o02MxAlRGXUZpKviy/27OSzHgz2PwpnH/B2RZg==',
+            'js/privatebin.js'       => 'sha512-R3sKfjPo3jyNzZi2BG/mNWzb0EUanNnMhu6MafzjOnwpsfC4NdPm2bdA0mmghp3NhKSZcHoR2KKNQW71heZ4Uw==',
             'js/purify-3.4.12.js'    => 'sha512-Akf6HnAJZm0sWWWI4gp2GYff0NDnHUB02XJE5S7Hdq/Z5xtMjkuFacsDA8ZtViv1gi+onBxMhEMIaGyQeGxBng==',
             'js/showdown-2.1.0.js'   => 'sha512-WYXZgkTR0u/Y9SVIA4nTTOih0kXMEd8RRV6MLFdL6YU8ymhR528NLlYQt1nlJQbYz4EW+ZsS0fx1awhiQJme1Q==',
             'js/zlib-1.3.2.js'       => 'sha512-RAhJgxg9siMIA8ky4c10Rc2zUgnK80olHB8Tt1IOYWY4Eh1WmrviQkDn+sgBlb38ZHq3tzufGC41kP360gmosQ==',


### PR DESCRIPTION
## Summary

- switch the shared warning/error element between Bootstrap warning and danger states
- restore error state after a warning
- update both Bootstrap 5 SVG icons and legacy glyph classes
- add a warning-to-error state-transition regression
- update the `privatebin.js` subresource-integrity hash

## Bug

`Alert.showWarning()` rendered into `#errormessage` without replacing its `alert-danger` class, so warnings were presented as errors. A later `showError()` also did not restore icon state after a warning. In the shipped Bootstrap 5 template, the static error SVG remained unchanged throughout.

The alert manager now explicitly applies the requested severity while preserving basic, Bootstrap 5, and legacy template behavior.

## Tests

- `npx mocha test/Alert.js` (17 passing)
- `npm test -- --reporter dot` (127 passing)
- `npm run lint`
- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit --filter '/^(?!.*ServerSaltTest)/'` (266 tests, 6505 assertions)
- verified the configured SHA-512 integrity value matches `js/privatebin.js`

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.
