### PR TITLE
Reset paste expiration to its configured default

### DIFF
--- a/js/privatebin.js
+++ b/js/privatebin.js
@@ -3816,6 +3816,7 @@ window.PrivateBin = (function () {
             sendButton,
             retryButton,
             pasteExpiration = null,
+            pasteExpirationDefault = null,
             retryButtonCallback;
 
         /**
@@ -4535,9 +4536,10 @@ window.PrivateBin = (function () {
                 burnAfterReadingOption.classList.remove('buttondisabled');
             }
 
-            pasteExpiration = Model.getExpirationDefault() || pasteExpiration;
+            pasteExpiration = pasteExpirationDefault || pasteExpiration;
             const pasteExpirationSelect = document.getElementById('pasteExpiration');
             if (pasteExpirationSelect) {
+                pasteExpirationSelect.value = pasteExpiration;
                 pasteExpirationSelect.querySelectorAll('option').forEach((option) => {
                     if (option.value === pasteExpiration) {
                         const display = document.getElementById('pasteExpirationDisplay');
@@ -4829,7 +4831,8 @@ window.PrivateBin = (function () {
             // get default values from template or fall back to set value
             burnAfterReadingDefault = me.getBurnAfterReading();
             openDiscussionDefault = me.getOpenDiscussion();
-            pasteExpiration = Model.getExpirationDefault();
+            pasteExpirationDefault = Model.getExpirationDefault();
+            pasteExpiration = pasteExpirationDefault;
 
             createButtonsDisplayed = false;
             viewButtonsDisplayed = false;
@@ -6154,5 +6157,4 @@ if (typeof module === 'undefined' || !module.exports) {
         window.PrivateBin.Controller.init();
     });
 }
-
 

--- a/js/test/TopNav.js
+++ b/js/test/TopNav.js
@@ -484,6 +484,29 @@ describe('TopNav', function () {
                 assert.ok(result);
             }
         );
+
+        it('restores the configured expiration', function () {
+            document.documentElement.innerHTML =
+                '<div id="burnafterreadingoption"><input id="burnafterreading" type="checkbox"></div>' +
+                '<div id="opendiscussionoption"><input id="opendiscussion" type="checkbox"></div>' +
+                '<select id="pasteExpiration">' +
+                    '<option value="1day" selected>1 day</option>' +
+                    '<option value="never">Never</option>' +
+                '</select>' +
+                '<span id="pasteExpirationDisplay">1 day</span>';
+            PrivateBin.TopNav.init();
+
+            const expiration = query('#pasteExpiration');
+            expiration.value = 'never';
+            expiration.dispatchEvent(new window.Event('change'));
+            assert.strictEqual(PrivateBin.TopNav.getExpiration(), 'never');
+
+            PrivateBin.TopNav.resetInput();
+
+            assert.strictEqual(PrivateBin.TopNav.getExpiration(), '1day');
+            assert.strictEqual(expiration.value, '1day');
+            assert.strictEqual(query('#pasteExpirationDisplay').textContent, '1 day');
+        });
     });
 
     describe('getExpiration', function () {

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -120,7 +120,7 @@ class Configuration
             'js/kjua-0.10.0.js'      => 'sha512-BYj4xggowR7QD150VLSTRlzH62YPfhpIM+b/1EUEr7RQpdWAGKulxWnOvjFx1FUlba4m6ihpNYuQab51H6XlYg==',
             'js/legacy.js'           => 'sha512-pRofxsrf5UItjiP22Dcjh3FAcBjF/n7h8U9/W5xqJk17U0N2U1oajhXypq/omo9jhwS1iVGOhWrRepoPeFns+w==',
             'js/prettify.js'         => 'sha512-puO0Ogy++IoA2Pb9IjSxV1n4+kQkKXYAEUtVzfZpQepyDPyXk8hokiYDS7ybMogYlyyEIwMLpZqVhCkARQWLMg==',
-            'js/privatebin.js'       => 'sha512-ah/QdETig/ovH1QPl9Ne+T3VvaP7Bj4Rd9Or9wqQgo5BHge9o02MxAlRGXUZpKviy/27OSzHgz2PwpnH/B2RZg==',
+            'js/privatebin.js'       => 'sha512-QLd3SZsHjPmN7gHK7y06+tb1FPPkUvDD+nMGFJSzyvz6wMlqyZ7rRGljAcg1fRt5sd8jhRx5lsmsUiNN/MLQWQ==',
             'js/purify-3.4.12.js'    => 'sha512-Akf6HnAJZm0sWWWI4gp2GYff0NDnHUB02XJE5S7Hdq/Z5xtMjkuFacsDA8ZtViv1gi+onBxMhEMIaGyQeGxBng==',
             'js/showdown-2.1.0.js'   => 'sha512-WYXZgkTR0u/Y9SVIA4nTTOih0kXMEd8RRV6MLFdL6YU8ymhR528NLlYQt1nlJQbYz4EW+ZsS0fx1awhiQJme1Q==',
             'js/zlib-1.3.2.js'       => 'sha512-RAhJgxg9siMIA8ky4c10Rc2zUgnK80olHB8Tt1IOYWY4Eh1WmrviQkDn+sgBlb38ZHq3tzufGC41kP360gmosQ==',


### PR DESCRIPTION
## Summary

- cache the configured expiration separately from the live selection
- restore both the internal expiration and the Bootstrap select when resetting the editor
- update the displayed expiration label consistently
- add a regression that changes the expiration and starts a fresh paste
- update the client bundle integrity hash

Previously the Bootstrap select’s current value was read back as the “default,” so New Paste retained the last selected expiration rather than restoring the server-configured default.

## Tests

- `npx mocha test/TopNav.js --grep "restores the configured expiration"` (1 passing)
- `npm run lint`
- `npm test -- --reporter dot` (127 passing)
- `phpunit --filter '/^(?!.*ServerSaltTest)/'` (266 tests, 6505 assertions)
- SHA-512 integrity value verified against `js/privatebin.js`

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.