### PR TITLE
Reject empty paste submissions

### DIFF
--- a/js/privatebin.js
+++ b/js/privatebin.js
@@ -5270,11 +5270,15 @@ window.PrivateBin = (function () {
             // get data
             const plainText = Editor.getText(),
                   format    = PasteViewer.getFormat(),
-                  // the methods may return different values if no files are attached (null, undefined or false)
-                  files     = TopNav.getFileList() || AttachmentViewer.getFiles() || AttachmentViewer.hasAttachmentData();
+                  files     = TopNav.getFileList() || AttachmentViewer.getFiles(),
+                  hasFiles  = (
+                      (files && files.length > 0) ||
+                      AttachmentViewer.hasAttachmentData() ||
+                      AttachmentViewer.hasAttachment()
+                  );
 
             // do not send if there is no data
-            if (plainText.length === 0 && !files) {
+            if (plainText.length === 0 && !hasFiles) {
                 // revert loading status…
                 Alert.hideLoading();
                 TopNav.showCreateButtons();
@@ -6154,5 +6158,4 @@ if (typeof module === 'undefined' || !module.exports) {
         window.PrivateBin.Controller.init();
     });
 }
-
 

--- a/js/test/PasteEncrypterEmpty.js
+++ b/js/test/PasteEncrypterEmpty.js
@@ -1,0 +1,49 @@
+'use strict';
+require('../common');
+
+describe('PasteEncrypter empty pastes', function () {
+    afterEach(function () {
+        globalThis.cleanup();
+    });
+
+    it('does not upload without text or attachments', async function () {
+        let prepares = 0,
+            uploads = 0,
+            loadingHides = 0,
+            createButtonShows = 0;
+
+        PrivateBin.Controller.hideStatusMessages = function () {};
+        PrivateBin.TopNav.hideAllButtons = function () {};
+        PrivateBin.TopNav.collapseBar = function () {};
+        PrivateBin.TopNav.showCreateButtons = function () { ++createButtonShows; };
+        PrivateBin.TopNav.getFileList = function () { return null; };
+        PrivateBin.TopNav.getPassword = function () { return ''; };
+        PrivateBin.TopNav.getOpenDiscussion = function () { return false; };
+        PrivateBin.TopNav.getBurnAfterReading = function () { return false; };
+        PrivateBin.TopNav.getExpiration = function () { return '1day'; };
+        PrivateBin.Alert.showLoading = function () {};
+        PrivateBin.Alert.hideLoading = function () { ++loadingHides; };
+        PrivateBin.Editor.getText = function () { return ''; };
+        PrivateBin.PasteViewer.getFormat = function () { return 'plaintext'; };
+        PrivateBin.PasteViewer.setText = function () {};
+        PrivateBin.PasteViewer.setFormat = function () {};
+        PrivateBin.AttachmentViewer.getFiles = function () { return []; };
+        PrivateBin.AttachmentViewer.hasAttachmentData = function () { return false; };
+        PrivateBin.AttachmentViewer.hasAttachment = function () { return false; };
+        PrivateBin.AttachmentViewer.getAttachmentsData = function () { return []; };
+        PrivateBin.ServerInteraction.prepare = function () { ++prepares; };
+        PrivateBin.ServerInteraction.setCryptParameters = function () {};
+        PrivateBin.ServerInteraction.setSuccess = function () {};
+        PrivateBin.ServerInteraction.setFailure = function () {};
+        PrivateBin.ServerInteraction.setUnencryptedData = function () {};
+        PrivateBin.ServerInteraction.setCipherMessage = async function () {};
+        PrivateBin.ServerInteraction.run = function () { ++uploads; };
+
+        await PrivateBin.PasteEncrypter.sendPaste();
+
+        assert.strictEqual(prepares, 0);
+        assert.strictEqual(uploads, 0);
+        assert.strictEqual(loadingHides, 1);
+        assert.strictEqual(createButtonShows, 1);
+    });
+});

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -120,7 +120,7 @@ class Configuration
             'js/kjua-0.10.0.js'      => 'sha512-BYj4xggowR7QD150VLSTRlzH62YPfhpIM+b/1EUEr7RQpdWAGKulxWnOvjFx1FUlba4m6ihpNYuQab51H6XlYg==',
             'js/legacy.js'           => 'sha512-pRofxsrf5UItjiP22Dcjh3FAcBjF/n7h8U9/W5xqJk17U0N2U1oajhXypq/omo9jhwS1iVGOhWrRepoPeFns+w==',
             'js/prettify.js'         => 'sha512-puO0Ogy++IoA2Pb9IjSxV1n4+kQkKXYAEUtVzfZpQepyDPyXk8hokiYDS7ybMogYlyyEIwMLpZqVhCkARQWLMg==',
-            'js/privatebin.js'       => 'sha512-ah/QdETig/ovH1QPl9Ne+T3VvaP7Bj4Rd9Or9wqQgo5BHge9o02MxAlRGXUZpKviy/27OSzHgz2PwpnH/B2RZg==',
+            'js/privatebin.js'       => 'sha512-ReLGIFnGEESz2D+03GRnZKx07KgeqX2+Lm52vlvVHGfxkXFS+EZp6A7IJu6ls4TFSkmAEm5Xzz7uz+ChENX/MQ==',
             'js/purify-3.4.12.js'    => 'sha512-Akf6HnAJZm0sWWWI4gp2GYff0NDnHUB02XJE5S7Hdq/Z5xtMjkuFacsDA8ZtViv1gi+onBxMhEMIaGyQeGxBng==',
             'js/showdown-2.1.0.js'   => 'sha512-WYXZgkTR0u/Y9SVIA4nTTOih0kXMEd8RRV6MLFdL6YU8ymhR528NLlYQt1nlJQbYz4EW+ZsS0fx1awhiQJme1Q==',
             'js/zlib-1.3.2.js'       => 'sha512-RAhJgxg9siMIA8ky4c10Rc2zUgnK80olHB8Tt1IOYWY4Eh1WmrviQkDn+sgBlb38ZHq3tzufGC41kP360gmosQ==',


### PR DESCRIPTION
## Summary

- evaluate actual selected-file length instead of treating an empty array as an attachment
- retain support for completed file reads and cloned attachment-only pastes
- stop before preparing encryption or upload when both text and attachments are absent
- add an end-to-end regression for the empty editor path
- update the client bundle integrity hash

`AttachmentViewer.getFiles()` returns `[]` after reset. Because arrays are truthy, the existing `!files` guard accepted that empty array and uploaded a blank paste.

## Tests

- `npx mocha test/PasteEncrypterEmpty.js` (1 passing)
- `npm run lint`
- `npm test -- --reporter dot` (127 passing)
- `phpunit --filter '/^(?!.*ServerSaltTest)/'` (266 tests, 6505 assertions)
- SHA-512 integrity value verified against `js/privatebin.js`

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.