### PR TITLE
Handle native popstate events

### DIFF
--- a/js/privatebin.js
+++ b/js/privatebin.js
@@ -1599,7 +1599,7 @@ window.PrivateBin = (function () {
          */
         function historyChange(event) {
             let currentLocation = Helper.baseUri();
-            if (event.originalEvent.state === null && // no state object passed
+            if (event.state === null && // no state object passed
                 event.target.location.href === currentLocation && // target location is home page
                 window.location.href === currentLocation // and we are not already on the home page
             ) {
@@ -1620,22 +1620,6 @@ window.PrivateBin = (function () {
             window.location.href = Helper.baseUri();
         };
 
-
-        /**
-         * trigger a history (pop) state change
-         *
-         * used to test the UiHelper.historyChange private function
-         *
-         * @name   UiHelper.mockHistoryChange
-         * @function
-         * @param  {string} state   (optional) state to mock
-         */
-        me.mockHistoryChange = function (state) {
-            if (typeof state === 'undefined') {
-                state = null;
-            }
-            historyChange({ originalEvent: new PopStateEvent('popstate', { state: state }), target: window });
-        };
 
         /**
          * initialize
@@ -6154,5 +6138,4 @@ if (typeof module === 'undefined' || !module.exports) {
         window.PrivateBin.Controller.init();
     });
 }
-
 

--- a/js/test/UiHelper.js
+++ b/js/test/UiHelper.js
@@ -3,14 +3,25 @@ const common = require('../common');
 const fc = require('fast-check');
 
 describe('UiHelper', function () {
-    // TODO: As per https://github.com/tmpvar/jsdom/issues/1565 there is no navigation support in jsdom, yet.
-    // for now we use a mock function to trigger the event
     describe('historyChange', function () {
         this.timeout(30000);
         beforeEach(function () {
             PrivateBin.Helper.reset();
             cleanup();
         });
+
+        function dispatchPopState(state = null) {
+            let eventError = null;
+            const captureError = event => {
+                eventError = event.error;
+                event.preventDefault();
+            };
+            window.addEventListener('error', captureError);
+            PrivateBin.UiHelper.init();
+            window.dispatchEvent(new window.PopStateEvent('popstate', {state: state}));
+            window.removeEventListener('error', captureError);
+            assert.strictEqual(eventError, null);
+        }
 
         it('redirects to home, when the state is null', () => {
             fc.assert(fc.property(
@@ -19,7 +30,7 @@ describe('UiHelper', function () {
                     const expected = common.urlToString(url),
                         clean = globalThis.cleanup('', {url: expected});
 
-                    PrivateBin.UiHelper.mockHistoryChange();
+                    dispatchPopState();
                     PrivateBin.Helper.reset();
                     var result = window.location.href;
                     clean();
@@ -37,7 +48,7 @@ describe('UiHelper', function () {
                     const expected = common.urlToString(url),
                         clean = globalThis.cleanup('', {url: expected});
 
-                    PrivateBin.UiHelper.mockHistoryChange([
+                    dispatchPopState([
                         {type: 'newpaste'}, '', expected
                     ]);
                     PrivateBin.Helper.reset();
@@ -77,4 +88,3 @@ describe('UiHelper', function () {
         */
     });
 });
-

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -120,7 +120,7 @@ class Configuration
             'js/kjua-0.10.0.js'      => 'sha512-BYj4xggowR7QD150VLSTRlzH62YPfhpIM+b/1EUEr7RQpdWAGKulxWnOvjFx1FUlba4m6ihpNYuQab51H6XlYg==',
             'js/legacy.js'           => 'sha512-pRofxsrf5UItjiP22Dcjh3FAcBjF/n7h8U9/W5xqJk17U0N2U1oajhXypq/omo9jhwS1iVGOhWrRepoPeFns+w==',
             'js/prettify.js'         => 'sha512-puO0Ogy++IoA2Pb9IjSxV1n4+kQkKXYAEUtVzfZpQepyDPyXk8hokiYDS7ybMogYlyyEIwMLpZqVhCkARQWLMg==',
-            'js/privatebin.js'       => 'sha512-ah/QdETig/ovH1QPl9Ne+T3VvaP7Bj4Rd9Or9wqQgo5BHge9o02MxAlRGXUZpKviy/27OSzHgz2PwpnH/B2RZg==',
+            'js/privatebin.js'       => 'sha512-t6ydK3dllX48jNWnOCf6GRnycx5jwkMVHBwmFYvMVWpgKuc4LjrXesuwhVMbm5aHlVRFG6y4HkORfv2wLaXvSA==',
             'js/purify-3.4.12.js'    => 'sha512-Akf6HnAJZm0sWWWI4gp2GYff0NDnHUB02XJE5S7Hdq/Z5xtMjkuFacsDA8ZtViv1gi+onBxMhEMIaGyQeGxBng==',
             'js/showdown-2.1.0.js'   => 'sha512-WYXZgkTR0u/Y9SVIA4nTTOih0kXMEd8RRV6MLFdL6YU8ymhR528NLlYQt1nlJQbYz4EW+ZsS0fx1awhiQJme1Q==',
             'js/zlib-1.3.2.js'       => 'sha512-RAhJgxg9siMIA8ky4c10Rc2zUgnK80olHB8Tt1IOYWY4Eh1WmrviQkDn+sgBlb38ZHq3tzufGC41kP360gmosQ==',


### PR DESCRIPTION
## Summary

- read `state` directly from native `PopStateEvent` objects
- replace the production-only history mock with real `window` event dispatch in tests
- assert that both null and populated history states complete without listener exceptions
- update the client bundle integrity hash

Closes #1841.

After the jQuery removal, `UiHelper` registered `historyChange` with `addEventListener()` but still accessed `event.originalEvent.state`. Real browser events have no `originalEvent`, so every popstate transition raised a `TypeError`; the old test helper accidentally hid the mismatch.

## Tests

- `npx mocha test/UiHelper.js --grep historyChange` (2 passing)
- `npm run lint`
- `npm test -- --reporter dot` (126 passing)
- `phpunit --filter '/^(?!.*ServerSaltTest)/'` (266 tests, 6505 assertions)
- SHA-512 integrity value verified against `js/privatebin.js`

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.