### PR TITLE
Use LONGBLOB for MySQL paste data

### DIFF
--- a/lib/Data/Database.php
+++ b/lib/Data/Database.php
@@ -642,6 +642,8 @@ class Database extends AbstractData
                 return 'CLOB';
             case 'pgsql':
                 return 'TEXT';
+            case 'mysql':
+                return 'LONGBLOB';
             default:
                 return 'MEDIUMBLOB';
         }
@@ -898,6 +900,17 @@ class Database extends AbstractData
                     '" DROP COLUMN "nickname"'
                 );
             }
+        }
+        if (
+            $this->_type === 'mysql' &&
+            version_compare($oldversion, '1.3', '>') &&
+            version_compare($oldversion, '2.0.5', '<=')
+        ) {
+            // releases through 2.0.5 created the MySQL paste data as MEDIUMBLOB
+            $this->_db->exec(
+                'ALTER TABLE "' . $this->_sanitizeIdentifier('paste') .
+                "\" MODIFY COLUMN \"data\" $attachmentType"
+            );
         }
         $this->_exec(
             'UPDATE "' . $this->_sanitizeIdentifier('config') .

--- a/tst/Data/DatabaseTest.php
+++ b/tst/Data/DatabaseTest.php
@@ -172,6 +172,19 @@ class DatabaseTest extends TestCase
         $this->assertFalse($this->_model->existsComment(Helper::getPasteId(), Helper::getPasteId(), Helper::getCommentId()), 'comment does still not exist');
     }
 
+    public function testMysqlPasteDataUsesLongBlob()
+    {
+        $reflection = new ReflectionClass(Database::class);
+        $database   = $reflection->newInstanceWithoutConstructor();
+        $type       = $reflection->getProperty('_type');
+        $type->setAccessible(true);
+        $type->setValue($database, 'mysql');
+        $getAttachmentType = $reflection->getMethod('_getAttachmentType');
+        $getAttachmentType->setAccessible(true);
+
+        $this->assertSame('LONGBLOB', $getAttachmentType->invoke($database));
+    }
+
     public function testGetIbmInstance()
     {
         $this->expectException(PDOException::class);


### PR DESCRIPTION
## Summary

- store encrypted paste payloads as `LONGBLOB` on MySQL and MariaDB instead of the 16 MiB-limited `MEDIUMBLOB`
- migrate existing MySQL schemas created after the legacy 1.3 payload migration and through version 2.0.5
- retain the existing payload types for all other PDO drivers
- add a regression test for the MySQL schema type

Closes #1398.

This removes the schema-level 16 MiB ceiling. MySQL/MariaDB server settings such as `max_allowed_packet` remain administrator-controlled limits.

## Tests

- `phpunit --filter testMysqlPasteDataUsesLongBlob Data/DatabaseTest.php` (1 test, 1 assertion)
- `phpunit --filter '/^(?!.*ServerSaltTest)/'` (267 tests, 6506 assertions)
- `php -l lib/Data/Database.php`
- `git diff --check`

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.