### PR TITLE
Match discussion notification severity icons

### DIFF
--- a/js/privatebin.js
+++ b/js/privatebin.js
@@ -3544,21 +3544,27 @@ window.PrivateBin = (function () {
                 return false;
             }
 
-            if (alertType === 'danger') {
-                replyStatus.classList.remove('alert-info');
-                replyStatus.classList.add('alert-danger');
-                const replyIcon = replyStatus.querySelector(':first-child');
-                if (replyIcon) {
-                    replyIcon.classList.remove('glyphicon-alert');
-                    replyIcon.classList.add('glyphicon-info-sign');
-                }
-            } else {
-                replyStatus.classList.remove('alert-danger');
-                replyStatus.classList.add('alert-info');
-                const replyIcon = replyStatus.querySelector(':first-child');
-                if (replyIcon) {
-                    replyIcon.classList.remove('glyphicon-info-sign');
-                    replyIcon.classList.add('glyphicon-alert');
+            const isDanger = alertType === 'danger';
+            replyStatus.classList.toggle('alert-info', !isDanger);
+            replyStatus.classList.toggle('alert-danger', isDanger);
+
+            const replyIcon = replyStatus.querySelector(':first-child');
+            if (replyIcon) {
+                const bootstrapIcon = replyIcon.querySelector('use');
+                if (bootstrapIcon) {
+                    const href = bootstrapIcon.getAttribute('href');
+                    if (href) {
+                        bootstrapIcon.setAttribute(
+                            'href',
+                            href.replace(
+                                /#[^#]*$/,
+                                isDanger ? '#exclamation-triangle' : '#info-circle'
+                            )
+                        );
+                    }
+                } else {
+                    replyIcon.classList.toggle('glyphicon-info-sign', !isDanger);
+                    replyIcon.classList.toggle('glyphicon-alert', isDanger);
                 }
             }
 
@@ -6154,5 +6160,4 @@ if (typeof module === 'undefined' || !module.exports) {
         window.PrivateBin.Controller.init();
     });
 }
-
 

--- a/js/test/DiscussionViewer.js
+++ b/js/test/DiscussionViewer.js
@@ -129,5 +129,38 @@ describe('DiscussionViewer', function () {
                 }
             ));
         });
+
+        it('uses matching Bootstrap 5 icons for reply notifications', function () {
+            const clean = globalThis.cleanup();
+            document.body.innerHTML = `
+                <div id="discussion"><div id="commentcontainer"></div></div>
+                <div id="templates">
+                    <p id="commenttailtemplate"><button>Add comment</button></p>
+                    <div id="replytemplate" class="hidden">
+                        <input id="nickname">
+                        <textarea id="replymessage"></textarea>
+                        <div id="replystatus" class="alert alert-info">
+                            <svg aria-hidden="true">
+                                <use href="img/bootstrap-icons.svg#info-circle"></use>
+                            </svg>
+                        </div>
+                        <button id="replybutton">Post comment</button>
+                    </div>
+                </div>
+            `;
+            PrivateBin.Model.reset();
+            PrivateBin.Model.init();
+            PrivateBin.DiscussionViewer.init();
+            PrivateBin.DiscussionViewer.prepareNewDiscussion();
+
+            const replyStatus = PrivateBin.DiscussionViewer.handleNotification('danger');
+            const icon = replyStatus.querySelector('use');
+            assert.strictEqual(icon.getAttribute('href'), 'img/bootstrap-icons.svg#exclamation-triangle');
+
+            PrivateBin.DiscussionViewer.handleNotification('info');
+            assert.strictEqual(icon.getAttribute('href'), 'img/bootstrap-icons.svg#info-circle');
+
+            clean();
+        });
     });
 });

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -120,7 +120,7 @@ class Configuration
             'js/kjua-0.10.0.js'      => 'sha512-BYj4xggowR7QD150VLSTRlzH62YPfhpIM+b/1EUEr7RQpdWAGKulxWnOvjFx1FUlba4m6ihpNYuQab51H6XlYg==',
             'js/legacy.js'           => 'sha512-pRofxsrf5UItjiP22Dcjh3FAcBjF/n7h8U9/W5xqJk17U0N2U1oajhXypq/omo9jhwS1iVGOhWrRepoPeFns+w==',
             'js/prettify.js'         => 'sha512-puO0Ogy++IoA2Pb9IjSxV1n4+kQkKXYAEUtVzfZpQepyDPyXk8hokiYDS7ybMogYlyyEIwMLpZqVhCkARQWLMg==',
-            'js/privatebin.js'       => 'sha512-ah/QdETig/ovH1QPl9Ne+T3VvaP7Bj4Rd9Or9wqQgo5BHge9o02MxAlRGXUZpKviy/27OSzHgz2PwpnH/B2RZg==',
+            'js/privatebin.js'       => 'sha512-Bgb30YBowChUWg+ouGbdIv/drALzcxJs5yyxHMfXXe9yZW2qEu98hL7WLKv7RL+Fv9lLtEkG21cjYkrms0QPpw==',
             'js/purify-3.4.12.js'    => 'sha512-Akf6HnAJZm0sWWWI4gp2GYff0NDnHUB02XJE5S7Hdq/Z5xtMjkuFacsDA8ZtViv1gi+onBxMhEMIaGyQeGxBng==',
             'js/showdown-2.1.0.js'   => 'sha512-WYXZgkTR0u/Y9SVIA4nTTOih0kXMEd8RRV6MLFdL6YU8ymhR528NLlYQt1nlJQbYz4EW+ZsS0fx1awhiQJme1Q==',
             'js/zlib-1.3.2.js'       => 'sha512-RAhJgxg9siMIA8ky4c10Rc2zUgnK80olHB8Tt1IOYWY4Eh1WmrviQkDn+sgBlb38ZHq3tzufGC41kP360gmosQ==',


### PR DESCRIPTION
## Summary

- derive reply notification styling and icons from one danger/info state
- correct the previously reversed legacy Glyphicon mapping
- update Bootstrap 5 reply-status SVG fragments
- add a danger-to-info regression using shipped template markup
- update the `privatebin.js` subresource-integrity hash

## Bug

`DiscussionViewer.handleNotification()` assigned the info Glyphicon in its danger branch and the alert Glyphicon in its info branch. The shipped Bootstrap 5 template uses SVG `<use>` icons, which the code did not update at all. Comment-post failures therefore retained an info icon instead of showing error feedback.

The regression observed `#info-circle` after a danger notification before the fix; it now switches to `#exclamation-triangle` and back to `#info-circle`.

## Tests

- `npx mocha test/DiscussionViewer.js` (2 passing)
- `npm test -- --reporter dot` (127 passing)
- `npm run lint`
- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit --filter '/^(?!.*ServerSaltTest)/'` (266 tests, 6505 assertions)
- verified the configured SHA-512 integrity value matches `js/privatebin.js`

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.
