### PR TITLE
Support URL shorteners without AbortSignal timeout

### DIFF
--- a/js/privatebin.js
+++ b/js/privatebin.js
@@ -1944,12 +1944,15 @@ window.PrivateBin = (function () {
             if (shortenButton.classList.contains('buttondisabled')) {
                 return;
             }
-            fetch(`${shortenButton.dataset.shortener}${encodeURIComponent(pasteUrl.href)}`, {
+            const options = {
                 method: 'GET',
                 headers: { 'Accept': 'text/html, application/xhtml+xml, application/xml, application/json' },
-                credentials: 'omit',
-                signal: AbortSignal.timeout(10000)
-            })
+                credentials: 'omit'
+            };
+            if (typeof AbortSignal !== 'undefined' && typeof AbortSignal.timeout === 'function') {
+                options.signal = AbortSignal.timeout(10000);
+            }
+            fetch(`${shortenButton.dataset.shortener}${encodeURIComponent(pasteUrl.href)}`, options)
                 .then(response => {
                     if (!response.ok) {
                         throw new Error('HTTP ' + response.status);
@@ -6154,5 +6157,4 @@ if (typeof module === 'undefined' || !module.exports) {
         window.PrivateBin.Controller.init();
     });
 }
-
 

--- a/js/test/PasteStatus.js
+++ b/js/test/PasteStatus.js
@@ -99,6 +99,50 @@ describe('PasteStatus', function () {
         );
     });
 
+    describe('checkAutoShorten', function () {
+        it('works when AbortSignal.timeout is unavailable', async function () {
+            globalThis.cleanup('', {url: 'https://example.com/'});
+            document.body.innerHTML =
+                '<a href="#" id="deletelink"><span></span></a>' +
+                '<div id="pastelink"></div><div id="pastesuccess"></div>' +
+                '<button id="shortenbutton" data-autoshorten="true" ' +
+                    'data-shortener="https://shortener.example/?url="></button>';
+            PrivateBin.PasteStatus.init();
+            PrivateBin.PasteStatus.createPasteNotification(
+                'https://example.com/?paste',
+                'https://example.com/?deletetoken'
+            );
+
+            const originalAbortSignal = global.AbortSignal;
+            const originalFetch = global.fetch;
+            let requestOptions = null;
+            global.AbortSignal = {};
+            global.fetch = async function (_url, options) {
+                requestOptions = options;
+                return {
+                    ok: true,
+                    text: async () => 'https://short.example/paste'
+                };
+            };
+
+            try {
+                PrivateBin.PasteStatus.checkAutoShorten();
+                await new Promise(resolve => setTimeout(resolve, 0));
+
+                assert.ok(requestOptions);
+                assert.ok(!Object.prototype.hasOwnProperty.call(requestOptions, 'signal'));
+                assert.strictEqual(
+                    document.getElementById('pasteurl').href,
+                    'https://short.example/paste'
+                );
+            } finally {
+                global.AbortSignal = originalAbortSignal;
+                global.fetch = originalFetch;
+                globalThis.cleanup();
+            }
+        });
+    });
+
     describe('extractUrl', function () {
         this.timeout(30000);
 

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -120,7 +120,7 @@ class Configuration
             'js/kjua-0.10.0.js'      => 'sha512-BYj4xggowR7QD150VLSTRlzH62YPfhpIM+b/1EUEr7RQpdWAGKulxWnOvjFx1FUlba4m6ihpNYuQab51H6XlYg==',
             'js/legacy.js'           => 'sha512-pRofxsrf5UItjiP22Dcjh3FAcBjF/n7h8U9/W5xqJk17U0N2U1oajhXypq/omo9jhwS1iVGOhWrRepoPeFns+w==',
             'js/prettify.js'         => 'sha512-puO0Ogy++IoA2Pb9IjSxV1n4+kQkKXYAEUtVzfZpQepyDPyXk8hokiYDS7ybMogYlyyEIwMLpZqVhCkARQWLMg==',
-            'js/privatebin.js'       => 'sha512-ah/QdETig/ovH1QPl9Ne+T3VvaP7Bj4Rd9Or9wqQgo5BHge9o02MxAlRGXUZpKviy/27OSzHgz2PwpnH/B2RZg==',
+            'js/privatebin.js'       => 'sha512-wwacg/VZeSCaTPe275rhMqC3iLIy2LBz1RRVJiPkEluSCN77vPc0YhdbdG+zPK9cMVYjv4vuC1AV+IcoAonLkw==',
             'js/purify-3.4.12.js'    => 'sha512-Akf6HnAJZm0sWWWI4gp2GYff0NDnHUB02XJE5S7Hdq/Z5xtMjkuFacsDA8ZtViv1gi+onBxMhEMIaGyQeGxBng==',
             'js/showdown-2.1.0.js'   => 'sha512-WYXZgkTR0u/Y9SVIA4nTTOih0kXMEd8RRV6MLFdL6YU8ymhR528NLlYQt1nlJQbYz4EW+ZsS0fx1awhiQJme1Q==',
             'js/zlib-1.3.2.js'       => 'sha512-RAhJgxg9siMIA8ky4c10Rc2zUgnK80olHB8Tt1IOYWY4Eh1WmrviQkDn+sgBlb38ZHq3tzufGC41kP360gmosQ==',


### PR DESCRIPTION
## Summary

- feature-detect `AbortSignal.timeout()` before adding the shortener request signal
- retain the 10-second abort in browsers that support the static timeout API
- allow otherwise supported browsers to issue the shortener request without that optional timeout
- add an end-to-end `PasteStatus` regression for the missing-method path
- update the client bundle integrity hash

The current code calls the newer static method unconditionally. In browsers where `AbortSignal` exists without `timeout()`, auto-shortening throws before `fetch()` and bypasses the existing request fallback.

## Tests

- `npx mocha test/PasteStatus.js --grep "AbortSignal.timeout"` (1 passing)
- `npm run lint`
- `npm test -- --reporter dot` (127 passing)
- `phpunit --filter '/^(?!.*ServerSaltTest)/'` (266 tests, 6505 assertions)
- SHA-512 integrity value verified against `js/privatebin.js`

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.