### PR TITLE
Update Bootstrap 5 alert icons

### DIFF
--- a/js/privatebin.js
+++ b/js/privatebin.js
@@ -1732,8 +1732,9 @@ window.PrivateBin = (function () {
                 element.prepend(glyphIcon);
                 element.appendChild(translationTarget);
 
+                const nextIcon = typeof icon === 'string' ? 'glyphicon-' + icon : null;
                 if (icon !== null && // icon was passed
-                    icon !== currentIcon[id] // and it differs from current icon
+                    nextIcon !== currentIcon[id] // and it differs from current icon
                 ) {
                     // remove (previous) icon
                     glyphIcon.classList.remove(currentIcon[id]);
@@ -1741,8 +1742,19 @@ window.PrivateBin = (function () {
                     // any other thing as a string (e.g. 'null') (only) removes the icon
                     if (typeof icon === 'string') {
                         // set new icon
-                        currentIcon[id] = 'glyphicon-' + icon;
-                        glyphIcon.classList.add(currentIcon[id]);
+                        currentIcon[id] = nextIcon;
+                        const bootstrapIcon = glyphIcon.querySelector('use');
+                        if (bootstrapIcon) {
+                            const href = bootstrapIcon.getAttribute('href');
+                            if (href) {
+                                bootstrapIcon.setAttribute(
+                                    'href',
+                                    href.replace(/#[^#]*$/, '#' + (icon === 'time' ? 'clock' : icon))
+                                );
+                            }
+                        } else {
+                            glyphIcon.classList.add(currentIcon[id]);
+                        }
                     }
                 }
             }
@@ -6154,5 +6166,4 @@ if (typeof module === 'undefined' || !module.exports) {
         window.PrivateBin.Controller.init();
     });
 }
-
 

--- a/js/test/Alert.js
+++ b/js/test/Alert.js
@@ -292,6 +292,24 @@ describe('Alert', function () {
                 }
             ));
         });
+
+        it('updates Bootstrap 5 loading icons', function () {
+            document.body.innerHTML = `
+                <div id="loadingindicator" class="hidden">
+                    <svg aria-hidden="true">
+                        <use href="img/bootstrap-icons.svg#clock"></use>
+                    </svg>
+                </div>
+            `;
+            PrivateBin.Alert.init();
+            const icon = document.querySelector('#loadingindicator use');
+
+            PrivateBin.Alert.showLoading('Sending document…', 'cloud-upload');
+            assert.strictEqual(icon.getAttribute('href'), 'img/bootstrap-icons.svg#cloud-upload');
+
+            PrivateBin.Alert.showLoading('Preparing new document…', 'time');
+            assert.strictEqual(icon.getAttribute('href'), 'img/bootstrap-icons.svg#clock');
+        });
     });
 
     describe('hideLoading', function () {

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -120,7 +120,7 @@ class Configuration
             'js/kjua-0.10.0.js'      => 'sha512-BYj4xggowR7QD150VLSTRlzH62YPfhpIM+b/1EUEr7RQpdWAGKulxWnOvjFx1FUlba4m6ihpNYuQab51H6XlYg==',
             'js/legacy.js'           => 'sha512-pRofxsrf5UItjiP22Dcjh3FAcBjF/n7h8U9/W5xqJk17U0N2U1oajhXypq/omo9jhwS1iVGOhWrRepoPeFns+w==',
             'js/prettify.js'         => 'sha512-puO0Ogy++IoA2Pb9IjSxV1n4+kQkKXYAEUtVzfZpQepyDPyXk8hokiYDS7ybMogYlyyEIwMLpZqVhCkARQWLMg==',
-            'js/privatebin.js'       => 'sha512-ah/QdETig/ovH1QPl9Ne+T3VvaP7Bj4Rd9Or9wqQgo5BHge9o02MxAlRGXUZpKviy/27OSzHgz2PwpnH/B2RZg==',
+            'js/privatebin.js'       => 'sha512-DXOdGAgzficY5qYoaXWaWk8J4DdFmGvc5VU/u7Hl5buTLv2Xo+2qcVGTIW2/DVuHN2I5uBDNrWlrxX1uxG4zdA==',
             'js/purify-3.4.12.js'    => 'sha512-Akf6HnAJZm0sWWWI4gp2GYff0NDnHUB02XJE5S7Hdq/Z5xtMjkuFacsDA8ZtViv1gi+onBxMhEMIaGyQeGxBng==',
             'js/showdown-2.1.0.js'   => 'sha512-WYXZgkTR0u/Y9SVIA4nTTOih0kXMEd8RRV6MLFdL6YU8ymhR528NLlYQt1nlJQbYz4EW+ZsS0fx1awhiQJme1Q==',
             'js/zlib-1.3.2.js'       => 'sha512-RAhJgxg9siMIA8ky4c10Rc2zUgnK80olHB8Tt1IOYWY4Eh1WmrviQkDn+sgBlb38ZHq3tzufGC41kP360gmosQ==',


### PR DESCRIPTION
## Summary

- update Bootstrap 5 SVG icon fragments when alert callers request a new icon
- map the legacy `time` icon name to Bootstrap Icons’ `clock`
- normalize icon-state comparisons while preserving Glyphicon behavior
- add regression coverage for upload and time loading states
- update the `privatebin.js` subresource-integrity hash

## Bug

The alert API accepts icon names such as `cloud-upload`, `cloud-download`, `copy`, and `time`. The shipped Bootstrap 5 template uses `<svg><use ...></use></svg>`, but the handler only added Glyphicon CSS classes to the SVG element. The visible icon therefore never changed from the template default.

The regression observed `#clock` after requesting `cloud-upload` before the fix; it now updates to `#cloud-upload` and maps `time` back to `#clock`.

## Tests

- `npx mocha test/Alert.js` (17 passing)
- `npm test -- --reporter dot` (127 passing)
- `npm run lint`
- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit --filter '/^(?!.*ServerSaltTest)/'` (266 tests, 6505 assertions)
- verified the configured SHA-512 integrity value matches `js/privatebin.js`

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.
