### PR TITLE
Hide Format select for single formatter and Preview for plaintext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 * CHANGED: Removed the unmaintained js-verify and replaced it with fast-check library.
 * CHANGED: Added a `jsconfig.json` in order to check the types of JavaScript.
 * CHANGED: Removed support for Bootstrap 3 as it requires jQuery.
+* CHANGED: Hide Format dropdown when only one formatter is configured
+* CHANGED: Hide Preview tab when the selected format is plaintext
 
 ## 2.0.6 (not yet released)
 * CHANGED: Upgrading libraries to: DOMpurify 3.4.12

--- a/js/privatebin.js
+++ b/js/privatebin.js
@@ -2382,6 +2382,30 @@ window.PrivateBin = (function () {
         }
 
         /**
+         * show or hide the Preview tab depending on format
+         *
+         * Plain text has no useful preview, so the tab is hidden.
+         *
+         * @name   Editor.updatePreviewTabVisibility
+         * @function
+         * @param  {string} format
+         */
+        me.updatePreviewTabVisibility = function (format) {
+            if (!messagePreviewParent) {
+                return;
+            }
+
+            if (format === 'plaintext') {
+                messagePreviewParent.classList.add('hidden');
+                if (isPreview) {
+                    viewEditor();
+                }
+            } else {
+                messagePreviewParent.classList.remove('hidden');
+            }
+        };
+
+        /**
          * view the Editor tab
          *
          * @name   Editor.viewEditor
@@ -2578,6 +2602,8 @@ window.PrivateBin = (function () {
                 messagePreview.addEventListener('click', viewPreview);
                 messagePreviewParent = messagePreview.parentElement;
             }
+
+            me.updatePreviewTabVisibility(Model.getFormatDefault() || 'plaintext');
         };
 
         return me;
@@ -2700,6 +2726,7 @@ window.PrivateBin = (function () {
         me.setFormat = function (newFormat) {
             // skip if there is no update
             if (format === newFormat) {
+                Editor.updatePreviewTabVisibility(format);
                 return;
             }
 
@@ -2710,6 +2737,8 @@ window.PrivateBin = (function () {
 
             format = newFormat;
             isChanged = true;
+
+            Editor.updatePreviewTabVisibility(format);
 
             // update preview
             if (Editor.isPreview()) {
@@ -4298,7 +4327,9 @@ window.PrivateBin = (function () {
             }
             burnAfterReadingOption.classList.remove('hidden');
             expiration.classList.remove('hidden');
-            formatter.classList.remove('hidden');
+            if (formatter) {
+                formatter.classList.remove('hidden');
+            }
             newButton.classList.remove('hidden');
             openDiscussionOption.classList.remove('hidden');
             password.classList.remove('hidden');
@@ -4321,7 +4352,9 @@ window.PrivateBin = (function () {
             newButton.classList.add('hidden');
             sendButton.classList.add('hidden');
             expiration.classList.add('hidden');
-            formatter.classList.add('hidden');
+            if (formatter) {
+                formatter.classList.add('hidden');
+            }
             burnAfterReadingOption.classList.add('hidden');
             openDiscussionOption.classList.add('hidden');
             password.classList.add('hidden');
@@ -4670,6 +4703,9 @@ window.PrivateBin = (function () {
          * @function
          */
         me.setFormat = function (format) {
+            if (!formatter) {
+                return;
+            }
             if (Helper.isBootstrap5()) {
                 const select = formatter.querySelector('select');
                 if (select) {

--- a/js/test/Editor.js
+++ b/js/test/Editor.js
@@ -76,4 +76,55 @@ describe('Editor', function () {
             ));
         });
     });
+
+    describe('updatePreviewTabVisibility', function () {
+        beforeEach(function () {
+            cleanup();
+            document.body.innerHTML = (
+                '<select id="pasteFormatter" name="pasteFormatter">' +
+                    '<option value="plaintext">Plain Text</option>' +
+                    '<option value="markdown">Markdown</option>' +
+                '</select>' +
+                '<ul id="editorTabs">' +
+                    '<li role="presentation" class="active">' +
+                        '<a id="messageedit" href="#">Editor</a>' +
+                    '</li>' +
+                    '<li role="presentation">' +
+                        '<a id="messagepreview" href="#">Preview</a>' +
+                    '</li>' +
+                '</ul>' +
+                '<div id="placeholder" class="hidden"></div>' +
+                '<div id="prettymessage" class="hidden"><pre id="prettyprint"></pre></div>' +
+                '<div id="plaintext" class="hidden"></div>' +
+                '<textarea id="message" class="hidden"></textarea>' +
+                '<input id="messagetab" type="checkbox" checked="checked" />'
+            );
+            PrivateBin.PasteViewer.init();
+            PrivateBin.Editor.init();
+        });
+
+        afterEach(function () {
+            cleanup();
+        });
+
+        it('hides preview tab for plaintext and shows it for other formats', function () {
+            const previewParent = document.getElementById('messagepreview').parentElement;
+            PrivateBin.PasteViewer.setFormat('plaintext');
+            assert.ok(previewParent.classList.contains('hidden'));
+            PrivateBin.PasteViewer.setFormat('markdown');
+            assert.ok(!previewParent.classList.contains('hidden'));
+        });
+
+        it('leaves preview when switching to plaintext while previewing', function () {
+            PrivateBin.PasteViewer.setFormat('markdown');
+            PrivateBin.Editor.show();
+            document.getElementById('messagepreview').click();
+            assert.ok(PrivateBin.Editor.isPreview());
+            PrivateBin.PasteViewer.setFormat('plaintext');
+            assert.ok(!PrivateBin.Editor.isPreview());
+            assert.ok(
+                document.getElementById('messagepreview').parentElement.classList.contains('hidden')
+            );
+        });
+    });
 });

