### PR TITLE
Ignore unavailable clipboard files

### DIFF
--- a/js/privatebin.js
+++ b/js/privatebin.js
@@ -3373,7 +3373,8 @@ window.PrivateBin = (function () {
                 const items = (event.clipboardData || event.originalEvent.clipboardData).items;
                 const files = [...items]
                     .filter(item => item.kind === 'file')
-                    .map(item => item.getAsFile());
+                    .map(item => item.getAsFile())
+                    .filter(file => file !== null);
 
                 if (TopNav.isAttachmentReadonly() && files.length) {
                     event.stopPropagation();
@@ -6154,5 +6155,4 @@ if (typeof module === 'undefined' || !module.exports) {
         window.PrivateBin.Controller.init();
     });
 }
-
 

--- a/js/test/AttachmentViewer.js
+++ b/js/test/AttachmentViewer.js
@@ -190,6 +190,43 @@ describe('AttachmentViewer', function () {
         )
     });
 
+    describe('clipboard attachments', function () {
+        it('ignores file items that are no longer available', function () {
+            document.body.innerHTML = '<div id="attachment"></div>';
+            const originalIsAttachmentReadonly = PrivateBin.TopNav.isAttachmentReadonly;
+            const originalFileReader = global.FileReader;
+            PrivateBin.TopNav.isAttachmentReadonly = () => false;
+            global.FileReader = window.FileReader;
+            PrivateBin.AttachmentViewer.init();
+
+            const pasteEvent = new window.Event('paste');
+            Object.defineProperty(pasteEvent, 'clipboardData', {
+                value: {
+                    items: [{
+                        kind: 'file',
+                        getAsFile: () => null
+                    }]
+                }
+            });
+            let pasteError = null;
+            const captureError = event => {
+                pasteError = event.error;
+                event.preventDefault();
+            };
+            window.addEventListener('error', captureError);
+
+            try {
+                document.dispatchEvent(pasteEvent);
+            } finally {
+                window.removeEventListener('error', captureError);
+                PrivateBin.TopNav.isAttachmentReadonly = originalIsAttachmentReadonly;
+                global.FileReader = originalFileReader;
+            }
+
+            assert.strictEqual(pasteError, null);
+        });
+    });
+
     function mockCreateObjectUrl() {
         if (typeof window.URL.createObjectURL === 'undefined') {
             Object.defineProperty(
@@ -204,5 +241,3 @@ describe('AttachmentViewer', function () {
         }
     }
 });
-
-

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -120,7 +120,7 @@ class Configuration
             'js/kjua-0.10.0.js'      => 'sha512-BYj4xggowR7QD150VLSTRlzH62YPfhpIM+b/1EUEr7RQpdWAGKulxWnOvjFx1FUlba4m6ihpNYuQab51H6XlYg==',
             'js/legacy.js'           => 'sha512-pRofxsrf5UItjiP22Dcjh3FAcBjF/n7h8U9/W5xqJk17U0N2U1oajhXypq/omo9jhwS1iVGOhWrRepoPeFns+w==',
             'js/prettify.js'         => 'sha512-puO0Ogy++IoA2Pb9IjSxV1n4+kQkKXYAEUtVzfZpQepyDPyXk8hokiYDS7ybMogYlyyEIwMLpZqVhCkARQWLMg==',
-            'js/privatebin.js'       => 'sha512-ah/QdETig/ovH1QPl9Ne+T3VvaP7Bj4Rd9Or9wqQgo5BHge9o02MxAlRGXUZpKviy/27OSzHgz2PwpnH/B2RZg==',
+            'js/privatebin.js'       => 'sha512-8Xdri6Uxk8bNM/cOmS6YdnhHXWpTWn5O1a4c3t1WNoRpPMODr2w+WKfjswyWPdSm0xokMBxeD9IcKi7OfbrR8g==',
             'js/purify-3.4.12.js'    => 'sha512-Akf6HnAJZm0sWWWI4gp2GYff0NDnHUB02XJE5S7Hdq/Z5xtMjkuFacsDA8ZtViv1gi+onBxMhEMIaGyQeGxBng==',
             'js/showdown-2.1.0.js'   => 'sha512-WYXZgkTR0u/Y9SVIA4nTTOih0kXMEd8RRV6MLFdL6YU8ymhR528NLlYQt1nlJQbYz4EW+ZsS0fx1awhiQJme1Q==',
             'js/zlib-1.3.2.js'       => 'sha512-RAhJgxg9siMIA8ky4c10Rc2zUgnK80olHB8Tt1IOYWY4Eh1WmrviQkDn+sgBlb38ZHq3tzufGC41kP360gmosQ==',


### PR DESCRIPTION
## Summary

- discard nullable `DataTransferItem.getAsFile()` results before reading clipboard attachments
- prevent the paste event handler from dereferencing an unavailable file
- add a regression test for an expired or otherwise unreadable file item
- update the client bundle integrity hash

The HTML Standard defines `getAsFile()` as nullable, including when the item is no longer in a readable drag-data-store mode: https://html.spec.whatwg.org/multipage/dnd.html#dom-datatransferitem-getasfile-dev

## Tests

- `npx mocha test/AttachmentViewer.js` (4 passing)
- `npm run lint`
- `npm test -- --reporter dot` (127 passing)
- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit --filter '/^(?!.*ServerSaltTest)/'` (266 tests, 6505 assertions)
- SHA-512 integrity value verified against `js/privatebin.js`

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.