### PR TITLE
Improve Markdown rendering styles

### DIFF
--- a/css/bootstrap5/privatebin.css
+++ b/css/bootstrap5/privatebin.css
@@ -60,3 +60,86 @@ html[dir="rtl"] #deletelink, html[dir="rtl"] #qrcodemodalClose {
 #sendbutton svg {
 	transform: translateY(1.5px);
 }
+
+/* Markdown rendering */
+
+#plaintext {
+	max-width: 1050px;
+	margin: 2rem auto 5rem;
+	padding: 0 1.5rem;
+	font-size: 16px;
+	line-height: 1.7;
+}
+
+#plaintext h1 {
+	margin: 0 0 1.75rem;
+	padding-bottom: 0.65rem;
+	border-bottom: 2px solid var(--bs-border-color);
+	font-size: 2.25rem;
+}
+
+#plaintext h2 {
+	margin: 2.75rem 0 1.25rem;
+	padding-bottom: 0.4rem;
+	border-bottom: 1px solid var(--bs-border-color);
+	font-size: 1.65rem;
+}
+
+#plaintext h3 {
+	margin: 2rem 0 1rem;
+	font-size: 1.3rem;
+}
+
+#plaintext p {
+	margin-bottom: 1.15rem;
+}
+
+#plaintext pre {
+	margin: 1rem 0 1.5rem;
+	padding: 1rem 1.2rem;
+	overflow-x: auto;
+	background: var(--bs-tertiary-bg);
+	border: 1px solid var(--bs-border-color);
+	border-radius: 0.5rem;
+	box-shadow: inset 3px 0 0 var(--bs-primary);
+	line-height: 1.55;
+}
+
+#plaintext pre code {
+	padding: 0;
+	color: var(--bs-body-color);
+	background: transparent;
+	white-space: pre;
+}
+
+#plaintext :not(pre) > code {
+	padding: 0.15em 0.4em;
+	color: var(--bs-body-color);
+	background: var(--bs-tertiary-bg);
+	border: 1px solid var(--bs-border-color);
+	border-radius: 0.3rem;
+}
+
+#plaintext ul,
+#plaintext ol {
+	margin-bottom: 1.25rem;
+}
+
+#plaintext blockquote {
+	padding: 0.5rem 1rem;
+	color: var(--bs-secondary-color);
+	border-left: 4px solid var(--bs-primary);
+}
+
+#plaintext table {
+	width: 100%;
+	margin: 1.5rem 0;
+}
+
+@media (max-width: 768px) {
+	#plaintext {
+		margin-top: 1rem;
+		padding: 0 1rem;
+		font-size: 15px;
+	}
+}


### PR DESCRIPTION
  ## Changes

  * Improve the readability of rendered Markdown in the Bootstrap 5 template.
  * Constrain Markdown content to a comfortable reading width.
  * Improve heading hierarchy and paragraph spacing.
  * Add clearer styling for code blocks, inline code, blockquotes, lists, and tables.
  * Use Bootstrap color variables for light and dark theme compatibility.
  * Add responsive spacing and font sizing for smaller screens.

  The styles are scoped to `#plaintext`, which PrivateBin uses as the rendered Markdown container.

  ## Testing

  * Manually tested using PHP 8.5's local development server.
  * Tested headings, paragraphs, lists, inline code, fenced code blocks, blockquotes, and tables.
  * Reviewed the rendered result locally in the browser.

  ## Screenshots

<img width="1832" height="1522" alt="image" src="https://github.com/user-attachments/assets/9de622a4-3a69-4307-b473-0af35cefdc20" />
<img width="1832" height="1522" alt="image" src="https://github.com/user-attachments/assets/c10f33af-6c13-4538-8252-fa0031baaf93" />
<img width="1832" height="1522" alt="image" src="https://github.com/user-attachments/assets/ad010515-fa3d-4ac6-b4af-9dd507a29685" />
<img width="1832" height="1522" alt="image" src="https://github.com/user-attachments/assets/ea0903bc-5f8a-4930-9ae2-c63c7358dc85" />
<img width="1832" height="1522" alt="image" src="https://github.com/user-attachments/assets/5d92c23d-1796-4726-bf79-d1a52e58e2b7" />
<img width="1832" height="1522" alt="image" src="https://github.com/user-attachments/assets/b6449b15-bf4f-49ca-abdc-6507fa7a6dd3" />


  ## ToDo

  * [x] Attach screenshots demonstrating the updated Markdown rendering.

  ## Disclosure

  * [x] I do have used an AI/LLM tool for the work in this PR.
  * [ ] I have **not** used an AI/LLM tool for the work in this PR.

  OpenAI Codex was used to trace the Markdown rendering path, identify the appropriate existing stylesheet, integrate the CSS, and assist with validation and PR
  preparation. The resulting change was manually reviewed and tested in a local PrivateBin instance.