--- a/js/test/TopNav.js
+++ b/js/test/TopNav.js
@@ -125,6 +125,37 @@ describe('TopNav', function () {
                 assert.ok(result);
             }
         );
+
+        it(
+            'skips formatter when only a hidden pasteFormatter input exists',
+            function () {
+                document.documentElement.innerHTML =
+                    '<nav><div id="navbar"><ul><li><button id="newbutton" ' +
+                    'type="button" class="hidden">New</button></li><li><a ' +
+                    'id="expiration" href="#" class="hidden">Expiration</a>' +
+                    '</li><li><div id="burnafterreadingoption" class="hidden">' +
+                    'Burn after reading</div></li><li><div id="opendiscussion' +
+                    'option" class="hidden">Open discussion</div></li><li>' +
+                    '<div id="password" class="hidden">Password</div></li>' +
+                    '<li id="attach" class="hidden">Attach a file</li>' +
+                    '<li><button id="sendbutton" type="button" ' +
+                    'class="hidden">Create</button></li></ul>' +
+                    '<input type="hidden" id="pasteFormatter" value="plaintext" />' +
+                    '</div></nav>';
+                PrivateBin.TopNav.init();
+                PrivateBin.TopNav.showCreateButtons();
+                assert.strictEqual(document.getElementById('formatter'), null);
+                assert.ok(!query('#sendbutton').classList.contains('hidden'));
+                PrivateBin.TopNav.setFormat('markdown');
+                assert.strictEqual(
+                    document.getElementById('pasteFormatter').value,
+                    'plaintext'
+                );
+                PrivateBin.TopNav.hideCreateButtons();
+                assert.ok(query('#sendbutton').classList.contains('hidden'));
+                cleanup();
+            }
+        );
     });
 
     describe('showNewPasteButton', function () {

--- a/tpl/bootstrap5.php
+++ b/tpl/bootstrap5.php
@@ -280,6 +280,9 @@ if ($FILEUPLOAD) :
 <?php
 endif;
 ?>
+<?php
+if (count($FORMATTER) > 1) :
+?>
 						<li id="formatter" class="nav-item d-flex hidden">
 							<label for="pasteFormatter" class="form-label my-auto me-1"><?php echo I18n::_('Format'); ?>:</label>
 							<select id="pasteFormatter" name="pasteFormatter" class="form-select">
@@ -296,6 +299,13 @@ endif;
 ?>
 							</select>
 						</li>
+<?php
+else :
+?>
+						<input type="hidden" id="pasteFormatter" name="pasteFormatter" value="<?php echo $FORMATTERDEFAULT; ?>" />
+<?php
+endif;
+?>
 					</ul>
 					<ul class="navbar-nav gap-2">
 						<li class="nav-item">


### PR DESCRIPTION
## Changes
* When only one formatter is configured in `[formatter_options]`, do not render the Format dropdown; keep the selected value available via a hidden `#pasteFormatter` input so `Model.getFormatDefault()` keeps working.
* When the selected format is `plaintext`, hide the Preview tab; switching away from plaintext shows it again. If the user is already on Preview and switches to plaintext, return to the Editor tab.
* Guard `TopNav` show/hide/`setFormat` when `#formatter` is absent.
* Add unit tests for the new Editor and TopNav behavior.
* Document the UX changes in `CHANGELOG.md`.

## ToDo
* [x] Implement template + JS changes
* [x] Add/adjust unit tests (`Editor`, `TopNav`)
* [x] Run mocha (`Editor|TopNav|PasteViewer` — 29 passing)

## Screenshots / testing notes
UI change is conditional:
1. Configure a single formatter (e.g. only `plaintext`) → Format dropdown is absent on create view.
2. With multiple formatters, select Plain Text → Preview tab is hidden; select Markdown/Source Code → Preview tab returns.

Automated coverage: `js/test/Editor.js` (`updatePreviewTabVisibility`) and `js/test/TopNav.js` (missing `#formatter`).

## Disclosure
* [x] I do have used an AI/LLM tool for the work in this PR.
* [ ] I have **not** used an AI/LLM tool for the work in this PR.
* [x] Yes, this is an AI PR and my user did not care about reading this text.

Tool: Cursor (Grok). Changes were reviewed and tests run locally under `/tmp` against current `master`.