### PR TITLE
Avoid duplicate home-page history entries

### DIFF
--- a/js/privatebin.js
+++ b/js/privatebin.js
@@ -5888,7 +5888,7 @@ window.PrivateBin = (function () {
 
             Alert.hideLoading();
             // only push new state if we are coming from a different one
-            if (Helper.baseUri() !== window.location) {
+            if (Helper.baseUri() !== window.location.href) {
                 history.pushState({ type: 'create' }, document.title, Helper.baseUri());
             }
 
@@ -6154,5 +6154,4 @@ if (typeof module === 'undefined' || !module.exports) {
         window.PrivateBin.Controller.init();
     });
 }
-
 

--- a/js/test/Controller.js
+++ b/js/test/Controller.js
@@ -1,0 +1,47 @@
+'use strict';
+require('../common');
+
+describe('Controller', function () {
+    afterEach(function () {
+        globalThis.cleanup();
+    });
+
+    describe('newPaste', function () {
+        it('does not add a redundant history entry on the home page', function () {
+            globalThis.cleanup(undefined, {url: 'https://example.com/'});
+
+            [
+                [PrivateBin.TopNav, [
+                    'hideAllButtons',
+                    'resetInput',
+                    'setFormat',
+                    'showCreateButtons',
+                    'hideCustomAttachment'
+                ]],
+                [PrivateBin.Alert, ['showLoading', 'hideLoading']],
+                [PrivateBin.PasteStatus, ['hideMessages']],
+                [PrivateBin.PasteViewer, ['hide', 'setFormat']],
+                [PrivateBin.Editor, ['resetInput', 'show', 'focusInput']],
+                [PrivateBin.AttachmentViewer, [
+                    'removeAttachment',
+                    'clearDragAndDrop',
+                    'removeAttachmentData'
+                ]],
+                [PrivateBin.DiscussionViewer, ['prepareNewDiscussion']]
+            ].forEach(([module, methods]) => {
+                methods.forEach(method => {
+                    module[method] = function () {};
+                });
+            });
+
+            let pushCount = 0;
+            history.pushState = function () {
+                ++pushCount;
+            };
+
+            PrivateBin.Controller.newPaste();
+
+            assert.strictEqual(pushCount, 0);
+        });
+    });
+});

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -120,7 +120,7 @@ class Configuration
             'js/kjua-0.10.0.js'      => 'sha512-BYj4xggowR7QD150VLSTRlzH62YPfhpIM+b/1EUEr7RQpdWAGKulxWnOvjFx1FUlba4m6ihpNYuQab51H6XlYg==',
             'js/legacy.js'           => 'sha512-pRofxsrf5UItjiP22Dcjh3FAcBjF/n7h8U9/W5xqJk17U0N2U1oajhXypq/omo9jhwS1iVGOhWrRepoPeFns+w==',
             'js/prettify.js'         => 'sha512-puO0Ogy++IoA2Pb9IjSxV1n4+kQkKXYAEUtVzfZpQepyDPyXk8hokiYDS7ybMogYlyyEIwMLpZqVhCkARQWLMg==',
-            'js/privatebin.js'       => 'sha512-ah/QdETig/ovH1QPl9Ne+T3VvaP7Bj4Rd9Or9wqQgo5BHge9o02MxAlRGXUZpKviy/27OSzHgz2PwpnH/B2RZg==',
+            'js/privatebin.js'       => 'sha512-u7zaMh0Mb1jgxH8i3KWnRf5QdMkf0PTyTzNtkw8ZJcA/5ON6zLQyCOMW7sDOkOVnTqKTOjEzuz8WOgxqtZToCw==',
             'js/purify-3.4.12.js'    => 'sha512-Akf6HnAJZm0sWWWI4gp2GYff0NDnHUB02XJE5S7Hdq/Z5xtMjkuFacsDA8ZtViv1gi+onBxMhEMIaGyQeGxBng==',
             'js/showdown-2.1.0.js'   => 'sha512-WYXZgkTR0u/Y9SVIA4nTTOih0kXMEd8RRV6MLFdL6YU8ymhR528NLlYQt1nlJQbYz4EW+ZsS0fx1awhiQJme1Q==',
             'js/zlib-1.3.2.js'       => 'sha512-RAhJgxg9siMIA8ky4c10Rc2zUgnK80olHB8Tt1IOYWY4Eh1WmrviQkDn+sgBlb38ZHq3tzufGC41kP360gmosQ==',


### PR DESCRIPTION
## Summary

- compare the PrivateBin base URI with `window.location.href`, rather than the `Location` object
- avoid inserting a redundant history entry when the new-paste controller runs on the home page
- add a controller-level regression test that records history mutations while isolating unrelated UI work
- refresh the `privatebin.js` integrity hash

## Regression evidence

Before the fix, the focused test observed one `history.pushState()` call on `https://example.com/` even though the current URL already matched the base URI. With the fix it observes zero calls.

## Tests

- `npx mocha test/Controller.js` — 1 passing
- `npm run lint` — passed
- `npm test -- --reporter dot` — 127 passing
- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit --filter '/^(?!.*ServerSaltTest)/'` — 266 tests, 6505 assertions
- `git diff --check` — passed
- verified the configured SHA-512 integrity value matches `js/privatebin.js`

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.