### PR TITLE
Restore paste defaults with optional controls disabled

### DIFF
--- a/js/privatebin.js
+++ b/js/privatebin.js
@@ -4528,12 +4528,8 @@ window.PrivateBin = (function () {
             if (openDiscussion) {
                 openDiscussion.checked = openDiscussionDefault;
             }
-            if (openDiscussionDefault || !burnAfterReadingDefault) {
-                openDiscussionOption.classList.remove('buttondisabled');
-            }
-            if (burnAfterReadingDefault || !openDiscussionDefault) {
-                burnAfterReadingOption.classList.remove('buttondisabled');
-            }
+            changeBurnAfterReading();
+            changeOpenDiscussion();
 
             pasteExpiration = Model.getExpirationDefault() || pasteExpiration;
             const pasteExpirationSelect = document.getElementById('pasteExpiration');
@@ -6154,5 +6150,4 @@ if (typeof module === 'undefined' || !module.exports) {
         window.PrivateBin.Controller.init();
     });
 }
-
 

--- a/js/privatebin.js
+++ b/js/privatebin.js
@@ -4300,8 +4300,12 @@ window.PrivateBin = (function () {
             expiration.classList.remove('hidden');
             formatter.classList.remove('hidden');
             newButton.classList.remove('hidden');
-            openDiscussionOption.classList.remove('hidden');
-            password.classList.remove('hidden');
+            if (openDiscussionOption) {
+                openDiscussionOption.classList.remove('hidden');
+            }
+            if (password) {
+                password.classList.remove('hidden');
+            }
             sendButton.classList.remove('hidden');
 
             createButtonsDisplayed = true;
@@ -4323,8 +4327,12 @@ window.PrivateBin = (function () {
             expiration.classList.add('hidden');
             formatter.classList.add('hidden');
             burnAfterReadingOption.classList.add('hidden');
-            openDiscussionOption.classList.add('hidden');
-            password.classList.add('hidden');
+            if (openDiscussionOption) {
+                openDiscussionOption.classList.add('hidden');
+            }
+            if (password) {
+                password.classList.add('hidden');
+            }
             if (attach) {
                 attach.classList.add('hidden');
             }
@@ -6150,4 +6158,3 @@ if (typeof module === 'undefined' || !module.exports) {
         window.PrivateBin.Controller.init();
     });
 }
-

--- a/js/test/TopNav.js
+++ b/js/test/TopNav.js
@@ -416,13 +416,20 @@ describe('TopNav', function () {
                 results.push(
                     !PrivateBin.TopNav.getOpenDiscussion()
                 );
+                results.push(
+                    query('#opendiscussionoption').classList.contains('buttondisabled')
+                );
                 query('#burnafterreading').checked = false;
                 query('#burnafterreading').removeAttribute('checked');
+                query('#burnafterreading').dispatchEvent(new window.Event('change'));
                 results.push(
                     !PrivateBin.TopNav.getBurnAfterReading()
                 );
                 results.push(
                     !PrivateBin.TopNav.getOpenDiscussion()
+                );
+                results.push(
+                    !query('#opendiscussionoption').classList.contains('buttondisabled')
                 );
                 PrivateBin.TopNav.resetInput();
                 results.push(
@@ -430,6 +437,9 @@ describe('TopNav', function () {
                 );
                 results.push(
                     !PrivateBin.TopNav.getOpenDiscussion()
+                );
+                results.push(
+                    query('#opendiscussionoption').classList.contains('buttondisabled')
                 );
                 cleanup();
                 const result = results.every(element => element);
@@ -459,10 +469,15 @@ describe('TopNav', function () {
                 results.push(
                     PrivateBin.TopNav.getOpenDiscussion()
                 );
+                results.push(
+                    query('#burnafterreadingoption').classList.contains('buttondisabled')
+                );
                 query('#opendiscussion').checked = false;
                 query('#opendiscussion').removeAttribute('checked');
+                query('#opendiscussion').dispatchEvent(new window.Event('change'));
                 query('#burnafterreading').checked = true;
                 query('#burnafterreading').setAttribute('checked', 'checked');
+                query('#burnafterreading').dispatchEvent(new window.Event('change'));
                 results.push(
                     PrivateBin.TopNav.getBurnAfterReading()
                 );
@@ -475,6 +490,10 @@ describe('TopNav', function () {
                 );
                 results.push(
                     PrivateBin.TopNav.getOpenDiscussion()
+                );
+                results.push(
+                    query('#burnafterreadingoption').classList.contains('buttondisabled') &&
+                    !query('#opendiscussionoption').classList.contains('buttondisabled')
                 );
                 cleanup();
                 const result = results.every(element => element);

--- a/js/test/TopNav.js
+++ b/js/test/TopNav.js
@@ -69,6 +69,25 @@ describe('TopNav', function () {
         });
 
         it(
+            'supports disabled discussion, password, and file upload controls',
+            function () {
+                document.body.innerHTML =
+                    '<button id="newbutton" class="hidden"></button>' +
+                    '<div id="expiration" class="hidden"></div>' +
+                    '<div id="burnafterreadingoption" class="hidden"></div>' +
+                    '<div id="formatter" class="hidden"></div>' +
+                    '<button id="sendbutton" class="hidden"></button>';
+                PrivateBin.TopNav.init();
+
+                assert.doesNotThrow(function () {
+                    PrivateBin.TopNav.resetInput();
+                    PrivateBin.TopNav.showCreateButtons();
+                    PrivateBin.TopNav.hideCreateButtons();
+                });
+            }
+        );
+
+        it(
             'displays & hides navigation elements for creating a document',
             function () { // eslint-disable-line complexity
                 let results = [];

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -120,7 +120,7 @@ class Configuration
             'js/kjua-0.10.0.js'      => 'sha512-BYj4xggowR7QD150VLSTRlzH62YPfhpIM+b/1EUEr7RQpdWAGKulxWnOvjFx1FUlba4m6ihpNYuQab51H6XlYg==',
             'js/legacy.js'           => 'sha512-pRofxsrf5UItjiP22Dcjh3FAcBjF/n7h8U9/W5xqJk17U0N2U1oajhXypq/omo9jhwS1iVGOhWrRepoPeFns+w==',
             'js/prettify.js'         => 'sha512-puO0Ogy++IoA2Pb9IjSxV1n4+kQkKXYAEUtVzfZpQepyDPyXk8hokiYDS7ybMogYlyyEIwMLpZqVhCkARQWLMg==',
-            'js/privatebin.js'       => 'sha512-ah/QdETig/ovH1QPl9Ne+T3VvaP7Bj4Rd9Or9wqQgo5BHge9o02MxAlRGXUZpKviy/27OSzHgz2PwpnH/B2RZg==',
+            'js/privatebin.js'       => 'sha512-84YmBpbBLjWPTu37MOh9trcSzgY726ntDTcTiAfrPrOvrUJSvZOZzfHygyh93rD8O7EGwJh86+uKV7R1vFXN2Q==',
             'js/purify-3.4.12.js'    => 'sha512-Akf6HnAJZm0sWWWI4gp2GYff0NDnHUB02XJE5S7Hdq/Z5xtMjkuFacsDA8ZtViv1gi+onBxMhEMIaGyQeGxBng==',
             'js/showdown-2.1.0.js'   => 'sha512-WYXZgkTR0u/Y9SVIA4nTTOih0kXMEd8RRV6MLFdL6YU8ymhR528NLlYQt1nlJQbYz4EW+ZsS0fx1awhiQJme1Q==',
             'js/zlib-1.3.2.js'       => 'sha512-RAhJgxg9siMIA8ky4c10Rc2zUgnK80olHB8Tt1IOYWY4Eh1WmrviQkDn+sgBlb38ZHq3tzufGC41kP360gmosQ==',

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -120,7 +120,7 @@ class Configuration
             'js/kjua-0.10.0.js'      => 'sha512-BYj4xggowR7QD150VLSTRlzH62YPfhpIM+b/1EUEr7RQpdWAGKulxWnOvjFx1FUlba4m6ihpNYuQab51H6XlYg==',
             'js/legacy.js'           => 'sha512-pRofxsrf5UItjiP22Dcjh3FAcBjF/n7h8U9/W5xqJk17U0N2U1oajhXypq/omo9jhwS1iVGOhWrRepoPeFns+w==',
             'js/prettify.js'         => 'sha512-puO0Ogy++IoA2Pb9IjSxV1n4+kQkKXYAEUtVzfZpQepyDPyXk8hokiYDS7ybMogYlyyEIwMLpZqVhCkARQWLMg==',
-            'js/privatebin.js'       => 'sha512-84YmBpbBLjWPTu37MOh9trcSzgY726ntDTcTiAfrPrOvrUJSvZOZzfHygyh93rD8O7EGwJh86+uKV7R1vFXN2Q==',
+            'js/privatebin.js'       => 'sha512-wEkyuWPuB0nsX/nCK9Or7rBeYyFf78J5Ej7Mr4o9MBiJJz8BM3HcYQA2kQ1RckZrFrVeZdUr993rLsiP39fzOQ==',
             'js/purify-3.4.12.js'    => 'sha512-Akf6HnAJZm0sWWWI4gp2GYff0NDnHUB02XJE5S7Hdq/Z5xtMjkuFacsDA8ZtViv1gi+onBxMhEMIaGyQeGxBng==',
             'js/showdown-2.1.0.js'   => 'sha512-WYXZgkTR0u/Y9SVIA4nTTOih0kXMEd8RRV6MLFdL6YU8ymhR528NLlYQt1nlJQbYz4EW+ZsS0fx1awhiQJme1Q==',
             'js/zlib-1.3.2.js'       => 'sha512-RAhJgxg9siMIA8ky4c10Rc2zUgnK80olHB8Tt1IOYWY4Eh1WmrviQkDn+sgBlb38ZHq3tzufGC41kP360gmosQ==',


### PR DESCRIPTION
## Summary

- restore both checkbox values and their mutually-exclusive visual state when starting a new paste
- reuse the same burn/discussion state transitions used during initialization
- guard optional discussion, password, and file-upload controls when showing and hiding the creation navigation
- add regressions for configured checkbox defaults and installations that disable optional controls
- update the client bundle integrity hash

Previously, toggling a configured default off and then resetting the editor restored its checkbox but left the opposite option at full opacity. Separately, installations with discussion or password support disabled could throw while preparing the new-paste view because the absent controls were dereferenced.

## Regression evidence

The optional-control test failed before the additional fix with `Cannot read properties of null (reading 'classList')`; it now completes reset/show/hide without an exception.

## Tests

- `npx mocha test/TopNav.js --grep "supports disabled discussion"` — 1 passing
- `npm run lint` — passed
- `npm test -- --reporter dot` — 127 passing
- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit --filter '/^(?!.*ServerSaltTest)/'` — 266 tests, 6505 assertions
- `git diff --check` — passed
- verified the configured SHA-512 integrity value matches `js/privatebin.js`

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.