### PR TITLE
Detect JSON API requests by content type

### DIFF
--- a/lib/Request.php
+++ b/lib/Request.php
@@ -266,10 +266,13 @@ class Request
     private function _detectJsonRequest()
     {
         $acceptHeader = $_SERVER['HTTP_ACCEPT'] ?? '';
+        $contentType  = $_SERVER['CONTENT_TYPE'] ?? ($_SERVER['HTTP_CONTENT_TYPE'] ?? '');
+        $contentType  = strtolower(trim(explode(';', $contentType, 2)[0]));
 
         // simple cases
         if (
             ($_SERVER['HTTP_X_REQUESTED_WITH'] ?? '') === 'JSONHttpRequest' ||
+            $contentType === self::MIME_JSON ||
             (
                 str_contains($acceptHeader, self::MIME_JSON) &&
                 !str_contains($acceptHeader, self::MIME_HTML) &&

--- a/tst/RequestTest.php
+++ b/tst/RequestTest.php
@@ -113,6 +113,22 @@ class RequestTest extends TestCase
         $this->assertEquals('foo', $request->getParam('ct'));
     }
 
+    public function testApiCreateWithJsonContentType()
+    {
+        $this->reset();
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+        $_SERVER['CONTENT_TYPE']    = 'Application/JSON; charset=UTF-8';
+        $file                       = Helper::createTempFile();
+        file_put_contents($file, '{"ct":"foo"}');
+        Request::setInputStream($file);
+        $request = new Request;
+        unlink($file);
+
+        $this->assertTrue($request->isJsonApiCall(), 'is JSON API call');
+        $this->assertEquals('create', $request->getOperation());
+        $this->assertEquals('foo', $request->getParam('ct'));
+    }
+
     public function testApiRead()
     {
         $this->reset();


### PR DESCRIPTION
## Summary

- recognize `Content-Type: application/json` as a JSON API request signal
- handle media-type casing and optional parameters such as `charset=UTF-8`
- retain the existing custom X-header and `Accept` negotiation paths
- add a regression for a conventional JSON POST client

## Regression evidence

Before the fix, a POST with `Content-Type: Application/JSON; charset=UTF-8` was parsed as JSON but classified for an HTML response (`isJsonApiCall() === false`). It now remains a create operation and receives the JSON API response path.

## Compatibility

This aligns the response representation with the request body representation. Existing browser and PrivateBin-client behavior is unchanged.

## Tests

- `php -d auto_prepend_file=/tmp/privatebin-google.ABreG0/vendor/autoload.php /usr/bin/phpunit --filter testApiCreateWithJsonContentType RequestTest.php` — failing before, passing after
- complete `RequestTest.php` — 16 tests, 59 assertions
- broad PHPUnit suite excluding known root-permission-sensitive `ServerSaltTest` — 267 tests, 6508 assertions
- `composer validate --no-check-publish` — valid (existing exact-version warnings only)
- `git diff --check` — passed

## AI/LLM disclosure

This change was investigated, implemented, and tested with OpenAI Codex assistance. The commits and test evidence are included in this draft for manual review.