### PR TITLE
fix noisy Prompt tests

### DIFF
--- a/js/test/Prompt.js
+++ b/js/test/Prompt.js
@@ -28,11 +28,42 @@ describe('Prompt', function () {
                                 </div>
                             </div>
                         </div>
+                        <nav class="navbar navbar-inverse navbar-static-top">
+                            <div id="navbar" class="navbar-collapse collapse">
+                            <ul class="nav navbar-nav"><li><button id="newbutton" type="button" class="hidden btn btn-warning navbar-btn">
+                            <span class="glyphicon glyphicon-file" aria-hidden="true">
+                                </span> New</button><button id="clonebutton" type="button" class="hidden btn btn-warning navbar-btn">
+                            <span class="glyphicon glyphicon-duplicate" aria-hidden="true"></span> Clone</button>
+                            <button id="rawtextbutton" type="button" class="hidden btn btn-warning navbar-btn">
+                            <span class="glyphicon glyphicon-text-background" aria-hidden="true"></span> Raw text</button>
+                            <button id="downloadtextbutton" type="button" class="hidden btn btn-default navbar-btn"></button>
+                            <button id="qrcodelink" type="button" data-toggle="modal" data-target="#qrcodemodal" class="hidden btn btn-warning navbar-btn"/>
+                            <span class="glyphicon glyphicon-qrcode" aria-hidden="true"></span> QR code</button></li></ul></div>
+                        </nav>
+                        <div id="errormessage"></div>
+                        <div id="loadingindicator"></div>
+                        <div id="status"></div>
                     `;
 
                     // Initialize the Prompt module to set up event listeners
+                    PrivateBin.Alert.init();
+                    PrivateBin.TopNav.init();
                     PrivateBin.Prompt.init();
                     PrivateBin.Prompt.requestPassword();
+
+                    // mock request response
+                    const originalFetch = globalThis.fetch;
+                    globalThis.fetch = function (url) {
+                        assert.strictEqual(url, 'ftp://example.com/?pasteid=0000000000000000');
+                        return Promise.resolve({
+                            ok: true,
+                            status: 200,
+                            statusText: 'OK',
+                            json: function () {
+                                return Promise.resolve({});
+                            }
+                        });
+                    };
 
                     // Simulate user input
                     const passwordInput = document.getElementById('passworddecrypt');
@@ -46,6 +77,7 @@ describe('Prompt', function () {
 
                     // Verify that getPassword returns the submitted password
                     const result = PrivateBin.Prompt.getPassword();
+                    globalThis.fetch = originalFetch;
                     clean();
                     return result === password;
                 }


### PR DESCRIPTION
They were dependent on Alert and TopNav elements to be present and having been initialized. Tests still passed, but produced lots of stack traces.

This PR fixes #2017

## Changes
* adds HTML elements accessed when password dialog is filled and Prompt processes the dialog
* initializes Alert and TopNav, which load these elements
* captures fetch request and returns a mock response, avoiding live requests during test runs

## Disclosure
* [x] I do have used an AI/LLM tool for the work in this PR.

The investigation and fix of the alert related errors was generated using qwen3.8:27b running in ollama via Continue plugin in Vscodium. Once the pattern was clear, I replicated a similar fix for TopNav and I lifted the fetch mock from I18n.js. The model also suggested re-architecting the call flow inside Prompt to avoid triggering the many side effects, but I interrupted this, as it would lead to a major refactoring, likely introducing further side-effects. Just want to reduce the noise for now and get back clean unit test output.