### PR TITLE
Clear nested drag state after a drop

### DIFF
--- a/js/privatebin.js
+++ b/js/privatebin.js
@@ -32,9 +32,9 @@ function draghover(element) {
         }
     });
 
-    element.addEventListener('drop', function (e) {
-        collection.delete(e.target);
-        if (collection.size === 0) {
+    element.addEventListener('drop', function () {
+        if (collection.size > 0) {
+            collection.clear();
             element.dispatchEvent(new CustomEvent('draghoverend'));
         }
     });
@@ -6154,5 +6154,4 @@ if (typeof module === 'undefined' || !module.exports) {
         window.PrivateBin.Controller.init();
     });
 }
-
 

--- a/js/test/AttachmentViewer.js
+++ b/js/test/AttachmentViewer.js
@@ -190,6 +190,41 @@ describe('AttachmentViewer', function () {
         )
     });
 
+    describe('drag and drop', function () {
+        it('hides the drop zone after dropping across nested targets', function () {
+            document.body.innerHTML = `
+                <div id="attachment"></div>
+                <div id="dragAndDropFileName"></div>
+                <div id="dropzone" class="hidden"></div>
+                <input id="file" type="file">
+                <div id="drag-outer"><div id="drag-inner"></div></div>
+            `;
+            const originalReadonly = PrivateBin.TopNav.isAttachmentReadonly;
+            const originalFileReader = global.FileReader;
+            PrivateBin.TopNav.isAttachmentReadonly = function () {
+                return false;
+            };
+            global.FileReader = function () {};
+            PrivateBin.AttachmentViewer.init();
+
+            document.getElementById('drag-outer').dispatchEvent(
+                new Event('dragenter', {bubbles: true})
+            );
+            document.getElementById('drag-inner').dispatchEvent(
+                new Event('dragenter', {bubbles: true})
+            );
+            assert.ok(!document.getElementById('dropzone').classList.contains('hidden'));
+
+            const drop = new Event('drop', {bubbles: true, cancelable: true});
+            drop.dataTransfer = {files: []};
+            document.getElementById('drag-inner').dispatchEvent(drop);
+
+            assert.ok(document.getElementById('dropzone').classList.contains('hidden'));
+            PrivateBin.TopNav.isAttachmentReadonly = originalReadonly;
+            global.FileReader = originalFileReader;
+        });
+    });
+
     function mockCreateObjectUrl() {
         if (typeof window.URL.createObjectURL === 'undefined') {
             Object.defineProperty(
@@ -204,5 +239,3 @@ describe('AttachmentViewer', function () {
         }
     }
 });
-
-

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -120,7 +120,7 @@ class Configuration
             'js/kjua-0.10.0.js'      => 'sha512-BYj4xggowR7QD150VLSTRlzH62YPfhpIM+b/1EUEr7RQpdWAGKulxWnOvjFx1FUlba4m6ihpNYuQab51H6XlYg==',
             'js/legacy.js'           => 'sha512-pRofxsrf5UItjiP22Dcjh3FAcBjF/n7h8U9/W5xqJk17U0N2U1oajhXypq/omo9jhwS1iVGOhWrRepoPeFns+w==',
             'js/prettify.js'         => 'sha512-puO0Ogy++IoA2Pb9IjSxV1n4+kQkKXYAEUtVzfZpQepyDPyXk8hokiYDS7ybMogYlyyEIwMLpZqVhCkARQWLMg==',
-            'js/privatebin.js'       => 'sha512-ah/QdETig/ovH1QPl9Ne+T3VvaP7Bj4Rd9Or9wqQgo5BHge9o02MxAlRGXUZpKviy/27OSzHgz2PwpnH/B2RZg==',
+            'js/privatebin.js'       => 'sha512-N98WNRMa9P/1Ll97N5X8joILJSu8bzcNAt8UZUjD2TiBJwX8uW3wpLcsF/CZHJLDt1w+UqXAijYvgRO9ZcKW6w==',
             'js/purify-3.4.12.js'    => 'sha512-Akf6HnAJZm0sWWWI4gp2GYff0NDnHUB02XJE5S7Hdq/Z5xtMjkuFacsDA8ZtViv1gi+onBxMhEMIaGyQeGxBng==',
             'js/showdown-2.1.0.js'   => 'sha512-WYXZgkTR0u/Y9SVIA4nTTOih0kXMEd8RRV6MLFdL6YU8ymhR528NLlYQt1nlJQbYz4EW+ZsS0fx1awhiQJme1Q==',
             'js/zlib-1.3.2.js'       => 'sha512-RAhJgxg9siMIA8ky4c10Rc2zUgnK80olHB8Tt1IOYWY4Eh1WmrviQkDn+sgBlb38ZHq3tzufGC41kP360gmosQ==',


### PR DESCRIPTION
## Summary

- clear all tracked drag targets when a drop ends the drag session
- emit the terminal `draghoverend` event once after nested drag entries
- add a regression with nested drop targets
- update the `privatebin.js` subresource-integrity hash

## Bug

The `draghover` helper stores every `dragenter` target in a set. Its `drop` handler removed only the final event target. When a drag entered nested elements, earlier targets remained in the set, `draghoverend` was not emitted, and the drop-zone overlay could remain visible after the drop.

The regression enters an outer and inner target, then drops on the inner target. The drop zone remained visible before the fix and is hidden afterward.

## Tests

- `npx mocha test/AttachmentViewer.js` (4 passing)
- `npm test -- --reporter dot` (127 passing)
- `npm run lint`
- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit --filter '/^(?!.*ServerSaltTest)/'` (266 tests, 6505 assertions)
- verified the configured SHA-512 integrity value matches `js/privatebin.js`

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.
