### PR TITLE
Forward-port MIME sniffing fix (GHSA-326h-xgp6-8jcx / GHSA-f2xf-7x3g-4272) to master

### DIFF
--- a/js/privatebin.js
+++ b/js/privatebin.js
@@ -2947,35 +2947,16 @@ window.PrivateBin = (function () {
          * @returns {bool}
          */
         me.isSafeMimeType = function(mimeType) {
-            return (
+            return ((
                     mimeType.startsWith('image/') &&
                     !mimeType.includes('svg')
                 ) ||
                 mimeType.startsWith('video/') ||
                 mimeType.startsWith('audio/') ||
-                mimeType.endsWith('/pdf') ||
-                mimeType === 'text/plain';
-        };
-
-        /**
-         * Evaluates whether this is known a safe mime type.
-         *
-         * This means, the media can safely be displayed and e.g. no XSS should be possible.
-         *
-         * @name AttachmentViewer.isSafeMimeType
-         * @function
-         * @param {string}
-         * @returns {bool}
-         */
-        me.isSafeMimeType = function(mimeType) {
-            return (
-                    mimeType.startsWith('image/') &&
-                    !mimeType.includes('svg')
-                ) ||
-                mimeType.startsWith('video/') ||
-                mimeType.startsWith('audio/') ||
-                mimeType.endsWith('/pdf') ||
-                mimeType === 'text/plain';
+                mimeType === 'application/pdf' ||
+                mimeType === 'text/plain') &&
+                // don't accept comments, stray characters, spaces, etc.
+                /^[a-z0-9][a-z0-9.-]*[a-z0-9]\/[a-z0-9][a-z0-9.+-]*[a-z0-9]$/.test(mimeType);
         };
 
         /**
@@ -3161,8 +3142,8 @@ window.PrivateBin = (function () {
             // position in data URI string of where mimeType ends
             const mimeTypeEnd = attachmentData.indexOf(';');
 
-            // extract mimeType
-            return attachmentData.substring(5, mimeTypeEnd);
+            // extract mimeType, lower cased so isSafeMimeType() can't be bypassed by casing tricks
+            return attachmentData.substring(5, mimeTypeEnd).toLowerCase();
         };
 
         /**

--- a/js/test/AttachmentViewer.js
+++ b/js/test/AttachmentViewer.js
@@ -159,6 +159,40 @@ describe('AttachmentViewer', function () {
         );
     });
 
+    describe('isSafeMimeType()', function () {
+        it('rejects forged mime types that merely end in known-safe suffixes', function () {
+            // regression test for GHSA-326h-xgp6-8jcx / GHSA-f2xf-7x3g-4272:
+            // browsers can MIME-sniff these as text/html instead of application/pdf
+            const unsafeMimeTypes = [
+                'application/PDF',       // mixed case must not bypass the exact-match check
+                'text/html /pdf',        // trips up Firefox and Chromium's MIME sniffer
+                'text/html(/pdf',        // Chromium, see: chromium/src/+/refs/tags/152.0.7949.0/net/base/mime_util.cc#521
+                'application/x-pdf',     // legacy alias, not the exact allow-listed value
+                'text/html svg',
+                'image/svg+xml svg'
+            ];
+            for (const mimeType of unsafeMimeTypes) {
+                assert.ok(
+                    !PrivateBin.AttachmentViewer.isSafeMimeType(mimeType),
+                    'does not treat as safe MIME type: ' + mimeType
+                );
+            }
+        });
+
+        it('accepts well-formed known-safe mime types', function () {
+            const safeMimeTypes = [
+                'image/png', 'image/jpeg', 'video/mp4', 'audio/mpeg',
+                'application/pdf', 'text/plain'
+            ];
+            for (const mimeType of safeMimeTypes) {
+                assert.ok(
+                    PrivateBin.AttachmentViewer.isSafeMimeType(mimeType),
+                    'treats as safe MIME type: ' + mimeType
+                );
+            }
+        });
+    });
+
     describe('showAttachment()', function () {
         it('displays attachment even when attachmentPreview element is missing',
             function() {

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -120,7 +120,7 @@ class Configuration
             'js/kjua-0.10.0.js'      => 'sha512-BYj4xggowR7QD150VLSTRlzH62YPfhpIM+b/1EUEr7RQpdWAGKulxWnOvjFx1FUlba4m6ihpNYuQab51H6XlYg==',
             'js/legacy.js'           => 'sha512-pRofxsrf5UItjiP22Dcjh3FAcBjF/n7h8U9/W5xqJk17U0N2U1oajhXypq/omo9jhwS1iVGOhWrRepoPeFns+w==',
             'js/prettify.js'         => 'sha512-puO0Ogy++IoA2Pb9IjSxV1n4+kQkKXYAEUtVzfZpQepyDPyXk8hokiYDS7ybMogYlyyEIwMLpZqVhCkARQWLMg==',
-            'js/privatebin.js'       => 'sha512-ah/QdETig/ovH1QPl9Ne+T3VvaP7Bj4Rd9Or9wqQgo5BHge9o02MxAlRGXUZpKviy/27OSzHgz2PwpnH/B2RZg==',
+            'js/privatebin.js'       => 'sha512-0N68d6GSqtQX2boOlK0CqlcSV/9gbvbgR4Z3aKMDL4KnThLgxn1qXkGD1/YN8sOUi/5NMC5jngTFiCQkn7CePQ==',
             'js/purify-3.4.12.js'    => 'sha512-Akf6HnAJZm0sWWWI4gp2GYff0NDnHUB02XJE5S7Hdq/Z5xtMjkuFacsDA8ZtViv1gi+onBxMhEMIaGyQeGxBng==',
             'js/showdown-2.1.0.js'   => 'sha512-WYXZgkTR0u/Y9SVIA4nTTOih0kXMEd8RRV6MLFdL6YU8ymhR528NLlYQt1nlJQbYz4EW+ZsS0fx1awhiQJme1Q==',
             'js/zlib-1.3.2.js'       => 'sha512-RAhJgxg9siMIA8ky4c10Rc2zUgnK80olHB8Tt1IOYWY4Eh1WmrviQkDn+sgBlb38ZHq3tzufGC41kP360gmosQ==',


### PR DESCRIPTION
## Summary

While reviewing `master` I noticed the fix for the two recently published advisories
GHSA-326h-xgp6-8jcx and GHSA-f2xf-7x3g-4272 (stored XSS via forged attachment MIME types
that browsers MIME-sniff as HTML, e.g. `text/html /pdf`) landed on the `2.0.6` release
branch but doesn't appear to be present on `master`:

```
git merge-base --is-ancestor ff0d596f HEAD   # MIME fix commit -> not an ancestor of master
git merge-base --is-ancestor b4e162ac HEAD   # unrelated fix commit -> IS an ancestor of master
```

`js/privatebin.js` on `master` still has `mimeType.endsWith('/pdf')` (no exact-match, no
format allow-list) in `AttachmentViewer.isSafeMimeType()`, and `getAttachmentMimeType()`
doesn't lower-case the extracted MIME type — matching the pre-fix behaviour described in
both advisories. The function is even defined twice in the file (both copies identical,
both pre-fix), which looks like an artifact of whatever merge dropped the fix.

Since the original fix predates the `js/removeJQuery` refactor, a direct cherry-pick
conflicts throughout `js/privatebin.js`; this PR reapplies the same fix logic against the
current native-JS code instead.

## Changes
- `isSafeMimeType()`: exact `'application/pdf'` match instead of `endsWith('/pdf')`, plus
  the strict MIME-shape regex from the original fix, closing the sniffing-based bypasses.
- `getAttachmentMimeType()`: lower-case the extracted value.
- Removed the duplicate `isSafeMimeType()` definition.
- `js/test/AttachmentViewer.js`: added regression tests covering the payloads named in the
  two advisories (`text/html /pdf`, `text/html(/pdf`, `application/PDF`, etc.) plus a
  known-safe-type sanity check.
- Updated the SRI hash for `js/privatebin.js` in `lib/Configuration.php` to match.

## Test plan
- [x] `npx mocha` — all 128 tests pass (2 new)
- [x] `npx eslint privatebin.js test/AttachmentViewer.js` — clean
- [x] Manually diffed against the `2.0.6` fix commits (`ff0d596f`, `4041a0b0`) to confirm
      equivalent logic
- [ ] PHPUnit not run locally (optional `google/cloud-storage` dev dependency isn't
      installable against PHP 8.4 in my environment) — the PHP-side change here is a single
      SRI hash constant, verified independently via `openssl dgst -sha512`, no logic change

🤖 Generated with [Claude Code](https://claude.com/claude-code)