### PR TITLE
Handle JSON API CORS preflight requests

### DIFF
--- a/lib/Request.php
+++ b/lib/Request.php
@@ -265,6 +265,13 @@ class Request
      */
     private function _detectJsonRequest()
     {
+        if (
+            ($_SERVER['REQUEST_METHOD'] ?? '') === 'OPTIONS' &&
+            isset($_SERVER['HTTP_ACCESS_CONTROL_REQUEST_METHOD'])
+        ) {
+            return true;
+        }
+
         $acceptHeader = $_SERVER['HTTP_ACCEPT'] ?? '';
 
         // simple cases

--- a/tst/RequestTest.php
+++ b/tst/RequestTest.php
@@ -99,6 +99,17 @@ class RequestTest extends TestCase
         $this->assertEquals('foo', $request->getParam('ct'));
     }
 
+    public function testApiCorsPreflight()
+    {
+        $this->reset();
+        $_SERVER['REQUEST_METHOD'] = 'OPTIONS';
+        $_SERVER['HTTP_ACCESS_CONTROL_REQUEST_METHOD'] = 'POST';
+        $request = new Request;
+
+        $this->assertTrue($request->isJsonApiCall(), 'is JSON API call');
+        $this->assertEquals('view', $request->getOperation());
+    }
+
     public function testApiCreateAlternative()
     {
         $this->reset();


### PR DESCRIPTION
## Summary

- recognize browser CORS preflight requests as JSON API traffic
- route `OPTIONS` requests carrying `Access-Control-Request-Method` through the existing API response path
- ensure the already-configured `Access-Control-Allow-*` headers are emitted instead of returning the HTML application
- add a request-classification regression test

## Regression evidence

Before the fix, an `OPTIONS` request with `Access-Control-Request-Method: POST` was classified as HTML (`isJsonApiCall() === false`). The regression now confirms it is classified as API traffic while remaining a non-mutating view operation.

## Security and compatibility

This does not broaden the existing CORS policy: PrivateBin already emits `Access-Control-Allow-Origin: *` and advertises GET, POST, PUT, and DELETE for JSON responses. It makes browser preflight behavior consistent with that declared policy and performs no storage operation.

## Tests

- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit --filter testApiCorsPreflight RequestTest.php` — failing before, passing after
- complete `RequestTest.php` — 16 tests, 58 assertions
- broad PHPUnit suite excluding known root-permission-sensitive `ServerSaltTest` — 267 tests, 6507 assertions
- `composer validate --no-check-publish` — valid (existing exact-version warnings only)
- `git diff --check` — passed

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.