### PR TITLE
Support disabled sharing controls

### DIFF
--- a/js/privatebin.js
+++ b/js/privatebin.js
@@ -4245,7 +4245,9 @@ window.PrivateBin = (function () {
             cloneButton.classList.remove('hidden');
             rawTextButton.classList.remove('hidden');
             downloadTextButton.classList.remove('hidden');
-            qrCodeLink.classList.remove('hidden');
+            if (qrCodeLink) {
+                qrCodeLink.classList.remove('hidden');
+            }
 
             viewButtonsDisplayed = true;
         };
@@ -4265,7 +4267,9 @@ window.PrivateBin = (function () {
             newButton.classList.add('hidden');
             rawTextButton.classList.add('hidden');
             downloadTextButton.classList.add('hidden');
-            qrCodeLink.classList.add('hidden');
+            if (qrCodeLink) {
+                qrCodeLink.classList.add('hidden');
+            }
             me.hideEmailButton();
 
             viewButtonsDisplayed = false;
@@ -4370,6 +4374,10 @@ window.PrivateBin = (function () {
          * @param {number|undefined} optionalRemainingTimeInSeconds
          */
         me.showEmailButton = function (optionalRemainingTimeInSeconds) {
+            if (!emailLink) {
+                return;
+            }
+
             try {
                 // we cache expiration date in closure to avoid inaccurate expiration datetime
                 const expirationDate = Helper.calculateExpirationDate(
@@ -4441,7 +4449,9 @@ window.PrivateBin = (function () {
          * @function
          */
         me.hideQrCodeButton = function () {
-            qrCodeLink.classList.add('hidden');
+            if (qrCodeLink) {
+                qrCodeLink.classList.add('hidden');
+            }
         };
 
         /**
@@ -6154,5 +6164,4 @@ if (typeof module === 'undefined' || !module.exports) {
         window.PrivateBin.Controller.init();
     });
 }
-
 

--- a/js/test/TopNav.js
+++ b/js/test/TopNav.js
@@ -61,6 +61,35 @@ describe('TopNav', function () {
                 assert.ok(result);
             }
         );
+
+        it('supports a disabled QR code control', function () {
+            cleanup();
+            document.body.innerHTML =
+                '<button id="newbutton" class="hidden"></button>' +
+                '<button id="clonebutton" class="hidden"></button>' +
+                '<button id="rawtextbutton" class="hidden"></button>' +
+                '<button id="downloadtextbutton" class="hidden"></button>';
+            PrivateBin.TopNav.init();
+
+            assert.doesNotThrow(function () {
+                PrivateBin.TopNav.showViewButtons();
+                PrivateBin.TopNav.hideBurnAfterReadingButtons();
+                PrivateBin.TopNav.hideViewButtons();
+            });
+        });
+
+        it('supports a disabled email control', function () {
+            cleanup();
+            let errors = 0;
+            PrivateBin.Alert.showError = function () {
+                ++errors;
+            };
+            PrivateBin.TopNav.init();
+
+            PrivateBin.TopNav.showEmailButton(60);
+
+            assert.strictEqual(errors, 0);
+        });
     });
 
     describe('showCreateButtons & hideCreateButtons', function () {

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -120,7 +120,7 @@ class Configuration
             'js/kjua-0.10.0.js'      => 'sha512-BYj4xggowR7QD150VLSTRlzH62YPfhpIM+b/1EUEr7RQpdWAGKulxWnOvjFx1FUlba4m6ihpNYuQab51H6XlYg==',
             'js/legacy.js'           => 'sha512-pRofxsrf5UItjiP22Dcjh3FAcBjF/n7h8U9/W5xqJk17U0N2U1oajhXypq/omo9jhwS1iVGOhWrRepoPeFns+w==',
             'js/prettify.js'         => 'sha512-puO0Ogy++IoA2Pb9IjSxV1n4+kQkKXYAEUtVzfZpQepyDPyXk8hokiYDS7ybMogYlyyEIwMLpZqVhCkARQWLMg==',
-            'js/privatebin.js'       => 'sha512-ah/QdETig/ovH1QPl9Ne+T3VvaP7Bj4Rd9Or9wqQgo5BHge9o02MxAlRGXUZpKviy/27OSzHgz2PwpnH/B2RZg==',
+            'js/privatebin.js'       => 'sha512-B9XP9HwQbpmFSbmxTM9wt5i+SY7YQDjYMhyCpStzf8zfJ4G6yNDq5k50uA0SQnilB8zydvIjY+VgrQvQNqVX1Q==',
             'js/purify-3.4.12.js'    => 'sha512-Akf6HnAJZm0sWWWI4gp2GYff0NDnHUB02XJE5S7Hdq/Z5xtMjkuFacsDA8ZtViv1gi+onBxMhEMIaGyQeGxBng==',
             'js/showdown-2.1.0.js'   => 'sha512-WYXZgkTR0u/Y9SVIA4nTTOih0kXMEd8RRV6MLFdL6YU8ymhR528NLlYQt1nlJQbYz4EW+ZsS0fx1awhiQJme1Q==',
             'js/zlib-1.3.2.js'       => 'sha512-RAhJgxg9siMIA8ky4c10Rc2zUgnK80olHB8Tt1IOYWY4Eh1WmrviQkDn+sgBlb38ZHq3tzufGC41kP360gmosQ==',


### PR DESCRIPTION
## Summary

- guard the optional QR-code control while showing, hiding, and restricting view actions
- skip email-button setup when email sharing is disabled
- add regressions for `qrcode = false` and `email = false`
- refresh the `privatebin.js` integrity hash

## Regression evidence

Before the fix, the QR regression threw `Cannot read properties of null (reading 'classList')`. The email regression caught the same null dereference and incorrectly reported a calculation error. Both configured-disabled paths now complete without errors.

## Tests

- `npx mocha test/TopNav.js --grep "disabled (QR code|email) control"` — 2 passing
- `npm run lint` — passed
- `npm test -- --reporter dot` — 128 passing
- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit --filter '/^(?!.*ServerSaltTest)/'` — 266 tests, 6505 assertions
- `git diff --check` — passed
- verified the configured SHA-512 integrity value matches `js/privatebin.js`

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.