### PR TITLE
Keep pastes readable without optional formatters

### DIFF
--- a/js/privatebin.js
+++ b/js/privatebin.js
@@ -2616,35 +2616,47 @@ window.PrivateBin = (function () {
             }
 
             if (format === 'markdown') {
-                const converter = new showdown.Converter({
-                    strikethrough: true,
-                    tables: true,
-                    tablesHeaderId: true,
-                    simplifiedAutoLink: true,
-                    excludeTrailingPunctuationFromURLs: true
-                });
-                // let showdown convert the HTML and sanitize HTML *afterwards*!
                 if (plainText) {
-                    plainText.innerHTML = DOMPurify.sanitize(
-                        converter.makeHtml(text),
-                        purifyHtmlConfig
-                    );
-                    // add table classes from bootstrap css
-                    plainText.querySelectorAll('table').forEach(t => {
-                        t.classList.add('table-condensed', 'table-bordered');
-                    });
+                    if (typeof showdown === 'undefined') {
+                        plainText.textContent = text;
+                        Helper.urls2links(plainText);
+                    } else {
+                        const converter = new showdown.Converter({
+                            strikethrough: true,
+                            tables: true,
+                            tablesHeaderId: true,
+                            simplifiedAutoLink: true,
+                            excludeTrailingPunctuationFromURLs: true
+                        });
+                        // let showdown convert the HTML and sanitize HTML *afterwards*!
+                        plainText.innerHTML = DOMPurify.sanitize(
+                            converter.makeHtml(text),
+                            purifyHtmlConfig
+                        );
+                        // add table classes from bootstrap css
+                        plainText.querySelectorAll('table').forEach(t => {
+                            t.classList.add('table-condensed', 'table-bordered');
+                        });
+                    }
                 }
             } else {
                 if (format === 'syntaxhighlighting') {
+                    const hasSyntaxRenderer =
+                        typeof prettyPrint === 'function' &&
+                        typeof prettyPrintOne === 'function';
                     // yes, this is really needed to initialize the environment
-                    if (typeof prettyPrint === 'function') {
+                    if (hasSyntaxRenderer) {
                         prettyPrint();
                     }
 
                     if (prettyPrintEl) {
-                        prettyPrintEl.innerHTML = prettyPrintOne(
-                            Helper.htmlEntities(text), null, true
-                        );
+                        if (hasSyntaxRenderer) {
+                            prettyPrintEl.innerHTML = prettyPrintOne(
+                                Helper.htmlEntities(text), null, true
+                            );
+                        } else {
+                            prettyPrintEl.textContent = text;
+                        }
                     }
                 } else {
                     // = 'plaintext'
@@ -6154,5 +6166,4 @@ if (typeof module === 'undefined' || !module.exports) {
         window.PrivateBin.Controller.init();
     });
 }
-
 

--- a/js/test/PasteViewer.js
+++ b/js/test/PasteViewer.js
@@ -36,6 +36,45 @@ describe('PasteViewer', function () {
             assert.ok(!document.getElementById('plaintext').classList.contains('hidden'));
         });
 
+        it('falls back to plaintext without the markdown renderer', function () {
+            const originalShowdown = globalThis.showdown;
+            delete globalThis.showdown;
+            try {
+                PrivateBin.PasteViewer.init();
+                PrivateBin.PasteViewer.setFormat('markdown');
+                PrivateBin.PasteViewer.setText('hello **bold**');
+                PrivateBin.PasteViewer.run();
+
+                assert.strictEqual(
+                    document.getElementById('plaintext').textContent,
+                    'hello **bold**'
+                );
+            } finally {
+                globalThis.showdown = originalShowdown;
+            }
+        });
+
+        it('falls back to plaintext without the syntax renderer', function () {
+            const originalPrettyPrint = globalThis.prettyPrint;
+            const originalPrettyPrintOne = globalThis.prettyPrintOne;
+            delete globalThis.prettyPrint;
+            delete globalThis.prettyPrintOne;
+            try {
+                PrivateBin.PasteViewer.init();
+                PrivateBin.PasteViewer.setFormat('syntaxhighlighting');
+                PrivateBin.PasteViewer.setText('const answer = 42;');
+                PrivateBin.PasteViewer.run();
+
+                assert.strictEqual(
+                    document.getElementById('prettyprint').textContent,
+                    'const answer = 42;'
+                );
+            } finally {
+                globalThis.prettyPrint = originalPrettyPrint;
+                globalThis.prettyPrintOne = originalPrettyPrintOne;
+            }
+        });
+
         it('initializes with empty text and shows nothing', () => {
             fc.assert(fc.property(
                 common.fcFormats(),

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -120,7 +120,7 @@ class Configuration
             'js/kjua-0.10.0.js'      => 'sha512-BYj4xggowR7QD150VLSTRlzH62YPfhpIM+b/1EUEr7RQpdWAGKulxWnOvjFx1FUlba4m6ihpNYuQab51H6XlYg==',
             'js/legacy.js'           => 'sha512-pRofxsrf5UItjiP22Dcjh3FAcBjF/n7h8U9/W5xqJk17U0N2U1oajhXypq/omo9jhwS1iVGOhWrRepoPeFns+w==',
             'js/prettify.js'         => 'sha512-puO0Ogy++IoA2Pb9IjSxV1n4+kQkKXYAEUtVzfZpQepyDPyXk8hokiYDS7ybMogYlyyEIwMLpZqVhCkARQWLMg==',
-            'js/privatebin.js'       => 'sha512-ah/QdETig/ovH1QPl9Ne+T3VvaP7Bj4Rd9Or9wqQgo5BHge9o02MxAlRGXUZpKviy/27OSzHgz2PwpnH/B2RZg==',
+            'js/privatebin.js'       => 'sha512-fLbot/DfKsnEotSyyzrsVYBjnIcwPeQl67D1nkbgy7WgLcBgwIU0bEYsujSleiDq6kWjGUzP0Le4VyC3omWRrA==',
             'js/purify-3.4.12.js'    => 'sha512-Akf6HnAJZm0sWWWI4gp2GYff0NDnHUB02XJE5S7Hdq/Z5xtMjkuFacsDA8ZtViv1gi+onBxMhEMIaGyQeGxBng==',
             'js/showdown-2.1.0.js'   => 'sha512-WYXZgkTR0u/Y9SVIA4nTTOih0kXMEd8RRV6MLFdL6YU8ymhR528NLlYQt1nlJQbYz4EW+ZsS0fx1awhiQJme1Q==',
             'js/zlib-1.3.2.js'       => 'sha512-RAhJgxg9siMIA8ky4c10Rc2zUgnK80olHB8Tt1IOYWY4Eh1WmrviQkDn+sgBlb38ZHq3tzufGC41kP360gmosQ==',


### PR DESCRIPTION
## Summary

- render Markdown pastes as safe plaintext when Showdown is not loaded
- render syntax-highlighted pastes as safe plaintext when Prettify is not loaded
- preserve readability of existing pastes after either formatter is disabled in configuration
- add regressions for both omitted renderer scripts
- refresh the `privatebin.js` integrity hash

## Regression evidence

Before the fix, the focused regressions failed with `ReferenceError: showdown is not defined` and `ReferenceError: prettyPrintOne is not defined`. Both formats now preserve the exact decrypted text when their optional renderer is unavailable.

## Security and compatibility

The fallbacks assign untrusted decrypted content through `textContent`; Markdown fallback linkification still passes through the existing strict sanitizer. Enabled formatter behavior is unchanged.

## Tests

- `npx mocha test/PasteViewer.js --grep "falls back to plaintext without"` — 2 passing
- `npm run lint` — passed
- `npm test -- --reporter dot` — 128 passing
- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit --filter '/^(?!.*ServerSaltTest)/'` — 266 tests, 6505 assertions
- `git diff --check` — passed
- verified the configured SHA-512 integrity value matches `js/privatebin.js`

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.