### PR TITLE
Respect disabled file uploads for clipboard pastes

### DIFF
--- a/js/privatebin.js
+++ b/js/privatebin.js
@@ -4691,7 +4691,7 @@ window.PrivateBin = (function () {
          * @return {bool}
          */
         me.isAttachmentReadonly = function () {
-            return !createButtonsDisplayed || (attach && attach.classList.contains('hidden'));
+            return !createButtonsDisplayed || !attach || attach.classList.contains('hidden');
         }
 
         /**
@@ -6154,5 +6154,4 @@ if (typeof module === 'undefined' || !module.exports) {
         window.PrivateBin.Controller.init();
     });
 }
-
 

--- a/js/test/TopNav.js
+++ b/js/test/TopNav.js
@@ -584,6 +584,27 @@ describe('TopNav', function () {
         );
     });
 
+    describe('isAttachmentReadonly', function () {
+        afterEach(function () {
+            globalThis.cleanup();
+        });
+
+        it('is read-only when file uploads are disabled', function () {
+            document.body.innerHTML =
+                '<div id="burnafterreadingoption"></div>' +
+                '<div id="expiration"></div>' +
+                '<div id="formatter"></div>' +
+                '<button id="newbutton"></button>' +
+                '<div id="opendiscussionoption"></div>' +
+                '<div id="password"></div>' +
+                '<button id="sendbutton"></button>';
+            PrivateBin.TopNav.init();
+            PrivateBin.TopNav.showCreateButtons();
+
+            assert.strictEqual(PrivateBin.TopNav.isAttachmentReadonly(), true);
+        });
+    });
+
     describe('getBurnAfterReading', function () {
         before(function () {
             cleanup();

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -120,7 +120,7 @@ class Configuration
             'js/kjua-0.10.0.js'      => 'sha512-BYj4xggowR7QD150VLSTRlzH62YPfhpIM+b/1EUEr7RQpdWAGKulxWnOvjFx1FUlba4m6ihpNYuQab51H6XlYg==',
             'js/legacy.js'           => 'sha512-pRofxsrf5UItjiP22Dcjh3FAcBjF/n7h8U9/W5xqJk17U0N2U1oajhXypq/omo9jhwS1iVGOhWrRepoPeFns+w==',
             'js/prettify.js'         => 'sha512-puO0Ogy++IoA2Pb9IjSxV1n4+kQkKXYAEUtVzfZpQepyDPyXk8hokiYDS7ybMogYlyyEIwMLpZqVhCkARQWLMg==',
-            'js/privatebin.js'       => 'sha512-ah/QdETig/ovH1QPl9Ne+T3VvaP7Bj4Rd9Or9wqQgo5BHge9o02MxAlRGXUZpKviy/27OSzHgz2PwpnH/B2RZg==',
+            'js/privatebin.js'       => 'sha512-zsoFo+3BHsiko48MQWkxqqtOP+v6iz64GE0wWSRnF9zeDXqJeBG9f6jBknOniAlGc+XwroCuDczXqXw3KmgpPQ==',
             'js/purify-3.4.12.js'    => 'sha512-Akf6HnAJZm0sWWWI4gp2GYff0NDnHUB02XJE5S7Hdq/Z5xtMjkuFacsDA8ZtViv1gi+onBxMhEMIaGyQeGxBng==',
             'js/showdown-2.1.0.js'   => 'sha512-WYXZgkTR0u/Y9SVIA4nTTOih0kXMEd8RRV6MLFdL6YU8ymhR528NLlYQt1nlJQbYz4EW+ZsS0fx1awhiQJme1Q==',
             'js/zlib-1.3.2.js'       => 'sha512-RAhJgxg9siMIA8ky4c10Rc2zUgnK80olHB8Tt1IOYWY4Eh1WmrviQkDn+sgBlb38ZHq3tzufGC41kP360gmosQ==',


### PR DESCRIPTION
## Summary

- treat the attachment input as read-only when file uploads are disabled and the input is absent
- prevent clipboard file pastes from bypassing the `fileupload = false` configuration
- add a regression test for the upload-disabled interface
- refresh the `privatebin.js` integrity hash

## Regression evidence

Before the fix, the focused test failed because `TopNav.isAttachmentReadonly()` returned `null` instead of `true` when `#attach` was absent. With the fix it passes.

## Tests

- `npx mocha test/TopNav.js --grep "file uploads are disabled"` — 1 passing
- `npm run lint` — passed
- `npm test -- --reporter dot` — 127 passing
- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit --filter '/^(?!.*ServerSaltTest)/'` — 266 tests, 6505 assertions
- `git diff --check` — passed
- verified the configured SHA-512 integrity value matches `js/privatebin.js`

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.